### PR TITLE
Add GotoChoice return type for Logic node handlers

### DIFF
--- a/tidepool-core/src/Tidepool/Graph/Example.hs
+++ b/tidepool-core/src/Tidepool/Graph/Example.hs
@@ -69,7 +69,7 @@ import Tidepool.Graph.Types
 import Tidepool.Graph.Validate (ValidGraph)
 import Tidepool.Graph.Generic (GraphMode(..), AsGraph, AsHandler, gotoField)
 import qualified Tidepool.Graph.Generic as G (Entry, Exit, LLMNode, LogicNode, ValidGraphRecord)
-import Tidepool.Graph.Goto (Goto)
+import Tidepool.Graph.Goto (Goto, To, GotoChoice, gotoChoice, gotoExit)
 import Tidepool.Graph.Tool (ToolDef(..), toolToInfo)
 import Tidepool.Graph.Template (TemplateDef(..), TypedTemplate, typedTemplateFile)
 import Tidepool.Graph.Example.Context (ClassifyContext(..))
@@ -456,18 +456,17 @@ supportHandlers = SupportGraph
         , categories = T.intercalate ", " st.sessionNotes
         }
   , sgRoute    = \intent -> do
-      -- Logic handler: examines intent and uses gotoField for graph-validated transitions
+      -- Logic handler: returns GotoChoice to specify transition
       --
-      -- gotoField @SupportGraph @"sgRefund" validates at compile time that:
-      -- 1. "sgRefund" is actually a field in SupportGraph
-      -- 2. The Goto "sgRefund" Message effect is in our effect stack
+      -- gotoChoice @"sgRefund" validates at compile time that:
+      -- 1. To "sgRefund" Message is in the node's allowed targets
       --
-      -- This catches typos and prevents referencing fields from wrong graphs.
+      -- The return type is GotoChoice, guaranteeing a transition is selected.
       let msg = Message "forwarded message"
-      case intent of
-        IntentRefund    -> gotoField @SupportGraph @"sgRefund" msg
-        IntentQuestion  -> gotoField @SupportGraph @"sgFaq" msg
-        IntentComplaint -> gotoField @SupportGraph @"sgFaq" msg  -- Complaints go to FAQ for now
+      pure $ case intent of
+        IntentRefund    -> gotoChoice @"sgRefund" msg
+        IntentQuestion  -> gotoChoice @"sgFaq" msg
+        IntentComplaint -> gotoChoice @"sgFaq" msg  -- Complaints go to FAQ for now
   , sgRefund   = \_msg -> do
       -- Refund template context builder
       pure SimpleContext { scContent = "Processing refund..." }

--- a/tidepool-core/src/Tidepool/Graph/Generic.hs
+++ b/tidepool-core/src/Tidepool/Graph/Generic.hs
@@ -129,8 +129,8 @@ import Effectful qualified as E
 
 import Tidepool.Graph.Types (type (:@), Needs, Schema, Template, Vision, Tools, Memory, System, UsesEffects)
 import Tidepool.Graph.Template (TemplateContext)
-import Tidepool.Graph.Edges (GetUsesEffects, GetGotoTargets)
-import Tidepool.Graph.Goto (Goto, goto)
+import Tidepool.Graph.Edges (GetUsesEffects, GetGotoTargets, GotoEffectsToTargets)
+import Tidepool.Graph.Goto (Goto, goto, GotoChoice)
 import Tidepool.Graph.Validate.RecordStructure (AllFieldsReachable, AllLogicFieldsReachExit, NoDeadGotosRecord)
 import Tidepool.Graph.Generic.Core
   ( GraphMode(..)
@@ -281,8 +281,10 @@ type family NodeHandlerDispatch nodeDef origNode es needs mTpl where
     )
 
   -- Base case: bare LogicNode with UsesEffects found
+  -- Logic handlers return GotoChoice containing the possible transitions
+  -- The effect stack is 'es' (from AsHandler), not 'effs' (the Goto effects)
   NodeHandlerDispatch LogicNode orig es needs ('Just (EffStack effs)) =
-    BuildFunctionType needs (E.Eff effs ())
+    BuildFunctionType needs (E.Eff es (GotoChoice (GotoEffectsToTargets effs)))
 
   -- Base case: bare LogicNode without UsesEffects - error
   NodeHandlerDispatch LogicNode orig es needs _ = TypeError

--- a/tidepool-core/src/Tidepool/Graph/Types.hs
+++ b/tidepool-core/src/Tidepool/Graph/Types.hs
@@ -32,6 +32,7 @@ module Tidepool.Graph.Types
     Graph
   , Entry
   , Exit
+  , Self
   , type (:~>)
   , type (:<~)
 
@@ -85,6 +86,10 @@ data Entry
 -- | Exit point marker. Used with ':<~' to declare the graph's output type.
 -- Also used as a 'Goto' target: @Goto Exit ResultType@.
 data Exit
+
+-- | Self-loop marker for transitions back to the current node.
+-- Used for retry/continuation patterns: @Goto Self UpdatedState@.
+data Self
 
 -- | Entry point declaration. @Entry :~> InputType@ declares that the graph
 -- accepts @InputType@ as input.


### PR DESCRIPTION
## Summary

Replace effect-based Goto with guaranteed-return-type GotoChoice for Logic nodes. This makes the "handler must transition" semantics structural.

## Changes

- Add `Self` marker type for self-loop transitions
- Add `To` marker type for GotoChoice targets (since `Goto` is Effect kind, not Type kind)
- Add `GotoChoice` GADT with `GotoChoiceNode`, `GotoChoiceExit`, `GotoChoiceSelf` constructors  
- Add `gotoChoice`, `gotoExit`, `gotoSelf` smart constructors
- Add `GotoEffectsToTargets` type family to convert `UsesEffects` to `To` list
- Update `NodeHandlerDispatch` to return `GotoChoice` for LogicNode
- Update Example.hs to demonstrate new pattern

## Handler Type Change

```haskell
-- Before (effect-based, may-happen semantics):
sgRoute :: Intent -> Eff '[Goto "sgRefund" Message, Goto "sgFaq" Message] ()

-- After (return-based, must-happen semantics):
sgRoute :: Intent -> Eff es (GotoChoice '[To "sgRefund" Message, To "sgFaq" Message])
```

## Usage

```haskell
sgRoute = \intent -> do
  let msg = Message "forwarded message"
  pure $ case intent of
    IntentRefund    -> gotoChoice @"sgRefund" msg
    IntentQuestion  -> gotoChoice @"sgFaq" msg
    IntentComplaint -> gotoChoice @"sgFaq" msg
```

## Test plan

- [x] `cabal build all` succeeds
- [x] `cabal test all` passes (12/12 tests)
- [x] Manual verification of Example.hs handler types

🤖 Generated with [Claude Code](https://claude.com/claude-code)