### PR TITLE
Add LLMHandler GADT for before/after LLM node handlers

### DIFF
--- a/tidepool-core/src/Tidepool/Graph/Generic.hs
+++ b/tidepool-core/src/Tidepool/Graph/Generic.hs
@@ -291,15 +291,15 @@ type family NodeHandlerDispatch nodeDef origNode es needs mTpl mSchema mEffs whe
   -- LLMNode Base Cases
   -- ══════════════════════════════════════════════════════════════════════════
 
-  -- LLMNode with Template only (before-only): returns LLMHandler with LLMBefore
+  -- LLMNode with Template only (before-only): handler must use LLMBefore constructor
   NodeHandlerDispatch LLMNode orig es needs ('Just tpl) ('Just schema) 'Nothing =
     LLMHandler (TupleOf needs) schema '[] es (TemplateContext tpl)
 
-  -- LLMNode with Template AND UsesEffects (both): returns LLMHandler with LLMBoth
+  -- LLMNode with Template AND UsesEffects (both): handler must use LLMBoth constructor
   NodeHandlerDispatch LLMNode orig es needs ('Just tpl) ('Just schema) ('Just (EffStack effs)) =
     LLMHandler (TupleOf needs) schema (GotoEffectsToTargets effs) es (TemplateContext tpl)
 
-  -- LLMNode with UsesEffects but no Template (after-only): returns LLMHandler with LLMAfter
+  -- LLMNode with UsesEffects but no Template (after-only): handler must use LLMAfter constructor
   NodeHandlerDispatch LLMNode orig es needs 'Nothing ('Just schema) ('Just (EffStack effs)) =
     LLMHandler (TupleOf needs) schema (GotoEffectsToTargets effs) es ()
 
@@ -314,8 +314,11 @@ type family NodeHandlerDispatch nodeDef origNode es needs mTpl mSchema mEffs whe
      ':$$: 'Text "  • Template annotation (for before-only or both phases)"
      ':$$: 'Text "  • UsesEffects annotation (for after-only routing with default context)"
      ':$$: 'Text ""
-     ':$$: 'Text "Fix: Add a Template annotation:"
+     ':$$: 'Text "Fix: Add a Template annotation (before-only with default routing):"
      ':$$: 'Text "  myNode :: mode :- LLMNode :@ Template MyTpl :@ Schema " ':<>: 'ShowType schema
+     ':$$: 'Text ""
+     ':$$: 'Text "Or add UsesEffects annotation (after-only with explicit routing):"
+     ':$$: 'Text "  myNode :: mode :- LLMNode :@ Schema " ':<>: 'ShowType schema ':<>: 'Text " :@ UsesEffects '[Goto \"target\" Payload]"
     )
 
   -- LLMNode missing both Template and Schema - error

--- a/tidepool-core/src/Tidepool/Graph/Goto.hs
+++ b/tidepool-core/src/Tidepool/Graph/Goto.hs
@@ -277,11 +277,11 @@ gotoChoiceToResult (GotoChoiceSelf payload) =
 -- sgClassify :: LLMHandler Message Intent '[] es ClassifyContext
 -- sgClassify = LLMBefore $ \\msg -> pure ClassifyContext { topic = msg.content }
 --
--- -- After-only: router using LLM output
--- sgRouter :: LLMHandler () Intent '[To "refund" Msg, To "faq" Msg] es ()
+-- -- After-only: router using LLM output (no access to before-phase data)
+-- sgRouter :: LLMHandler () Intent '[To "refund" Intent, To "faq" Intent] es ()
 -- sgRouter = LLMAfter $ \\intent -> pure $ case intent of
---   IntentRefund -> gotoChoice @"refund" msg
---   IntentFaq    -> gotoChoice @"faq" msg
+--   IntentRefund -> gotoChoice @"refund" intent
+--   IntentFaq    -> gotoChoice @"faq" intent
 --
 -- -- Both: custom context AND explicit routing
 -- sgSmart :: LLMHandler Message Intent '[To "a" X, To "b" Y] es SmartContext


### PR DESCRIPTION
## Summary

Adds the `LLMHandler` GADT that provides explicit handler variants for LLM nodes:

- **`LLMBefore`**: Provides template context before LLM call, implicit routing
- **`LLMAfter`**: Routes based on LLM output, uses default context
- **`LLMBoth`**: Custom context AND explicit routing based on output

This is Phase 2 of the GotoChoice refactor (Phase 1 was PR #9 for LogicNode handlers).

## Changes

### Goto.hs
- Add `LLMHandler` GADT with `LLMBefore`, `LLMAfter`, `LLMBoth` constructors
- Export `LLMHandler(..)` for use in handler definitions

### Generic.hs
- Extend `NodeHandlerDispatch` type family to 7 parameters (was 5)
- Track `mTpl`, `mSchema`, and `mEffs` separately in accumulator
- Add `TupleOf` type family for converting Needs list to single type
- LLMNode now returns `LLMHandler needs schema targets es tpl` instead of function

### Example.hs
- Wrap LLM handlers in `LLMBefore`:
  ```haskell
  -- Before
  sgClassify = \msg -> pure ClassifyContext { ... }
  
  -- After
  sgClassify = LLMBefore $ \msg -> pure ClassifyContext { ... }
  ```

## Handler Type Change

```haskell
-- Before (implicit function):
sgClassify :: Message -> Eff es (TemplateContext ClassifyTpl)

-- After (explicit wrapper):
sgClassify :: LLMHandler Message Intent '[] es (TemplateContext ClassifyTpl)
```

## Usage Examples

```haskell
-- Before-only: classifier with custom context
sgClassify = LLMBefore $ \msg -> pure ClassifyContext { topic = msg.content }

-- After-only: router using LLM output
sgRouter = LLMAfter $ \intent -> pure $ case intent of
  IntentRefund -> gotoChoice @"refund" msg
  IntentFaq    -> gotoChoice @"faq" msg

-- Both: custom context AND explicit routing
sgSmart = LLMBoth
  (\msg -> pure SmartContext { ... })
  (\intent -> pure $ gotoChoice @"route" result)
```

## Test plan

- [x] `cabal build all` succeeds
- [x] `cabal test all` passes (9/9 tests)
- [x] Example.hs compiles with new handler pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)