### PR TITLE
Add unit tests for v2 graph components

### DIFF
--- a/tidepool-core/test/CallHandlerSpec.hs
+++ b/tidepool-core/test/CallHandlerSpec.hs
@@ -1,0 +1,143 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+
+-- | Tests for CallHandler typeclass.
+--
+-- CallHandler abstracts over how different handler types are invoked:
+-- * Logic handlers: plain functions (payload -> Eff es (GotoChoice targets))
+-- * LLM handlers: LLMHandler GADT (requires template context, LLM call, etc.)
+--
+-- These tests focus on Logic handler invocation. LLM handler tests would
+-- require mocking the LLM effect.
+module CallHandlerSpec (spec) where
+
+import Test.Hspec
+import Effectful (Eff, runPureEff)
+
+import Tidepool.Graph.Goto
+  ( OneOf(..)
+  , To
+  , GotoChoice(..)
+  , gotoChoice
+  , gotoExit
+  )
+import Tidepool.Graph.Execute (CallHandler(..))
+import Tidepool.Graph.Types (Exit)
+
+-- | Simple target list.
+type SimpleTargets = '[To "next" String, To Exit Int]
+
+-- | Branching targets.
+type BranchTargets = '[To "pathA" Int, To "pathB" Int, To Exit String]
+
+spec :: Spec
+spec = do
+  -- ════════════════════════════════════════════════════════════════════════════
+  -- LOGIC HANDLER INVOCATION
+  -- ════════════════════════════════════════════════════════════════════════════
+  describe "CallHandler for Logic handlers" $ do
+
+    it "invokes handler that returns gotoExit" $
+      let handler :: Int -> Eff '[] (GotoChoice '[To Exit Int])
+          handler n = pure $ gotoExit (n * 2)
+          result = runPureEff $ callHandler handler (21 :: Int)
+      in case result of
+        GotoChoice (Here n) -> n `shouldBe` (42 :: Int)
+        GotoChoice (There _) -> expectationFailure "Unexpected There"
+
+    it "invokes handler that returns gotoChoice" $
+      let handler :: Int -> Eff '[] (GotoChoice SimpleTargets)
+          handler n = pure $ gotoChoice @"next" (("got: " ++ show n) :: String)
+          result = runPureEff $ callHandler handler (42 :: Int)
+      in case result of
+        GotoChoice (Here s) -> s `shouldBe` "got: 42"
+        GotoChoice (There _) -> expectationFailure "Expected position 0"
+
+    it "invokes handler with branching logic" $ do
+      -- Test negative -> pathA
+      let handler :: Int -> Eff '[] (GotoChoice BranchTargets)
+          handler n
+            | n < 0     = pure $ gotoChoice @"pathA" (abs n)
+            | n > 100   = pure $ gotoChoice @"pathB" (n - 100)
+            | otherwise = pure $ gotoExit (("normal: " ++ show n) :: String)
+          resultA = runPureEff $ callHandler handler ((-5) :: Int)
+      case resultA of
+        GotoChoice (Here n) -> n `shouldBe` (5 :: Int)
+        _ -> expectationFailure "Expected pathA"
+
+      -- Test > 100 -> pathB
+      let resultB = runPureEff $ callHandler handler (150 :: Int)
+      case resultB of
+        GotoChoice (There (Here n)) -> n `shouldBe` (50 :: Int)
+        _ -> expectationFailure "Expected pathB"
+
+      -- Test normal -> Exit
+      let resultExit = runPureEff $ callHandler handler (42 :: Int)
+      case resultExit of
+        GotoChoice (There (There (Here s))) -> s `shouldBe` "normal: 42"
+        _ -> expectationFailure "Expected Exit"
+
+    it "invokes handler with multiple parameters (via tuple)" $
+      let handler :: (Int, String) -> Eff '[] (GotoChoice '[To Exit String])
+          handler (n, s) = pure $ gotoExit ((s ++ ": " ++ show n) :: String)
+          result = runPureEff $ callHandler handler ((42, "answer") :: (Int, String))
+      in case result of
+        GotoChoice (Here s) -> s `shouldBe` "answer: 42"
+        GotoChoice (There _) -> expectationFailure "Unexpected There"
+
+    it "invokes handler with unit input" $
+      let handler :: () -> Eff '[] (GotoChoice '[To Exit String])
+          handler () = pure $ gotoExit ("started" :: String)
+          result = runPureEff $ callHandler handler ()
+      in case result of
+        GotoChoice (Here s) -> s `shouldBe` "started"
+        GotoChoice (There _) -> expectationFailure "Unexpected There"
+
+  -- ════════════════════════════════════════════════════════════════════════════
+  -- HANDLER TYPE INFERENCE
+  -- ════════════════════════════════════════════════════════════════════════════
+  describe "Handler type inference" $ do
+
+    it "handler type determines payload and targets" $ do
+      -- The CallHandler instance infers payload type from handler signature
+      let intHandler :: Int -> Eff '[] (GotoChoice '[To Exit Bool])
+          intHandler n = pure $ gotoExit (n > 0)
+          intResult = runPureEff $ callHandler intHandler (42 :: Int)
+
+      case intResult of
+        GotoChoice (Here b) -> b `shouldBe` True
+        GotoChoice (There _) -> expectationFailure "Unexpected There"
+
+      let strHandler :: String -> Eff '[] (GotoChoice '[To Exit Int])
+          strHandler s = pure $ gotoExit (length s)
+          strResult = runPureEff $ callHandler strHandler ("hello" :: String)
+
+      case strResult of
+        GotoChoice (Here n) -> n `shouldBe` (5 :: Int)
+        GotoChoice (There _) -> expectationFailure "Unexpected There"
+
+  -- ════════════════════════════════════════════════════════════════════════════
+  -- EDGE CASES
+  -- ════════════════════════════════════════════════════════════════════════════
+  describe "Edge cases" $ do
+
+    it "handler with complex return type" $
+      let handler :: Int -> Eff '[] (GotoChoice '[To Exit (Int, Int, Int)])
+          handler n = pure $ gotoExit (n, n * 2, n * 3)
+          result = runPureEff $ callHandler handler (10 :: Int)
+      in case result of
+        GotoChoice (Here (a, b, c)) -> do
+          a `shouldBe` (10 :: Int)
+          b `shouldBe` (20 :: Int)
+          c `shouldBe` (30 :: Int)
+        GotoChoice (There _) -> expectationFailure "Unexpected There"
+
+    it "handler identity (just wraps input)" $
+      let handler :: Int -> Eff '[] (GotoChoice '[To Exit Int])
+          handler = pure . gotoExit
+          result = runPureEff $ callHandler handler (123 :: Int)
+      in case result of
+        GotoChoice (Here n) -> n `shouldBe` (123 :: Int)
+        GotoChoice (There _) -> expectationFailure "Unexpected There"

--- a/tidepool-core/test/DispatchGotoSpec.hs
+++ b/tidepool-core/test/DispatchGotoSpec.hs
@@ -1,0 +1,137 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+-- | Tests for DispatchGoto typeclass.
+--
+-- DispatchGoto is the core dispatch mechanism that routes GotoChoice values
+-- through the graph, calling handlers and recursing until Exit is reached.
+--
+-- Note: Multi-hop dispatch (handler → handler → Exit) requires complex
+-- HasField instance resolution that isn't working in these tests.
+-- Those tests are deferred pending investigation. For now, we test:
+-- * Exit-only dispatch (base cases)
+-- * Single-hop dispatch (handler → Exit)
+module DispatchGotoSpec (spec) where
+
+import Data.Proxy (Proxy(..))
+import GHC.Generics (Generic)
+import Test.Hspec
+import Effectful (runPureEff)
+
+import Tidepool.Graph.Goto
+  ( To
+  , GotoChoice(..)
+  , gotoChoice
+  , gotoExit
+  )
+import Tidepool.Graph.Execute (DispatchGoto(..))
+import Tidepool.Graph.Generic (GraphMode(..), type (:-), AsHandler)
+import Tidepool.Graph.Generic.Core (Entry)
+import Tidepool.Graph.Types (Needs, UsesEffects, type (:@))
+import qualified Tidepool.Graph.Types as Types (Exit)
+import qualified Tidepool.Graph.Generic as G
+import Tidepool.Graph.Goto (Goto)
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- TEST GRAPHS
+-- ════════════════════════════════════════════════════════════════════════════
+
+-- | Simple graph: Entry(Int) → compute(+1) → Exit(Int)
+data SimpleGraph mode = SimpleGraph
+  { sgEntry   :: mode :- Entry Int
+  , sgCompute :: mode :- G.LogicNode :@ Needs '[Int] :@ UsesEffects '[Goto Types.Exit Int]
+  , sgExit    :: mode :- G.Exit Int
+  }
+  deriving Generic
+
+simpleHandlers :: SimpleGraph (AsHandler '[])
+simpleHandlers = SimpleGraph
+  { sgEntry   = Proxy
+  , sgCompute = \n -> pure $ gotoExit (n + 1 :: Int)
+  , sgExit    = Proxy
+  }
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- TESTS
+-- ════════════════════════════════════════════════════════════════════════════
+
+spec :: Spec
+spec = do
+  -- ════════════════════════════════════════════════════════════════════════════
+  -- EXIT-ONLY DISPATCH
+  -- ════════════════════════════════════════════════════════════════════════════
+  describe "Exit-only dispatch" $ do
+
+    it "returns value directly when Exit is the only target" $ do
+      let choice :: GotoChoice '[To Types.Exit Int] = gotoExit (42 :: Int)
+          result :: Int = runPureEff $ dispatchGoto simpleHandlers choice
+      result `shouldBe` (42 :: Int)
+
+    it "returns value for Exit target in multi-target list (same exitType)" $ do
+      let choice :: GotoChoice '[To "sgCompute" Int, To Types.Exit Int] = gotoExit (99 :: Int)
+          result :: Int = runPureEff $ dispatchGoto simpleHandlers choice
+      result `shouldBe` (99 :: Int)
+
+  -- ════════════════════════════════════════════════════════════════════════════
+  -- SIMPLE GRAPH DISPATCH
+  -- ════════════════════════════════════════════════════════════════════════════
+  describe "Simple graph dispatch (Entry → compute → Exit)" $ do
+
+    it "dispatches to compute handler then exits" $ do
+      let choice :: GotoChoice '[To "sgCompute" Int, To Types.Exit Int] = gotoChoice @"sgCompute" (5 :: Int)
+          result :: Int = runPureEff $ dispatchGoto simpleHandlers choice
+      result `shouldBe` (6 :: Int)  -- compute adds 1
+
+    it "dispatches multiple times with different inputs" $ do
+      let choice0 :: GotoChoice '[To "sgCompute" Int, To Types.Exit Int] = gotoChoice @"sgCompute" (0 :: Int)
+          choice10 :: GotoChoice '[To "sgCompute" Int, To Types.Exit Int] = gotoChoice @"sgCompute" (10 :: Int)
+          choiceNeg :: GotoChoice '[To "sgCompute" Int, To Types.Exit Int] = gotoChoice @"sgCompute" ((-5) :: Int)
+          results :: [Int] = runPureEff $ sequence
+            [ dispatchGoto simpleHandlers choice0
+            , dispatchGoto simpleHandlers choice10
+            , dispatchGoto simpleHandlers choiceNeg
+            ]
+      results `shouldBe` ([1, 11, -4] :: [Int])
+
+  -- ════════════════════════════════════════════════════════════════════════════
+  -- EDGE CASES (Exit-only, no handler dispatch)
+  -- ════════════════════════════════════════════════════════════════════════════
+  describe "Edge cases (Exit-only)" $ do
+
+    it "handles tuple exit payload" $ do
+      let payload :: (Int, String) = (42 :: Int, "hi!" :: String)
+          choice :: GotoChoice '[To Types.Exit (Int, String)] = gotoExit payload
+          result :: (Int, String) = runPureEff $ dispatchGoto simpleHandlers choice
+      result `shouldBe` ((42 :: Int), ("hi!" :: String))
+
+    it "handles unit exit payload" $ do
+      let choice :: GotoChoice '[To Types.Exit ()] = gotoExit ()
+          result :: () = runPureEff $ dispatchGoto simpleHandlers choice
+      result `shouldBe` ()
+
+    it "handles Bool exit payload" $ do
+      let choice :: GotoChoice '[To Types.Exit Bool] = gotoExit True
+          result :: Bool = runPureEff $ dispatchGoto simpleHandlers choice
+      result `shouldBe` True
+
+    it "handles String exit payload" $ do
+      let choice :: GotoChoice '[To Types.Exit String] = gotoExit ("done" :: String)
+          result :: String = runPureEff $ dispatchGoto simpleHandlers choice
+      result `shouldBe` ("done" :: String)
+
+  -- ════════════════════════════════════════════════════════════════════════════
+  -- DEFERRED: MULTI-HOP DISPATCH
+  -- ════════════════════════════════════════════════════════════════════════════
+  -- The following tests are deferred pending investigation of HasField
+  -- instance resolution for multi-hop dispatch (handler → handler → Exit):
+  --
+  -- * Chain graph dispatch (Entry → step1 → step2 → Exit)
+  -- * Branching graph dispatch (router → pathA | pathB → Exit)
+  -- * Diamond graph dispatch (split → pathA/pathB → merge → Exit)
+  --
+  -- These work at the type level but the test infrastructure has issues
+  -- with GHC's HasField constraint resolution for record types.

--- a/tidepool-core/test/GotoChoiceSpec.hs
+++ b/tidepool-core/test/GotoChoiceSpec.hs
@@ -1,0 +1,156 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+
+-- | Tests for GotoChoice and its smart constructors.
+--
+-- GotoChoice is the return type for Logic node handlers. It wraps OneOf
+-- with target metadata, guaranteeing a transition is always selected.
+module GotoChoiceSpec (spec) where
+
+import Test.Hspec
+import Tidepool.Graph.Goto
+  ( OneOf(..)
+  , To
+  , GotoChoice(..)
+  , gotoChoice
+  , gotoExit
+  , gotoSelf
+  )
+import Tidepool.Graph.Types (Exit, Self)
+
+-- | Simple target list for basic tests.
+type BasicTargets = '[To "nodeA" Int, To "nodeB" String, To Exit Bool]
+
+-- | Targets including Self for self-loop tests.
+type SelfLoopTargets = '[To Self Int, To "other" String, To Exit Bool]
+
+-- | Multiple named targets.
+type MultiNodeTargets = '[To "first" Int, To "second" Int, To "third" String, To Exit ()]
+
+spec :: Spec
+spec = do
+  -- ════════════════════════════════════════════════════════════════════════════
+  -- gotoChoice SMART CONSTRUCTOR
+  -- ════════════════════════════════════════════════════════════════════════════
+  describe "gotoChoice" $ do
+
+    it "constructs choice for first named target" $ do
+      let choice :: GotoChoice BasicTargets = gotoChoice @"nodeA" (42 :: Int)
+      case choice of
+        GotoChoice (Here n) -> n `shouldBe` (42 :: Int)
+        GotoChoice (There _) -> expectationFailure "Expected position 0"
+
+    it "constructs choice for second named target" $ do
+      let choice :: GotoChoice BasicTargets = gotoChoice @"nodeB" ("hello" :: String)
+      case choice of
+        GotoChoice (There (Here s)) -> s `shouldBe` "hello"
+        _ -> expectationFailure "Expected position 1"
+
+    it "constructs choice with same payload type different names" $ do
+      -- Both "first" and "second" have Int payload
+      let first :: GotoChoice MultiNodeTargets = gotoChoice @"first" (100 :: Int)
+          second :: GotoChoice MultiNodeTargets = gotoChoice @"second" (200 :: Int)
+
+      case first of
+        GotoChoice (Here n) -> n `shouldBe` (100 :: Int)
+        _ -> expectationFailure "first should be at position 0"
+
+      case second of
+        GotoChoice (There (Here n)) -> n `shouldBe` (200 :: Int)
+        _ -> expectationFailure "second should be at position 1"
+
+  -- ════════════════════════════════════════════════════════════════════════════
+  -- gotoExit SMART CONSTRUCTOR
+  -- ════════════════════════════════════════════════════════════════════════════
+  describe "gotoExit" $ do
+
+    it "constructs Exit choice at correct position" $ do
+      let choice :: GotoChoice BasicTargets = gotoExit True
+      case choice of
+        GotoChoice (There (There (Here b))) -> b `shouldBe` True
+        _ -> expectationFailure "Exit should be at position 2"
+
+    it "constructs Exit choice when Exit is first" $ do
+      let choice :: GotoChoice '[To Exit Int] = gotoExit (42 :: Int)
+      case choice of
+        GotoChoice (Here n) -> n `shouldBe` (42 :: Int)
+        GotoChoice (There _) -> expectationFailure "Unexpected There"
+
+    it "constructs Exit choice with unit payload" $ do
+      let choice :: GotoChoice MultiNodeTargets = gotoExit ()
+      case choice of
+        GotoChoice (There (There (There (Here ())))) -> pure ()
+        _ -> expectationFailure "Exit should be at position 3"
+
+  -- ════════════════════════════════════════════════════════════════════════════
+  -- gotoSelf SMART CONSTRUCTOR
+  -- ════════════════════════════════════════════════════════════════════════════
+  describe "gotoSelf" $ do
+
+    it "constructs Self choice at correct position" $ do
+      let choice :: GotoChoice SelfLoopTargets = gotoSelf (42 :: Int)
+      case choice of
+        GotoChoice (Here n) -> n `shouldBe` (42 :: Int)
+        GotoChoice (There _) -> expectationFailure "Self should be at position 0"
+
+    it "Self can coexist with other targets" $ do
+      let selfChoice :: GotoChoice SelfLoopTargets = gotoSelf (10 :: Int)
+          otherChoice :: GotoChoice SelfLoopTargets = gotoChoice @"other" ("hi" :: String)
+          exitChoice :: GotoChoice SelfLoopTargets = gotoExit False
+
+      case selfChoice of
+        GotoChoice (Here n) -> n `shouldBe` (10 :: Int)
+        _ -> expectationFailure "Self wrong position"
+
+      case otherChoice of
+        GotoChoice (There (Here s)) -> s `shouldBe` "hi"
+        _ -> expectationFailure "other wrong position"
+
+      case exitChoice of
+        GotoChoice (There (There (Here b))) -> b `shouldBe` False
+        _ -> expectationFailure "Exit wrong position"
+
+  -- ════════════════════════════════════════════════════════════════════════════
+  -- PATTERN MATCHING ON GotoChoice
+  -- ════════════════════════════════════════════════════════════════════════════
+  describe "GotoChoice pattern matching" $ do
+
+    it "can dispatch based on GotoChoice value" $ do
+      let dispatch :: GotoChoice BasicTargets -> String
+          dispatch (GotoChoice (Here n)) = "nodeA: " ++ show n
+          dispatch (GotoChoice (There (Here s))) = "nodeB: " ++ s
+          dispatch (GotoChoice (There (There (Here b)))) = "Exit: " ++ show b
+
+      dispatch (gotoChoice @"nodeA" (42 :: Int)) `shouldBe` "nodeA: 42"
+      dispatch (gotoChoice @"nodeB" ("test" :: String)) `shouldBe` "nodeB: test"
+      dispatch (gotoExit True) `shouldBe` "Exit: True"
+
+    it "GotoChoice wraps OneOf with Payloads" $ do
+      -- Pattern match to extract raw OneOf
+      let choice :: GotoChoice '[To "a" Int, To Exit String] = gotoChoice @"a" (42 :: Int)
+      case choice of
+        GotoChoice (Here n) -> n `shouldBe` (42 :: Int)
+        GotoChoice (There _) -> expectationFailure "wrong"
+
+  -- ════════════════════════════════════════════════════════════════════════════
+  -- EDGE CASES
+  -- ════════════════════════════════════════════════════════════════════════════
+  describe "Edge cases" $ do
+
+    it "single Exit target" $ do
+      let choice :: GotoChoice '[To Exit Int] = gotoExit (999 :: Int)
+      case choice of
+        GotoChoice (Here n) -> n `shouldBe` (999 :: Int)
+        GotoChoice (There _) -> expectationFailure "Unexpected There"
+
+    it "Exit with complex payload" $ do
+      let payload :: (Int, String, Bool) = (1, "two", True)
+          choice :: GotoChoice '[To Exit (Int, String, Bool)] = gotoExit payload
+      case choice of
+        GotoChoice (Here (a, b, c)) -> do
+          a `shouldBe` (1 :: Int)
+          b `shouldBe` "two"
+          c `shouldBe` True
+        GotoChoice (There _) -> expectationFailure "Unexpected There"

--- a/tidepool-core/test/InjectTargetSpec.hs
+++ b/tidepool-core/test/InjectTargetSpec.hs
@@ -1,0 +1,120 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+
+-- | Tests for InjectTarget typeclass.
+--
+-- InjectTarget is like Inject but matches on full (To name payload) markers
+-- instead of just payload types. This correctly handles cases where multiple
+-- targets have the same payload type but different names.
+module InjectTargetSpec (spec) where
+
+import Test.Hspec
+import Tidepool.Graph.Goto (OneOf(..), InjectTarget(..), To, Payloads)
+import Tidepool.Graph.Types (Exit)
+
+-- | Test targets with different payload types.
+type SimpleTargets = '[To "nodeA" Int, To "nodeB" String, To Exit Bool]
+
+-- | Test targets with DUPLICATE payload types (same Int at different names).
+-- This is the key case that InjectTarget handles correctly.
+type DuplicatePayloadTargets = '[To "alpha" Int, To "beta" Int, To Exit String]
+
+-- | All same payload type.
+type AllSamePayload = '[To "a" Int, To "b" Int, To "c" Int]
+
+spec :: Spec
+spec = do
+  -- ════════════════════════════════════════════════════════════════════════════
+  -- SIMPLE TARGETS (different payload types)
+  -- ════════════════════════════════════════════════════════════════════════════
+  describe "InjectTarget with different payload types" $ do
+
+    it "injects first target at position 0" $ do
+      let x :: OneOf (Payloads SimpleTargets) = injectTarget @(To "nodeA" Int) @SimpleTargets 42
+      case x of
+        Here n -> n `shouldBe` 42
+        There _ -> expectationFailure "Expected position 0"
+
+    it "injects second target at position 1" $ do
+      let x :: OneOf (Payloads SimpleTargets) = injectTarget @(To "nodeB" String) @SimpleTargets "hello"
+      case x of
+        There (Here s) -> s `shouldBe` "hello"
+        _ -> expectationFailure "Expected position 1"
+
+    it "injects Exit target at position 2" $ do
+      let x :: OneOf (Payloads SimpleTargets) = injectTarget @(To Exit Bool) @SimpleTargets True
+      case x of
+        There (There (Here b)) -> b `shouldBe` True
+        _ -> expectationFailure "Expected position 2"
+
+  -- ════════════════════════════════════════════════════════════════════════════
+  -- DUPLICATE PAYLOAD TYPES (the critical case)
+  -- ════════════════════════════════════════════════════════════════════════════
+  describe "InjectTarget with duplicate payload types" $ do
+
+    it "To 'alpha' Int injects at position 0 (not position 1)" $ do
+      let x :: OneOf (Payloads DuplicatePayloadTargets) =
+            injectTarget @(To "alpha" Int) @DuplicatePayloadTargets 100
+      case x of
+        Here n -> n `shouldBe` 100
+        There (Here _) -> expectationFailure "Wrong position: got 1, expected 0"
+        There (There _) -> expectationFailure "Wrong position: got 2, expected 0"
+
+    it "To 'beta' Int injects at position 1 (not position 0)" $ do
+      let x :: OneOf (Payloads DuplicatePayloadTargets) =
+            injectTarget @(To "beta" Int) @DuplicatePayloadTargets 200
+      case x of
+        Here _ -> expectationFailure "Wrong position: got 0, expected 1"
+        There (Here n) -> n `shouldBe` 200
+        There (There _) -> expectationFailure "Wrong position: got 2, expected 1"
+
+    it "To Exit String injects at position 2" $ do
+      let x :: OneOf (Payloads DuplicatePayloadTargets) =
+            injectTarget @(To Exit String) @DuplicatePayloadTargets "done"
+      case x of
+        There (There (Here s)) -> s `shouldBe` "done"
+        _ -> expectationFailure "Expected position 2"
+
+    it "different names with same payload go to different positions" $ do
+      -- This is THE key property: same payload type, different target names
+      let alpha = injectTarget @(To "alpha" Int) @DuplicatePayloadTargets 1
+          beta = injectTarget @(To "beta" Int) @DuplicatePayloadTargets 2
+
+      -- alpha should be at position 0, beta at position 1
+      case alpha of
+        Here n -> n `shouldBe` 1
+        _ -> expectationFailure "alpha should be at position 0"
+
+      case beta of
+        There (Here n) -> n `shouldBe` 2
+        _ -> expectationFailure "beta should be at position 1"
+
+  -- ════════════════════════════════════════════════════════════════════════════
+  -- ALL SAME PAYLOAD TYPE
+  -- ════════════════════════════════════════════════════════════════════════════
+  describe "InjectTarget with all same payload type" $ do
+
+    it "distinguishes three Int targets by name" $ do
+      let a = injectTarget @(To "a" Int) @AllSamePayload 10
+          b = injectTarget @(To "b" Int) @AllSamePayload 20
+          c = injectTarget @(To "c" Int) @AllSamePayload 30
+
+      case a of { Here n -> n `shouldBe` 10; _ -> expectationFailure "a wrong" }
+      case b of { There (Here n) -> n `shouldBe` 20; _ -> expectationFailure "b wrong" }
+      case c of { There (There (Here n)) -> n `shouldBe` 30; _ -> expectationFailure "c wrong" }
+
+  -- ════════════════════════════════════════════════════════════════════════════
+  -- PAYLOADS TYPE FAMILY
+  -- ════════════════════════════════════════════════════════════════════════════
+  describe "Payloads type family" $ do
+
+    it "extracts payload types from To markers" $ do
+      -- Payloads '[To "a" Int, To "b" String] = '[Int, String]
+      -- We verify this by constructing OneOf values
+      let intVal :: OneOf (Payloads '[To "a" Int, To "b" String]) = Here 42
+          strVal :: OneOf (Payloads '[To "a" Int, To "b" String]) = There (Here "hi")
+
+      case intVal of { Here n -> n `shouldBe` 42; _ -> expectationFailure "wrong" }
+      case strVal of { There (Here s) -> s `shouldBe` "hi"; _ -> expectationFailure "wrong" }

--- a/tidepool-core/test/OneOfSpec.hs
+++ b/tidepool-core/test/OneOfSpec.hs
@@ -1,0 +1,100 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+
+-- | Tests for the OneOf GADT.
+--
+-- OneOf is a type-indexed sum type where position in the type list
+-- encodes which type was chosen. These tests verify:
+-- * Direct construction via Here/There
+-- * Pattern matching extracts correct types
+--
+-- Note: The Inject typeclass is internal (not exported). Use InjectTarget
+-- with To markers for injection. See InjectTargetSpec for those tests.
+module OneOfSpec (spec) where
+
+import Test.Hspec
+import Tidepool.Graph.Goto (OneOf(..))
+
+spec :: Spec
+spec = do
+  -- ════════════════════════════════════════════════════════════════════════════
+  -- DIRECT CONSTRUCTION
+  -- ════════════════════════════════════════════════════════════════════════════
+  describe "OneOf direct construction" $ do
+
+    it "Here puts value at position 0 (head)" $ do
+      let x :: OneOf '[Int, String, Bool] = Here 42
+      case x of
+        Here n -> n `shouldBe` 42
+        There _ -> expectationFailure "Expected Here, got There"
+
+    it "There (Here _) puts value at position 1" $ do
+      let x :: OneOf '[Int, String, Bool] = There (Here "hello")
+      case x of
+        Here _ -> expectationFailure "Expected There (Here _), got Here"
+        There (Here s) -> s `shouldBe` "hello"
+        There (There _) -> expectationFailure "Expected position 1, got deeper"
+
+    it "There (There (Here _)) puts value at position 2" $ do
+      let x :: OneOf '[Int, String, Bool] = There (There (Here True))
+      case x of
+        Here _ -> expectationFailure "Expected position 2"
+        There (Here _) -> expectationFailure "Expected position 2"
+        There (There (Here b)) -> b `shouldBe` True
+
+    it "single-element list uses Here" $ do
+      let x :: OneOf '[Int] = Here 99
+      case x of
+        Here n -> n `shouldBe` 99
+
+  -- ════════════════════════════════════════════════════════════════════════════
+  -- PATTERN MATCHING
+  -- ════════════════════════════════════════════════════════════════════════════
+  describe "Pattern matching" $ do
+
+    it "exhaustive match on three-element OneOf" $ do
+      let check :: OneOf '[Int, String, Bool] -> String
+          check (Here n) = "Int: " ++ show n
+          check (There (Here s)) = "String: " ++ s
+          check (There (There (Here b))) = "Bool: " ++ show b
+
+      check (Here 42) `shouldBe` "Int: 42"
+      check (There (Here "hi")) `shouldBe` "String: hi"
+      check (There (There (Here True))) `shouldBe` "Bool: True"
+
+    it "can extract values with helper function" $ do
+      let getInt :: OneOf '[Int, String] -> Maybe Int
+          getInt (Here n) = Just n
+          getInt (There _) = Nothing
+
+          getString :: OneOf '[Int, String] -> Maybe String
+          getString (Here _) = Nothing
+          getString (There (Here s)) = Just s
+
+      getInt (Here 42) `shouldBe` Just 42
+      getInt (There (Here "hi")) `shouldBe` Nothing
+      getString (There (Here "hi")) `shouldBe` Just "hi"
+      getString (Here 42) `shouldBe` Nothing
+
+  -- ════════════════════════════════════════════════════════════════════════════
+  -- TYPE SAFETY
+  -- ════════════════════════════════════════════════════════════════════════════
+  describe "Type safety" $ do
+
+    it "different types at same position are distinguished" $ do
+      -- Even though both are "first element", they have different types
+      let intList :: OneOf '[Int] = Here 42
+          strList :: OneOf '[String] = Here "hello"
+
+      case intList of { Here n -> n `shouldBe` 42 }
+      case strList of { Here s -> s `shouldBe` "hello" }
+
+    it "same value, different list positions" $ do
+      -- Int at position 0 vs position 1
+      let pos0 :: OneOf '[Int, String] = Here 42
+          pos1 :: OneOf '[String, Int] = There (Here 42)
+
+      case pos0 of { Here n -> n `shouldBe` 42; _ -> expectationFailure "wrong" }
+      case pos1 of { There (Here n) -> n `shouldBe` 42; _ -> expectationFailure "wrong" }

--- a/tidepool-core/test/Spec.hs
+++ b/tidepool-core/test/Spec.hs
@@ -5,6 +5,11 @@ import Test.Hspec
 import qualified GraphValidationSpec
 import qualified LLMNodeExecuteSpec
 import qualified MemorySerializationSpec
+import qualified OneOfSpec
+import qualified InjectTargetSpec
+import qualified GotoChoiceSpec
+import qualified CallHandlerSpec
+import qualified DispatchGotoSpec
 
 main :: IO ()
 main = hspec $ do
@@ -16,3 +21,18 @@ main = hspec $ do
 
   describe "Memory Serialization" $ do
     MemorySerializationSpec.spec
+
+  describe "OneOf GADT" $ do
+    OneOfSpec.spec
+
+  describe "InjectTarget" $ do
+    InjectTargetSpec.spec
+
+  describe "GotoChoice" $ do
+    GotoChoiceSpec.spec
+
+  describe "CallHandler" $ do
+    CallHandlerSpec.spec
+
+  describe "DispatchGoto" $ do
+    DispatchGotoSpec.spec

--- a/tidepool-core/tidepool-core.cabal
+++ b/tidepool-core/tidepool-core.cabal
@@ -93,6 +93,11 @@ test-suite graph-validation-tests
         GraphValidationSpec
         LLMNodeExecuteSpec
         MemorySerializationSpec
+        OneOfSpec
+        InjectTargetSpec
+        GotoChoiceSpec
+        CallHandlerSpec
+        DispatchGotoSpec
     build-depends:
         base >= 4.17 && < 5,
         hspec >= 2.10 && < 3,


### PR DESCRIPTION
## Summary

Adds comprehensive unit tests for the core v2 graph DSL types defined in `Goto.hs` and `Execute.hs`:

- **OneOfSpec.hs** - Tests OneOf GADT construction (`Here`/`There`) and pattern matching
- **InjectTargetSpec.hs** - Tests `InjectTarget` typeclass, particularly handling duplicate payload types (e.g., `To "a" Int` vs `To "b" Int`)
- **GotoChoiceSpec.hs** - Tests `gotoChoice`, `gotoExit`, `gotoSelf` smart constructors
- **CallHandlerSpec.hs** - Tests `CallHandler` typeclass for logic handler invocation
- **DispatchGotoSpec.hs** - Tests `DispatchGoto` for typed recursive dispatch through handlers

These validate the value-level behavior of the typed dispatch mechanism that routes `GotoChoice` values through graph handlers.

**Note**: Multi-hop `DispatchGoto` tests (handler → handler → Exit) are deferred pending investigation of `HasField` instance resolution for record types.

## Test plan

- [x] All 79 tests pass (`cabal test tidepool-core`)
- [x] Build passes with no errors
- [x] Only minor warnings (unused imports, name shadowing in unrelated files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)