### PR TITLE
Add Telegram effect types for Haskell and TypeScript

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -4,6 +4,7 @@ packages:
     tidepool-dm
     tidepool-tidying
     tidepool-wasm
+    tidepool-telegram-hs
 
 -- Use GHC 9.6+ for best GHC2021 support
 -- with-compiler: ghc-9.6

--- a/tidepool-telegram-hs/src/Tidepool/Telegram.hs
+++ b/tidepool-telegram-hs/src/Tidepool/Telegram.hs
@@ -1,0 +1,73 @@
+-- | Telegram effect for Tidepool agents
+--
+-- This module provides a typed DSL for Telegram bot interactions,
+-- designed for use with the Tidepool agent framework.
+--
+-- == Overview
+--
+-- The Telegram effect uses a Send/Receive model:
+--
+-- * 'tgSend' - Fire and forget message sending
+-- * 'tgReceive' - Block until messages arrive (returns 'NonEmpty')
+-- * 'tgTryReceive' - Non-blocking check (may return empty)
+--
+-- == Example
+--
+-- @
+-- import Tidepool.Telegram
+--
+-- greetUser :: Telegram :> es => Eff es Text
+-- greetUser = do
+--   responses <- askText "What's your name?"
+--   case firstText responses of
+--     Just name -> do
+--       tgSend (TextMsg $ "Hello, " <> name <> "!")
+--       pure name
+--     Nothing -> greetUser  -- ask again if they sent media instead
+-- @
+--
+-- == Design Notes
+--
+-- * __Thread-blind__: Each graph instance owns one conversation.
+--   The runtime routes messages to the correct instance.
+--
+-- * __Accumulating receive__: 'tgReceive' returns ALL pending messages,
+--   not just one. This handles the case where users send multiple
+--   messages before the bot responds.
+--
+-- * __Separate message types__: 'IncomingMessage' distinguishes text,
+--   photos, documents, and button clicks for clean pattern matching.
+module Tidepool.Telegram
+  ( -- * Effect
+    Telegram(..)
+
+    -- * Operations
+  , tgSend
+  , tgReceive
+  , tgTryReceive
+
+    -- * Combinators
+  , ask
+  , askText
+  , askButtons
+
+    -- * Extractors
+  , firstText
+  , firstClick
+  , firstMedia
+  , allTexts
+  , allClicks
+  , allMedia
+
+    -- * Types
+  , MediaHandle(..)
+  , InlineButton(..)
+  , OutgoingMessage(..)
+  , IncomingMessage(..)
+
+    -- * Stub Runner
+  , runTelegramStub
+  ) where
+
+import Tidepool.Telegram.Effect
+import Tidepool.Telegram.Types

--- a/tidepool-telegram-hs/src/Tidepool/Telegram/Effect.hs
+++ b/tidepool-telegram-hs/src/Tidepool/Telegram/Effect.hs
@@ -1,0 +1,151 @@
+-- | Telegram effect for conversational agents
+--
+-- This module provides a Send/Receive model for Telegram interactions:
+--
+-- * 'tgSend' - Fire and forget message sending
+-- * 'tgReceive' - Block until at least one message arrives
+-- * 'tgTryReceive' - Non-blocking check for pending messages
+--
+-- The 'ask' combinator combines send + receive for common request-response flows.
+module Tidepool.Telegram.Effect
+  ( -- * Effect
+    Telegram(..)
+
+    -- * Operations
+  , tgSend
+  , tgReceive
+  , tgTryReceive
+
+    -- * Combinators
+  , ask
+  , askText
+  , askButtons
+
+    -- * Extractors
+  , firstText
+  , firstClick
+  , firstMedia
+  , allTexts
+  , allClicks
+  , allMedia
+
+    -- * Stub Runner
+  , runTelegramStub
+  ) where
+
+import Data.Aeson (Value)
+import Data.List.NonEmpty (NonEmpty)
+import qualified Data.List.NonEmpty as NE
+import Data.Maybe (mapMaybe, listToMaybe)
+import Data.Text (Text)
+import Effectful
+import Effectful.Dispatch.Dynamic
+
+import Tidepool.Telegram.Types
+
+-- | The Telegram effect for conversational messaging.
+--
+-- Thread-blind: each graph instance "owns" one conversation thread.
+-- The runtime handles routing messages to the correct graph instance.
+data Telegram :: Effect where
+  -- | Send a message (fire and forget)
+  Send :: OutgoingMessage -> Telegram m ()
+
+  -- | Block until at least one message arrives, return all pending
+  Receive :: Telegram m (NonEmpty IncomingMessage)
+
+  -- | Non-blocking check for pending messages (may be empty)
+  TryReceive :: Telegram m [IncomingMessage]
+
+type instance DispatchOf Telegram = 'Dynamic
+
+-- ══════════════════════════════════════════════════════════════
+-- OPERATIONS
+-- ══════════════════════════════════════════════════════════════
+
+-- | Send an outgoing message (fire and forget).
+tgSend :: Telegram :> es => OutgoingMessage -> Eff es ()
+tgSend = send . Send
+
+-- | Block until at least one incoming message arrives.
+-- Returns all pending messages (guaranteed non-empty).
+tgReceive :: Telegram :> es => Eff es (NonEmpty IncomingMessage)
+tgReceive = send Receive
+
+-- | Non-blocking check for pending messages.
+-- Returns empty list if no messages are pending.
+tgTryReceive :: Telegram :> es => Eff es [IncomingMessage]
+tgTryReceive = send TryReceive
+
+-- ══════════════════════════════════════════════════════════════
+-- COMBINATORS
+-- ══════════════════════════════════════════════════════════════
+
+-- | Send a message and wait for response(s).
+--
+-- This is the common request-response pattern: send something,
+-- then block until the user replies.
+ask :: Telegram :> es => OutgoingMessage -> Eff es (NonEmpty IncomingMessage)
+ask msg = tgSend msg >> tgReceive
+
+-- | Send a text message and wait for response(s).
+askText :: Telegram :> es => Text -> Eff es (NonEmpty IncomingMessage)
+askText = ask . TextMsg
+
+-- | Send a message with buttons and wait for response(s).
+--
+-- Note: The user might reply with text instead of clicking a button.
+-- Use 'firstClick' to extract button responses.
+askButtons :: Telegram :> es => Text -> [[InlineButton]] -> Eff es (NonEmpty IncomingMessage)
+askButtons text buttons = ask (ButtonsMsg text buttons)
+
+-- ══════════════════════════════════════════════════════════════
+-- EXTRACTORS
+-- ══════════════════════════════════════════════════════════════
+
+-- | Extract the first text reply from messages.
+firstText :: NonEmpty IncomingMessage -> Maybe Text
+firstText = listToMaybe . allTexts
+
+-- | Extract the first button click from messages.
+firstClick :: NonEmpty IncomingMessage -> Maybe Value
+firstClick = listToMaybe . allClicks
+
+-- | Extract the first media handle from messages.
+firstMedia :: NonEmpty IncomingMessage -> Maybe MediaHandle
+firstMedia = listToMaybe . allMedia
+
+-- | Extract all text replies from messages.
+allTexts :: NonEmpty IncomingMessage -> [Text]
+allTexts = mapMaybe getText . NE.toList
+  where
+    getText (TextReply t) = Just t
+    getText _ = Nothing
+
+-- | Extract all button clicks from messages.
+allClicks :: NonEmpty IncomingMessage -> [Value]
+allClicks = mapMaybe getClick . NE.toList
+  where
+    getClick (ButtonClick v) = Just v
+    getClick _ = Nothing
+
+-- | Extract all media handles from messages.
+allMedia :: NonEmpty IncomingMessage -> [MediaHandle]
+allMedia = mapMaybe getMedia . NE.toList
+  where
+    getMedia (PhotoReply h _) = Just h
+    getMedia (DocReply h _) = Just h
+    getMedia _ = Nothing
+
+-- ══════════════════════════════════════════════════════════════
+-- STUB RUNNER
+-- ══════════════════════════════════════════════════════════════
+
+-- | Stub interpreter that errors on any operation.
+--
+-- Useful for testing graph structure without a real Telegram connection.
+runTelegramStub :: Eff (Telegram : es) a -> Eff es a
+runTelegramStub = interpret $ \_ -> \case
+  Send _msg -> error "Telegram.Send: stub - not implemented"
+  Receive -> error "Telegram.Receive: stub - not implemented"
+  TryReceive -> error "Telegram.TryReceive: stub - not implemented"

--- a/tidepool-telegram-hs/src/Tidepool/Telegram/Types.hs
+++ b/tidepool-telegram-hs/src/Tidepool/Telegram/Types.hs
@@ -1,0 +1,141 @@
+-- | Core types for the Telegram effect DSL
+--
+-- These types define the boundary between Haskell agent logic and
+-- the TypeScript Telegram integration runtime.
+--
+-- JSON encoding is designed to match TypeScript discriminated unions:
+-- @{"type": "text", "text": "..."}@ not @{"tag": "TextMsg", "contents": "..."}@
+module Tidepool.Telegram.Types
+  ( -- * Opaque Handles
+    MediaHandle(..)
+
+    -- * Button Types
+  , InlineButton(..)
+
+    -- * Messages
+  , OutgoingMessage(..)
+  , IncomingMessage(..)
+  ) where
+
+import Data.Aeson
+  ( FromJSON(..), ToJSON(..), Value, (.:), (.:?), (.=)
+  , object, withObject
+  )
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+-- | Opaque handle for media files.
+--
+-- The runtime interprets these handles - agent code just passes them around.
+-- Handles are obtained from incoming media and can be used to send media.
+newtype MediaHandle = MediaHandle Text
+  deriving stock (Show, Eq, Generic)
+  deriving newtype (FromJSON, ToJSON)
+
+-- | Inline keyboard button with callback data.
+--
+-- When pressed, the button's callback data is returned to the agent.
+-- Only callback buttons are supported (no URL/login buttons).
+--
+-- JSON: @{"text": "Click me", "data": {...}}@
+data InlineButton = InlineButton
+  { buttonText :: Text   -- ^ Display text on the button
+  , buttonData :: Value  -- ^ JSON payload returned on click
+  }
+  deriving stock (Show, Eq, Generic)
+
+instance ToJSON InlineButton where
+  toJSON b = object ["text" .= b.buttonText, "data" .= b.buttonData]
+
+instance FromJSON InlineButton where
+  parseJSON = withObject "InlineButton" $ \v ->
+    InlineButton <$> v .: "text" <*> v .: "data"
+
+-- | Outgoing messages that can be sent to the user.
+--
+-- JSON uses TypeScript-style discriminated unions with @type@ field.
+data OutgoingMessage
+  = TextMsg Text
+    -- ^ Plain text message
+  | PhotoMsg MediaHandle (Maybe Text)
+    -- ^ Photo with optional caption
+  | DocMsg MediaHandle Text
+    -- ^ Document with filename
+  | ButtonsMsg Text [[InlineButton]]
+    -- ^ Text message with inline keyboard (rows of buttons)
+  deriving stock (Show, Eq, Generic)
+
+instance ToJSON OutgoingMessage where
+  toJSON (TextMsg t) = object
+    [ "type" .= ("text" :: Text)
+    , "text" .= t
+    ]
+  toJSON (PhotoMsg h c) = object $
+    [ "type" .= ("photo" :: Text)
+    , "media" .= h
+    ] ++ maybe [] (\x -> ["caption" .= x]) c
+  toJSON (DocMsg h f) = object
+    [ "type" .= ("document" :: Text)
+    , "media" .= h
+    , "filename" .= f
+    ]
+  toJSON (ButtonsMsg t bs) = object
+    [ "type" .= ("buttons" :: Text)
+    , "text" .= t
+    , "buttons" .= bs
+    ]
+
+instance FromJSON OutgoingMessage where
+  parseJSON = withObject "OutgoingMessage" $ \v -> do
+    typ <- v .: "type"
+    case (typ :: Text) of
+      "text" -> TextMsg <$> v .: "text"
+      "photo" -> PhotoMsg <$> v .: "media" <*> v .:? "caption"
+      "document" -> DocMsg <$> v .: "media" <*> v .: "filename"
+      "buttons" -> ButtonsMsg <$> v .: "text" <*> v .: "buttons"
+      _ -> fail $ "Unknown OutgoingMessage type: " ++ show typ
+
+-- | Incoming messages received from the user.
+--
+-- Each variant is distinct to allow pattern matching on the type of response.
+--
+-- JSON uses TypeScript-style discriminated unions with @type@ field.
+data IncomingMessage
+  = TextReply Text
+    -- ^ Plain text from user
+  | PhotoReply MediaHandle (Maybe Text)
+    -- ^ Photo with optional caption
+  | DocReply MediaHandle Text
+    -- ^ Document with filename
+  | ButtonClick Value
+    -- ^ Inline button callback data
+  deriving stock (Show, Eq, Generic)
+
+instance ToJSON IncomingMessage where
+  toJSON (TextReply t) = object
+    [ "type" .= ("text" :: Text)
+    , "text" .= t
+    ]
+  toJSON (PhotoReply h c) = object $
+    [ "type" .= ("photo" :: Text)
+    , "media" .= h
+    ] ++ maybe [] (\x -> ["caption" .= x]) c
+  toJSON (DocReply h f) = object
+    [ "type" .= ("document" :: Text)
+    , "media" .= h
+    , "filename" .= f
+    ]
+  toJSON (ButtonClick d) = object
+    [ "type" .= ("button_click" :: Text)
+    , "data" .= d
+    ]
+
+instance FromJSON IncomingMessage where
+  parseJSON = withObject "IncomingMessage" $ \v -> do
+    typ <- v .: "type"
+    case (typ :: Text) of
+      "text" -> TextReply <$> v .: "text"
+      "photo" -> PhotoReply <$> v .: "media" <*> v .:? "caption"
+      "document" -> DocReply <$> v .: "media" <*> v .: "filename"
+      "button_click" -> ButtonClick <$> v .: "data"
+      _ -> fail $ "Unknown IncomingMessage type: " ++ show typ

--- a/tidepool-telegram-hs/tidepool-telegram-hs.cabal
+++ b/tidepool-telegram-hs/tidepool-telegram-hs.cabal
@@ -1,0 +1,38 @@
+cabal-version:      3.0
+name:               tidepool-telegram-hs
+version:            0.1.0.0
+synopsis:           Telegram effect types for Tidepool agents
+license:            MIT
+author:             Inanna
+build-type:         Simple
+
+common warnings
+    ghc-options: -Wall -Wno-missing-export-lists -Wincomplete-patterns
+
+library
+    import:           warnings
+    exposed-modules:
+        Tidepool.Telegram
+        Tidepool.Telegram.Types
+        Tidepool.Telegram.Effect
+    build-depends:
+        base >= 4.17 && < 5,
+        effectful-core >= 2.3 && < 3,
+        text >= 2.0 && < 3,
+        aeson >= 2.1 && < 3
+    hs-source-dirs:   src
+    default-language: GHC2021
+    default-extensions:
+        DataKinds
+        DeriveAnyClass
+        DeriveGeneric
+        DerivingStrategies
+        DerivingVia
+        DuplicateRecordFields
+        GADTs
+        LambdaCase
+        NoFieldSelectors
+        OverloadedRecordDot
+        OverloadedStrings
+        TypeFamilies
+        TypeOperators

--- a/tidepool-telegram-ts/.gitignore
+++ b/tidepool-telegram-ts/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/tidepool-telegram-ts/package.json
+++ b/tidepool-telegram-ts/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "tidepool-telegram",
+  "version": "0.1.0",
+  "description": "Telegram effect types for Tidepool agents",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.2"
+  }
+}

--- a/tidepool-telegram-ts/pnpm-lock.yaml
+++ b/tidepool-telegram-ts/pnpm-lock.yaml
@@ -1,0 +1,24 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+
+packages:
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+snapshots:
+
+  typescript@5.9.3: {}

--- a/tidepool-telegram-ts/src/effects.ts
+++ b/tidepool-telegram-ts/src/effects.ts
@@ -1,0 +1,117 @@
+/**
+ * Telegram effect types for WASM ↔ TypeScript communication.
+ *
+ * These types define the serialized effects that flow between
+ * Haskell agent code (compiled to WASM) and the TypeScript runtime.
+ *
+ * Protocol:
+ * 1. WASM yields a TelegramEffect
+ * 2. TypeScript executes the effect (calls Telegram API)
+ * 3. TypeScript returns a TelegramEffectResult
+ * 4. WASM continues execution
+ */
+
+import type { OutgoingMessage, IncomingMessage } from './types.js';
+
+// ══════════════════════════════════════════════════════════════
+// EFFECTS (Haskell → TypeScript)
+// ══════════════════════════════════════════════════════════════
+
+/**
+ * Telegram effects yielded by the agent.
+ */
+export type TelegramEffect =
+  | SendEffect
+  | ReceiveEffect
+  | TryReceiveEffect;
+
+/**
+ * Send a message (fire and forget).
+ *
+ * Mirrors Haskell: Send :: OutgoingMessage -> Telegram m ()
+ */
+export interface SendEffect {
+  type: 'telegram_send';
+  message: OutgoingMessage;
+}
+
+/**
+ * Block until at least one message arrives.
+ *
+ * The runtime should block until there's at least one message,
+ * then return all pending messages.
+ *
+ * Mirrors Haskell: Receive :: Telegram m (NonEmpty IncomingMessage)
+ */
+export interface ReceiveEffect {
+  type: 'telegram_receive';
+}
+
+/**
+ * Non-blocking check for pending messages.
+ *
+ * Returns immediately with any pending messages (may be empty).
+ *
+ * Mirrors Haskell: TryReceive :: Telegram m [IncomingMessage]
+ */
+export interface TryReceiveEffect {
+  type: 'telegram_try_receive';
+}
+
+// ══════════════════════════════════════════════════════════════
+// RESULTS (TypeScript → Haskell)
+// ══════════════════════════════════════════════════════════════
+
+/**
+ * Results returned to the agent after effect execution.
+ */
+export type TelegramEffectResult =
+  | UnitResult
+  | MessagesResult;
+
+/**
+ * Unit result (for Send).
+ */
+export interface UnitResult {
+  type: 'unit';
+}
+
+/**
+ * Messages result (for Receive and TryReceive).
+ *
+ * For Receive: guaranteed to have at least one message.
+ * For TryReceive: may be empty.
+ */
+export interface MessagesResult {
+  type: 'messages';
+  messages: IncomingMessage[];
+}
+
+// ══════════════════════════════════════════════════════════════
+// HELPERS
+// ══════════════════════════════════════════════════════════════
+
+/** Create a unit result. */
+export function unitResult(): UnitResult {
+  return { type: 'unit' };
+}
+
+/** Create a messages result. */
+export function messagesResult(messages: IncomingMessage[]): MessagesResult {
+  return { type: 'messages', messages };
+}
+
+/** Type guard for SendEffect. */
+export function isSendEffect(effect: TelegramEffect): effect is SendEffect {
+  return effect.type === 'telegram_send';
+}
+
+/** Type guard for ReceiveEffect. */
+export function isReceiveEffect(effect: TelegramEffect): effect is ReceiveEffect {
+  return effect.type === 'telegram_receive';
+}
+
+/** Type guard for TryReceiveEffect. */
+export function isTryReceiveEffect(effect: TelegramEffect): effect is TryReceiveEffect {
+  return effect.type === 'telegram_try_receive';
+}

--- a/tidepool-telegram-ts/src/index.ts
+++ b/tidepool-telegram-ts/src/index.ts
@@ -1,0 +1,78 @@
+/**
+ * Telegram effect types for Tidepool agents.
+ *
+ * This package provides TypeScript types that mirror the Haskell
+ * Telegram effect DSL, enabling type-safe communication between
+ * agent logic (compiled to WASM) and the TypeScript runtime.
+ *
+ * @example
+ * ```typescript
+ * import {
+ *   TelegramEffect,
+ *   TelegramEffectResult,
+ *   isSendEffect,
+ *   isReceiveEffect,
+ *   unitResult,
+ *   messagesResult,
+ *   firstText
+ * } from 'tidepool-telegram';
+ *
+ * async function handleEffect(effect: TelegramEffect): Promise<TelegramEffectResult> {
+ *   if (isSendEffect(effect)) {
+ *     await sendToTelegram(effect.message);
+ *     return unitResult();
+ *   }
+ *   if (isReceiveEffect(effect)) {
+ *     const messages = await waitForMessages();
+ *     return messagesResult(messages);
+ *   }
+ *   // ... etc
+ * }
+ * ```
+ *
+ * @packageDocumentation
+ */
+
+// Types
+export type {
+  MediaHandle,
+  InlineButton,
+  OutgoingMessage,
+  IncomingMessage,
+} from './types.js';
+
+export {
+  // Type guards
+  isTextReply,
+  isPhotoReply,
+  isDocReply,
+  isButtonClick,
+  // Extractors
+  firstText,
+  firstClick,
+  firstMedia,
+  allTexts,
+  allClicks,
+  allMedia,
+} from './types.js';
+
+// Effects
+export type {
+  TelegramEffect,
+  SendEffect,
+  ReceiveEffect,
+  TryReceiveEffect,
+  TelegramEffectResult,
+  UnitResult,
+  MessagesResult,
+} from './effects.js';
+
+export {
+  // Result constructors
+  unitResult,
+  messagesResult,
+  // Type guards
+  isSendEffect,
+  isReceiveEffect,
+  isTryReceiveEffect,
+} from './effects.js';

--- a/tidepool-telegram-ts/src/types.ts
+++ b/tidepool-telegram-ts/src/types.ts
@@ -1,0 +1,118 @@
+/**
+ * Core types for the Telegram effect DSL.
+ *
+ * These types mirror the Haskell types in Tidepool.Telegram.Types
+ * and define the boundary between agent logic and the Telegram runtime.
+ */
+
+/**
+ * Opaque handle for media files.
+ *
+ * The runtime interprets these handles - agent code just passes them around.
+ * Handles are obtained from incoming media and can be used to send media.
+ */
+export type MediaHandle = string;
+
+/**
+ * Inline keyboard button with callback data.
+ *
+ * When pressed, the button's callback data is returned to the agent.
+ * Only callback buttons are supported (no URL/login buttons).
+ */
+export interface InlineButton {
+  /** Display text on the button */
+  text: string;
+  /** JSON payload returned on click */
+  data: unknown;
+}
+
+/**
+ * Outgoing messages that can be sent to the user.
+ *
+ * Mirrors Haskell: OutgoingMessage
+ */
+export type OutgoingMessage =
+  | { type: 'text'; text: string }
+  | { type: 'photo'; media: MediaHandle; caption?: string }
+  | { type: 'document'; media: MediaHandle; filename: string }
+  | { type: 'buttons'; text: string; buttons: InlineButton[][] };
+
+/**
+ * Incoming messages received from the user.
+ *
+ * Each variant is distinct to allow pattern matching on the type of response.
+ *
+ * Mirrors Haskell: IncomingMessage
+ */
+export type IncomingMessage =
+  | { type: 'text'; text: string }
+  | { type: 'photo'; media: MediaHandle; caption?: string }
+  | { type: 'document'; media: MediaHandle; filename: string }
+  | { type: 'button_click'; data: unknown };
+
+// ══════════════════════════════════════════════════════════════
+// TYPE GUARDS
+// ══════════════════════════════════════════════════════════════
+
+export function isTextReply(msg: IncomingMessage): msg is { type: 'text'; text: string } {
+  return msg.type === 'text';
+}
+
+export function isPhotoReply(msg: IncomingMessage): msg is { type: 'photo'; media: MediaHandle; caption?: string } {
+  return msg.type === 'photo';
+}
+
+export function isDocReply(msg: IncomingMessage): msg is { type: 'document'; media: MediaHandle; filename: string } {
+  return msg.type === 'document';
+}
+
+export function isButtonClick(msg: IncomingMessage): msg is { type: 'button_click'; data: unknown } {
+  return msg.type === 'button_click';
+}
+
+// ══════════════════════════════════════════════════════════════
+// EXTRACTORS
+// ══════════════════════════════════════════════════════════════
+
+/** Extract the first text reply from messages. */
+export function firstText(messages: IncomingMessage[]): string | undefined {
+  const textMsg = messages.find(isTextReply);
+  return textMsg?.text;
+}
+
+/** Extract the first button click from messages. */
+export function firstClick(messages: IncomingMessage[]): unknown | undefined {
+  const clickMsg = messages.find(isButtonClick);
+  return clickMsg?.data;
+}
+
+/** Extract the first media handle from messages. */
+export function firstMedia(messages: IncomingMessage[]): MediaHandle | undefined {
+  for (const msg of messages) {
+    if (msg.type === 'photo' || msg.type === 'document') {
+      return msg.media;
+    }
+  }
+  return undefined;
+}
+
+/** Extract all text replies from messages. */
+export function allTexts(messages: IncomingMessage[]): string[] {
+  return messages.filter(isTextReply).map(m => m.text);
+}
+
+/** Extract all button clicks from messages. */
+export function allClicks(messages: IncomingMessage[]): unknown[] {
+  return messages.filter(isButtonClick).map(m => m.data);
+}
+
+/** Extract all media handles from messages. */
+export function allMedia(messages: IncomingMessage[]): MediaHandle[] {
+  const result: MediaHandle[] = [];
+  for (const msg of messages) {
+    if (msg.type === 'photo' || msg.type === 'document') {
+      result.push(msg.media);
+    }
+  }
+  return result;
+}

--- a/tidepool-telegram-ts/tsconfig.json
+++ b/tidepool-telegram-ts/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

- Adds `tidepool-telegram-hs` Haskell package with Telegram effect DSL
- Adds `tidepool-telegram-ts` TypeScript package with matching types
- Implements Send/Receive model for conversational bot interactions

### Haskell Effect

```haskell
data Telegram :: Effect where
  Send :: OutgoingMessage -> Telegram m ()
  Receive :: Telegram m (NonEmpty IncomingMessage)  -- blocks until ≥1
  TryReceive :: Telegram m [IncomingMessage]        -- non-blocking
```

### Design Decisions

- **Thread-blind**: Each graph instance owns one conversation
- **Accumulating receive**: Returns all pending messages (handles user sending multiple before bot responds)
- **Separate message types**: Text, Photo, Document, ButtonClick as distinct constructors
- **Custom JSON instances**: Produces TypeScript-compatible discriminated unions

### Coordination

This defines the DSL/types layer. A parallel `telegram-integration` workstream will port the TypeScript implementation from shoal to consume these types.

## Test plan

- [x] `cabal build tidepool-telegram-hs` passes
- [x] `pnpm typecheck` passes in tidepool-telegram-ts
- [x] Full `cabal build all` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)