### PR TITLE
Add /habitica-status endpoint for auth testing

### DIFF
--- a/deploy/.dev.vars.example
+++ b/deploy/.dev.vars.example
@@ -1,0 +1,11 @@
+# Local development secrets (copy to .dev.vars and fill in values)
+# For production, use: wrangler secret put <SECRET_NAME>
+
+# Telegram Bot API
+TELEGRAM_TOKEN=your-bot-token-from-botfather
+TELEGRAM_WEBHOOK_SECRET=random-secret-for-webhook-verification
+ALLOWED_TELEGRAM_USERS=123456789,987654321
+
+# Habitica API (get from https://habitica.com/user/settings/api)
+HABITICA_USER_ID=your-habitica-user-id
+HABITICA_API_TOKEN=your-habitica-api-token

--- a/deploy/.gitignore
+++ b/deploy/.gitignore
@@ -1,0 +1,1 @@
+.dev.vars


### PR DESCRIPTION
## Summary

- Adds `/habitica-status` endpoint to verify Habitica API credentials
- Returns user HP/MP/EXP/GP on success
- Provides helpful error messages if secrets aren't configured
- Adds `.dev.vars.example` documenting all required secrets (Telegram + Habitica)

## Usage

```bash
# Set secrets
wrangler secret put HABITICA_USER_ID
wrangler secret put HABITICA_API_TOKEN

# Test
curl https://tidepool.YOUR-SUBDOMAIN.workers.dev/habitica-status
```

## Test plan

- [ ] Deploy to Cloudflare Workers
- [ ] Verify endpoint returns error before secrets are set
- [ ] Set Habitica secrets via wrangler
- [ ] Verify endpoint returns HP/MP/EXP/GP

🤖 Generated with [Claude Code](https://claude.com/claude-code)