### PR TITLE
Enhance Copilot configuration for better reviews and coding agent

### DIFF
--- a/.github/copilot-review-instructions.md
+++ b/.github/copilot-review-instructions.md
@@ -1,0 +1,50 @@
+# Copilot Code Review Instructions
+
+## Language-Specific Guidance
+
+### Haskell (tidepool-core/, tidepool-dm/, tidepool-tidying/)
+
+**Effect System (effectful)**
+- Effect constraints should be ordered correctly - effects are interpreted outermost-first
+- Agent code must NOT use `IOE` directly (IO-blind architecture)
+- Check that `DispatchOf` is set to `'Dynamic` for new effects
+- Effect handlers should be in runner code, not agent code
+
+**Tool Definitions**
+- Every `Tool` instance needs `deriveJSONSchema` for the input type
+- Tool execution should only use effects available in `ToolEffects`
+- Look for missing `Proxy @` in `ToolList` definitions
+
+**Delta Fields**
+- Mutation types should use deltas (`+2`), not absolute values
+- Every delta type needs a `because :: Text` field for explainability
+- Check `applyTurnOutput` correctly handles all delta fields
+
+**Templates**
+- `typedTemplateFile` requires the context type to match template variables
+- Template includes should exist in the templates/ directory
+- Jinja syntax should be valid (LLMs know Jinja well)
+
+**Common Mistakes**
+- Using `unsafeCoerce` or `Dynamic` (should use `OneOf` pattern instead)
+- Missing `INLINE` pragmas (not needed with effectful, flag if present)
+- Partial functions (`head`, `tail`, `!!`) without guards
+
+### TypeScript (deploy/)
+
+- Protocol types must match Haskell `Serializable.hs` exactly
+- WASM loader uses GHC-specific JSFFI - don't modify without care
+- Durable Object state must be serializable
+
+## Review Focus
+
+1. **Type Safety** - This codebase prioritizes compile-time guarantees
+2. **Effect Ordering** - Wrong order causes runtime issues
+3. **Schema Derivation** - LLM tools need valid JSON schemas
+4. **IO-Blindness** - Agents must not escape their effect sandbox
+
+## Less Important
+
+- Style/formatting (hlint handles this)
+- Documentation coverage (intentionally minimal)
+- Test coverage suggestions (tests are for critical paths only)

--- a/.github/instructions/haskell.instructions.md
+++ b/.github/instructions/haskell.instructions.md
@@ -1,0 +1,48 @@
+---
+applyTo: "**/*.hs"
+---
+
+# Haskell Review Instructions
+
+This is an effectful-based codebase with specific patterns. Focus on:
+
+## Critical Issues
+
+**Effect System**
+- Effect constraints must be ordered correctly (outermost runs first)
+- Agent code must NOT use `IOE` - this is IO-blind architecture
+- New effects need `type instance DispatchOf MyEffect = 'Dynamic`
+- Effect handlers belong in runner code, not agent code
+
+**Type Safety**
+- No `unsafeCoerce` or `Dynamic` - use `OneOf` pattern instead
+- No partial functions (`head`, `tail`, `!!`) without guards
+- Tool input types need `deriveJSONSchema`
+
+**Delta Pattern**
+- Mutations use deltas (`stressDelta = +2`), not absolute values
+- Every delta type must have `because :: Text` field
+
+## Less Important
+
+- INLINE pragmas (effectful doesn't need them)
+- Missing documentation (intentionally minimal)
+- Stylistic issues (hlint handles this)
+
+## Common Patterns
+
+```haskell
+-- Effect definition pattern
+data MyEffect :: Effect where
+  DoThing :: Arg -> MyEffect m Result
+
+type instance DispatchOf MyEffect = 'Dynamic
+
+-- Constraint pattern
+myFunction
+  :: (State s :> es, Emit e :> es)
+  => Eff es ()
+
+-- Tool list pattern
+type MyTools = TCons (Proxy @Tool1) $ TCons (Proxy @Tool2) $ TNil
+```

--- a/.github/instructions/templates.instructions.md
+++ b/.github/instructions/templates.instructions.md
@@ -1,0 +1,40 @@
+---
+applyTo: "**/templates/**/*.jinja"
+---
+
+# Jinja Template Review Instructions
+
+These are typed Jinja templates validated at compile-time against Haskell context types.
+
+## Critical Issues
+
+**Variable Names**
+- Template variables must match fields in the corresponding Haskell context type
+- `dm_turn.jinja` uses `DMContext`, `compression.jinja` uses `CompressionContext`, etc.
+- Typos in variable names cause compile-time errors
+
+**Include/Extends Paths**
+- Included templates must exist
+- Paths are relative to templates directory
+
+**Schema Blocks**
+- `{% schema %}` blocks define JSON schema for LLM structured output
+- Must be valid JSON Schema
+- Field names must match Haskell output types
+
+## Jinja Patterns Used
+
+```jinja
+{# Context access #}
+{{ player.stress }}
+{{ clocks | length }}
+
+{# Conditionals #}
+{% if precarity == "HangingByThread" %}
+
+{# Loops #}
+{% for clock in clocks %}
+
+{# Includes #}
+{% include "partials/npc_list.jinja" %}
+```

--- a/.github/instructions/typescript.instructions.md
+++ b/.github/instructions/typescript.instructions.md
@@ -1,0 +1,36 @@
+---
+applyTo: "deploy/**/*.ts"
+---
+
+# TypeScript Review Instructions (Cloudflare Worker)
+
+This is a Cloudflare Worker Durable Object harness for WASM state machines.
+
+## Critical Issues
+
+**Protocol Conformance**
+- Types in `protocol.ts` must exactly match Haskell `Serializable.hs`
+- Any protocol change requires updating both sides
+- WebSocket message types are the contract between client and WASM
+
+**Durable Object Constraints**
+- State must be JSON-serializable
+- Don't hold references across await points
+- Use `blockConcurrencyWhile` for initialization
+
+**WASM/JSFFI**
+- `loader.ts` and `jsffi.ts` implement GHC WASM runtime
+- These are delicate - don't modify without understanding GHC WASM internals
+- WASI polyfills are minimal, only what's needed
+
+## Less Important
+
+- General TypeScript style (ESLint handles this)
+- Test coverage (critical paths only)
+
+## Key Files
+
+- `src/index.ts` - Durable Object, WebSocket handling, effect loop
+- `src/protocol.ts` - Must match Haskell types exactly
+- `src/loader.ts` - GHC WASM loader (careful!)
+- `src/jsffi.ts` - JavaScript FFI for GHC WASM (careful!)

--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -1,4 +1,4 @@
-name: Request Copilot Review
+name: Copilot Review
 
 on:
   pull_request:
@@ -7,6 +7,10 @@ on:
 jobs:
   request-review:
     runs-on: ubuntu-latest
+    # Don't review draft PRs or dependabot
+    if: |
+      github.event.pull_request.draft == false &&
+      github.actor != 'dependabot[bot]'
     permissions:
       pull-requests: write
     steps:
@@ -14,15 +18,25 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const pr = context.payload.pull_request;
+
+            // Log what we're reviewing
+            console.log(`Requesting Copilot review for PR #${pr.number}: ${pr.title}`);
+            console.log(`Changed files: ${pr.changed_files}, Additions: ${pr.additions}, Deletions: ${pr.deletions}`);
+
             try {
               await github.rest.pulls.requestReviewers({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                pull_number: context.payload.pull_request.number,
+                pull_number: pr.number,
                 reviewers: ['copilot']
               });
-              console.log('Copilot review requested');
+              console.log('Copilot review requested successfully');
             } catch (error) {
-              console.log('Could not request Copilot review:', error.message);
-              // Don't fail the workflow if Copilot isn't available
+              // Copilot might already be requested, or not available
+              if (error.status === 422) {
+                console.log('Copilot review already requested or not available');
+              } else {
+                console.log('Could not request Copilot review:', error.message);
+              }
             }

--- a/copilot-setup-steps.yaml
+++ b/copilot-setup-steps.yaml
@@ -1,0 +1,43 @@
+# Copilot Coding Agent Environment Setup
+# This gives the coding agent access to build tools
+
+setup:
+  - name: Setup Haskell
+    uses: haskell-actions/setup@v2
+    with:
+      ghc-version: '9.6'
+      cabal-version: '3.10'
+
+  - name: Setup just
+    uses: extractions/setup-just@v2
+
+  - name: Install hlint
+    run: |
+      curl -sSL https://github.com/ndmitchell/hlint/releases/download/v3.8/hlint-3.8-x86_64-linux.tar.gz | tar xz
+      sudo mv hlint-3.8/hlint /usr/local/bin/
+
+  - name: Cache cabal store
+    uses: actions/cache@v4
+    with:
+      path: ~/.cabal/store
+      key: cabal-${{ hashFiles('**/*.cabal', 'cabal.project') }}
+
+  - name: Update cabal and build
+    run: |
+      cabal update
+      cabal build all
+
+  - name: Setup pnpm (for deploy/)
+    uses: pnpm/action-setup@v4
+    with:
+      version: 9
+
+  - name: Setup Node
+    uses: actions/setup-node@v4
+    with:
+      node-version: '20'
+
+  - name: Install TypeScript dependencies
+    run: |
+      cd deploy
+      pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary

- Add path-specific review instructions for Haskell (`*.hs`), TypeScript (`deploy/**/*.ts`), and Jinja templates
- Add `copilot-review-instructions.md` with domain-specific review focus (effectful patterns, IO-blindness, delta fields)
- Add `copilot-setup-steps.yaml` so coding agent has access to GHC 9.6, cabal, hlint, just, and pnpm
- Improve `copilot-review.yml` workflow: skip draft PRs and dependabot, better logging

## Files Added

| File | Purpose |
|------|---------|
| `.github/instructions/haskell.instructions.md` | Effect system, IO-blindness, delta patterns |
| `.github/instructions/typescript.instructions.md` | Protocol conformance, Durable Object constraints |
| `.github/instructions/templates.instructions.md` | Typed Jinja template rules |
| `.github/copilot-review-instructions.md` | General review guidance |
| `copilot-setup-steps.yaml` | Coding agent build environment |

## Test plan

- [ ] Open a PR with Haskell changes, verify Copilot review uses haskell.instructions.md guidance
- [ ] Try Copilot coding agent, verify it can run `cabal build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)