### PR TITLE
Remove heavy GUI/HTTP packages from build

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,11 +1,14 @@
 packages:
     tidepool-core
-    tidepool-platform
-    tidepool-dm
-    tidepool-tidying
     tidepool-wasm
-    tidepool-telegram-hs
     tidepool-generated-ts
+
+-- Disabled packages (heavy deps, not needed for WASM deployment):
+-- tidepool-platform   -- threepenny-gui, http-client, sqlite
+-- tidepool-dm         -- GUI app, depends on platform
+-- tidepool-tidying    -- GUI app, depends on platform
+-- template            -- unused template skeleton
+-- tidepool-telegram-hs -- types only, not used by tidepool-wasm
 
 -- Use GHC 9.6+ for best GHC2021 support
 -- with-compiler: ghc-9.6

--- a/justfile
+++ b/justfile
@@ -51,7 +51,7 @@ test-protocol-conformance:
 # Run hlint on Haskell sources (errors only, not suggestions)
 lint-hs:
     @echo "── Running hlint ──"
-    hlint tidepool-core tidepool-dm tidepool-tidying tidepool-platform tidepool-wasm --ignore-suggestions
+    hlint tidepool-core tidepool-wasm --ignore-suggestions
 
 # Run ESLint on TypeScript sources
 lint-ts:
@@ -101,20 +101,10 @@ test-roundtrip:
     cd deploy && pnpm test -- --grep "roundtrip"
 
 # ─────────────────────────────────────────────────────────────
-# Running
+# Running (disabled - GUI packages removed from build)
 # ─────────────────────────────────────────────────────────────
 
-# Run DM CLI
-dm:
-    cabal run tidepool-dm
-
-# Run DM GUI
-dm-gui:
-    cabal run tidepool-dm-gui
-
-# Run Tidying GUI
-tidy-gui:
-    cabal run tidepool-tidy-gui
+# NOTE: dm, dm-gui, tidy-gui disabled - see cabal.project for details
 
 # ─────────────────────────────────────────────────────────────
 # Git hooks


### PR DESCRIPTION
## Summary

Drastically reduce CI build times by trimming cabal.project to only packages needed for WASM deployment:

**Kept:**
- tidepool-core (graph DSL)
- tidepool-wasm (FFI exports)
- tidepool-generated-ts (TypeScript codegen)

**Removed from build** (still in repo for reference):
- tidepool-platform (threepenny-gui, http-client, sqlite)
- tidepool-dm (GUI app)
- tidepool-tidying (GUI app)
- tidepool-telegram-hs (unused types)
- template (unused skeleton)

The heavy deps like threepenny-gui, sqlite-simple, and http-client were absolutely killing build times. None of them are used for WASM deployment.

## Test plan

- [x] `cabal build all` succeeds
- [x] `cabal test all` passes (299 tests)
- [x] `just lint-hs` passes
- [x] TypeScript tests pass
- [ ] CI build should be significantly faster

🤖 Generated with [Claude Code](https://claude.com/claude-code)