### PR TITLE
Fix CI cabal cache path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
       - name: Cache cabal store
         uses: actions/cache@v4
         with:
-          # Use absolute path - in Docker container HOME may differ from cabal's default
-          path: /root/.cabal/store
+          # In container, HOME=/github/home, so cabal store is there
+          path: ~/.cabal/store
           key: ${{ runner.os }}-ghc9.6-cabal-${{ hashFiles('**/*.cabal', 'cabal.project') }}
           restore-keys: |
             ${{ runner.os }}-ghc9.6-cabal-


### PR DESCRIPTION
## Summary

Fix the cabal store cache path in CI - was pointing to wrong location.

**The bug:**
- Container sets `HOME=/github/home`
- Cabal stores packages at `$HOME/.cabal/store` → `/github/home/.cabal/store`
- Cache was configured for `/root/.cabal/store` → doesn't exist

**Evidence from CI logs:**
```
Cache not found for input keys: Linux-ghc9.6-cabal-...
[warning] Path(s) specified do not exist, no cache saved
```

Result: All 70 dependencies rebuilt from scratch every CI run (~6 min wasted).

## Fix

Change cache path from `/root/.cabal/store` to `~/.cabal/store`

## Expected impact

- First run: Still rebuilds (populates cache)
- Subsequent runs: ~6 min faster (deps cached)

🤖 Generated with [Claude Code](https://claude.com/claude-code)