### PR TITLE
Add typed Telegram GADT effect

### DIFF
--- a/tidepool-core/src/Tidepool/Effect/Metadata.hs
+++ b/tidepool-core/src/Tidepool/Effect/Metadata.hs
@@ -95,7 +95,8 @@ allEffectMeta =
   , EffectMeta "LogError"        Internal FireAndForget
   , EffectMeta "LlmComplete"     Internal Blocking
   , EffectMeta "Habitica"        Internal Blocking
-  , EffectMeta "TelegramConfirm" Yielded  Blocking
+  , EffectMeta "TelegramSend"    Yielded  FireAndForget
+  , EffectMeta "TelegramAsk"     Yielded  Blocking
   ]
 
 

--- a/tidepool-core/src/Tidepool/Effects/Telegram.hs
+++ b/tidepool-core/src/Tidepool/Effects/Telegram.hs
@@ -1,0 +1,120 @@
+-- | Telegram messaging effect with type-safe buttons and responses
+module Tidepool.Effects.Telegram
+  ( -- * Effect
+    Telegram(..)
+  , telegramSend
+  , telegramMarkdown
+  , telegramHtml
+  , telegramAsk
+
+    -- * Types
+  , MessageId(..)
+  , CallbackData(..)
+  , ParseMode(..)
+  , TelegramMessage(..)
+  , TelegramButton(..)
+
+    -- * Helpers
+  , parseModeText
+
+    -- * Runner (stub)
+  , runTelegramStub
+  ) where
+
+import Data.Text (Text)
+import Data.Aeson (FromJSON, ToJSON)
+import Data.String (IsString)
+import GHC.Generics (Generic)
+import Effectful
+import Effectful.Dispatch.Dynamic
+
+import Tidepool.Effect (Log, logInfo)
+
+-- Types
+
+-- | Message ID returned by Telegram API, useful for editing/deleting
+newtype MessageId = MessageId { unMessageId :: Int }
+  deriving (Show, Eq, Generic)
+  deriving newtype (FromJSON, ToJSON)
+
+-- | Callback data from button press
+newtype CallbackData = CallbackData { unCallbackData :: Text }
+  deriving (Show, Eq, Generic)
+  deriving newtype (FromJSON, ToJSON, IsString)
+
+-- | Parse mode for message formatting
+data ParseMode = PlainText | Markdown | HTML
+  deriving (Show, Eq, Generic)
+  deriving anyclass (FromJSON, ToJSON)
+
+-- | Structured message with text and formatting
+data TelegramMessage = TelegramMessage
+  { tmText :: Text
+  , tmParseMode :: ParseMode
+  }
+  deriving (Show, Eq, Generic, FromJSON, ToJSON)
+
+-- | Button definition for inline keyboards
+data TelegramButton = TelegramButton
+  { tbLabel :: Text           -- ^ What user sees
+  , tbCallback :: CallbackData  -- ^ What we receive on click
+  }
+  deriving (Show, Eq, Generic, FromJSON, ToJSON)
+
+-- Effect
+
+-- | Telegram messaging effect
+data Telegram :: Effect where
+  -- | Send a message, returns message ID for potential editing
+  TelegramSendOp :: TelegramMessage -> Telegram m MessageId
+
+  -- | Send message with inline keyboard, blocks until user clicks a button
+  TelegramAskOp :: TelegramMessage -> [TelegramButton] -> Telegram m CallbackData
+
+type instance DispatchOf Telegram = 'Dynamic
+
+-- | Send plain text message
+telegramSend :: Telegram :> es => Text -> Eff es MessageId
+telegramSend txt = send $ TelegramSendOp (TelegramMessage txt PlainText)
+
+-- | Send Markdown-formatted message
+telegramMarkdown :: Telegram :> es => Text -> Eff es MessageId
+telegramMarkdown txt = send $ TelegramSendOp (TelegramMessage txt Markdown)
+
+-- | Send HTML-formatted message
+telegramHtml :: Telegram :> es => Text -> Eff es MessageId
+telegramHtml txt = send $ TelegramSendOp (TelegramMessage txt HTML)
+
+-- | Ask with custom buttons, returns the callback data as Text
+telegramAsk :: Telegram :> es
+            => Text
+            -> [(Text, Text)]  -- ^ [(label, callback)]
+            -> Eff es Text
+telegramAsk msg buttons = do
+  CallbackData cb <- send $ TelegramAskOp
+    (TelegramMessage msg Markdown)
+    [TelegramButton lbl (CallbackData cb') | (lbl, cb') <- buttons]
+  pure cb
+
+
+-- Helpers
+
+-- | Convert ParseMode to text for serialization
+parseModeText :: ParseMode -> Text
+parseModeText PlainText = "PlainText"
+parseModeText Markdown = "Markdown"
+parseModeText HTML = "HTML"
+
+-- Stub runner (errors on call)
+
+runTelegramStub :: (IOE :> es, Log :> es) => Eff (Telegram : es) a -> Eff es a
+runTelegramStub = interpret $ \_ -> \case
+  TelegramSendOp msg -> do
+    logInfo $ "[Telegram:stub] TelegramSend called: " <> msg.tmText
+    error "Telegram.telegramSend: not implemented"
+  TelegramAskOp msg buttons -> do
+    logInfo $ "[Telegram:stub] TelegramAsk called: " <> msg.tmText <> " with " <> showButtons buttons
+    error "Telegram.telegramAsk: not implemented"
+
+showButtons :: [TelegramButton] -> Text
+showButtons bs = "[" <> mconcat [b.tbLabel <> "," | b <- bs] <> "]"

--- a/tidepool-core/tidepool-core.cabal
+++ b/tidepool-core/tidepool-core.cabal
@@ -22,6 +22,7 @@ library
         Tidepool.Schema
         Tidepool.Anthropic.Types
         Tidepool.Effects.Habitica
+        Tidepool.Effects.Telegram
         Tidepool.Effects.Obsidian
         Tidepool.Effects.GitHub
         Tidepool.Effects.Calendar

--- a/tidepool-wasm/test/ProtocolPropertySpec.hs
+++ b/tidepool-wasm/test/ProtocolPropertySpec.hs
@@ -87,8 +87,12 @@ instance Arbitrary SerializableEffect where
     , EffHabitica
         <$> elements ["GetUser", "ScoreTask", "GetTasks", "FetchTodos", "CreateTodo", "AddChecklistItem"]
         <*> scale (`div` 2) arbitrary
-    , EffTelegramConfirm
+    , EffTelegramSend
         <$> arbitrary
+        <*> elements ["PlainText", "Markdown", "HTML"]
+    , EffTelegramAsk
+        <$> arbitrary
+        <*> elements ["PlainText", "Markdown", "HTML"]
         <*> listOf ((,) <$> arbitrary <*> arbitrary)
     ]
 
@@ -109,10 +113,13 @@ instance Arbitrary SerializableEffect where
   shrink (EffHabitica op payload) =
     [ EffLogInfo op ]
     ++ [ EffHabitica op payload' | payload' <- shrink payload ]
-  shrink (EffTelegramConfirm msg buttons) =
-    [ EffLogInfo msg ]
-    ++ [ EffTelegramConfirm msg' buttons | msg' <- shrink msg ]
-    ++ [ EffTelegramConfirm msg buttons' | buttons' <- shrink buttons ]
+  shrink (EffTelegramSend txt parseMode) =
+    [ EffLogInfo txt ]
+    ++ [ EffTelegramSend txt' parseMode | txt' <- shrink txt ]
+  shrink (EffTelegramAsk txt parseMode buttons) =
+    [ EffLogInfo txt ]
+    ++ [ EffTelegramAsk txt' parseMode buttons | txt' <- shrink txt ]
+    ++ [ EffTelegramAsk txt parseMode buttons' | buttons' <- shrink buttons ]
 
 
 -- | Arbitrary EffectResult covering success and error cases


### PR DESCRIPTION
## Summary

- Replace fragile JSON field convention (`"message" .= brSummary`) with type-safe `Telegram :: Effect` GADT
- New effect operations: `TelegramSendOp` (fire-and-forget) and `TelegramAskOp` (blocking)
- Wire types: `EffTelegramSend` + `EffTelegramAsk` replace old `EffTelegramConfirm`
- No hardcoded buttons - callers provide their own via `telegramAsk`

## Test plan

- [x] All existing tests pass
- [x] HabiticaRoutingGraph updated to use `telegramAsk` with explicit buttons
- [x] Property tests updated for new wire types

🤖 Generated with [Claude Code](https://claude.com/claude-code)