### PR TITLE
feat: Expand Prelude with common combinator re-exports

### DIFF
--- a/tidepool-wasm/src/Tidepool/Wasm/Prelude.hs
+++ b/tidepool-wasm/src/Tidepool/Wasm/Prelude.hs
@@ -183,7 +183,7 @@ whenM mb action = mb >>= \b -> when b action
 -- | Lifted 'unless' - run action when monadic condition is false.
 --
 -- @
--- unlessM (hasErrors state) $ continue processing
+-- unlessM (hasErrors state) $ logInfo "Processing complete"
 -- @
 unlessM :: Monad m => m Bool -> m () -> m ()
 unlessM mb action = mb >>= \b -> unless b action


### PR DESCRIPTION
## Summary

- Adds commonly-needed re-exports to `Tidepool.Wasm.Prelude` so handler modules can use a single import instead of 10+ repetitive imports
- Introduces `whenM`/`unlessM` lifted conditional helpers

### New re-exports

| Category | Functions |
|----------|-----------|
| **Aeson** | `Value(..)`, `object`, `(.=)`, `(.:)`, `(.:?)` |
| **Control.Monad** | `forM`, `forM_`, `when`, `unless`, `void`, `(>=>)`, `(<=<)` |
| **Data.Maybe** | `fromMaybe`, `catMaybes`, `mapMaybe`, `isJust`, `isNothing` |
| **Data.Either** | `lefts`, `rights`, `partitionEithers` |
| **Data.Text** | `pack`, `unpack` |
| **New helpers** | `whenM`, `unlessM` |

### Usage

```haskell
-- Before (many imports):
import Tidepool.Graph.Types (...)
import Tidepool.Wasm.Effect (...)
import Data.Text (Text)
import Data.Aeson (Value, object, (.=))
import Control.Monad (forM, when)
import Data.Maybe (fromMaybe)
-- ...

-- After (one import):
import Tidepool.Wasm.Prelude
```

## Test plan

- [x] All 229 tidepool-wasm tests pass
- [x] All 94 tidepool-core tests pass
- [x] hlint clean
- [x] TypeScript lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)