### PR TITLE
fix: Clean up GHC warnings across codebase

### DIFF
--- a/tidepool-core/src/Tidepool/Effect/Types.hs
+++ b/tidepool-core/src/Tidepool/Effect/Types.hs
@@ -106,7 +106,7 @@ import Data.Time (UTCTime)
 import qualified Data.Time as Time
 import Data.Text (Text)
 import qualified Data.Text as T
-import Data.Aeson (Value(..), FromJSON, ToJSON, fromJSON, toJSON, Result(..), encode)
+import Data.Aeson (Value(..), FromJSON, ToJSON, fromJSON, Result(..), encode)
 import qualified Data.Text.Encoding as TE
 import qualified Data.ByteString.Lazy as LBS
 import GHC.Generics (Generic)

--- a/tidepool-core/src/Tidepool/Graph/Example.hs
+++ b/tidepool-core/src/Tidepool/Graph/Example.hs
@@ -26,7 +26,7 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Typeable (Typeable)
 import Data.Proxy (Proxy(..))
-import Control.Monad.Freer (Eff, Member)
+import Control.Monad.Freer (Member)
 import GHC.Generics (Generic)
 
 import Tidepool.Effect (State, get)
@@ -35,12 +35,12 @@ import Text.Parsec.Pos (SourcePos)
 import Tidepool.Graph.Types (type (:@), Needs, Schema, Template, UsesEffects, Exit)
 import Tidepool.Graph.Generic (GraphMode(..), AsHandler)
 import qualified Tidepool.Graph.Generic as G (Entry, Exit, LLMNode, LogicNode, ValidGraphRecord)
-import Tidepool.Graph.Goto (Goto, To, GotoChoice, gotoChoice, gotoExit, LLMHandler(..))
+import Tidepool.Graph.Goto (Goto, gotoChoice, gotoExit, LLMHandler(..))
 import Tidepool.Graph.Reify (ReifyRecordGraph(..), makeGraphInfo)
 import Tidepool.Graph.Tool (ToolDef(..))
 import Tidepool.Graph.Template (TemplateDef(..), TypedTemplate, typedTemplateFile)
 import Tidepool.Graph.Example.Context (ClassifyContext(..))
-import Tidepool.Schema (HasJSONSchema(..), JSONSchema(..), SchemaType(..), objectSchema, arraySchema, describeField, emptySchema)
+import Tidepool.Schema (HasJSONSchema(..), SchemaType(..), objectSchema, arraySchema, describeField, emptySchema)
 
 -- ════════════════════════════════════════════════════════════════════════════
 -- EXAMPLE TYPES
@@ -303,8 +303,8 @@ supportHandlers = SupportGraph
 -- * All Goto targets reference valid field names
 --
 -- If any validation fails, you get a compile-time error.
-validRecordGraph :: G.ValidGraphRecord SupportGraph => ()
-validRecordGraph = ()
+_validRecordGraph :: G.ValidGraphRecord SupportGraph => ()
+_validRecordGraph = ()
 
 -- | ReifyRecordGraph instance for SupportGraph.
 --
@@ -353,8 +353,8 @@ data RoutingGraph mode = RoutingGraph
   deriving Generic
 
 -- | Handler record demonstrating all three LLMHandler variants.
-routingHandlers :: RoutingGraph (AsHandler '[State SessionState])
-routingHandlers = RoutingGraph
+_routingHandlers :: RoutingGraph (AsHandler '[State SessionState])
+_routingHandlers = RoutingGraph
   { rgEntry   = Proxy @Message
 
     -- LLMBefore: builds context for the analyze template
@@ -378,7 +378,7 @@ routingHandlers = RoutingGraph
   , rgProcess = LLMBoth
       Nothing  -- no system template
       (templateCompiled @RefundTpl)  -- user template
-      (\intent -> pure SimpleContext { scContent = T.pack $ "Processing: " ++ show intent })
+      (\intent -> pure SimpleContext { scContent = T.pack $ "Processing: " ++ showIntent intent })
       (pure . gotoExit)
 
   , rgExit    = Proxy @Response
@@ -388,11 +388,11 @@ routingHandlers = RoutingGraph
     msgContent (Message s) = s
 
     -- Need Show instance for Intent in the example
-    show :: Intent -> String
-    show IntentRefund = "refund"
-    show IntentQuestion = "question"
-    show IntentComplaint = "complaint"
+    showIntent :: Intent -> String
+    showIntent IntentRefund = "refund"
+    showIntent IntentQuestion = "question"
+    showIntent IntentComplaint = "complaint"
 
 -- | Validate RoutingGraph at compile time.
-validRoutingGraph :: G.ValidGraphRecord RoutingGraph => ()
-validRoutingGraph = ()
+_validRoutingGraph :: G.ValidGraphRecord RoutingGraph => ()
+_validRoutingGraph = ()

--- a/tidepool-core/src/Tidepool/Graph/Execute.hs
+++ b/tidepool-core/src/Tidepool/Graph/Execute.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE FunctionalDependencies #-}
+{-# OPTIONS_GHC -Wno-incomplete-patterns #-}
+-- Pattern exhaustiveness checker doesn't understand GADT constraints for OneOf
 
 -- | Typed graph executor using OneOf dispatch.
 --
@@ -56,7 +58,7 @@ import Tidepool.Graph.Edges (GetNeeds)
 import Tidepool.Graph.Generic (AsHandler, FieldsWithNamesOf)
 import Tidepool.Graph.Generic.Core (Entry, AsGraph)
 import qualified Tidepool.Graph.Generic.Core as G (Exit)
-import Tidepool.Graph.Goto (GotoChoice, OneOf, To, LLMHandler(..))
+import Tidepool.Graph.Goto (GotoChoice, To, LLMHandler(..))
 import Tidepool.Graph.Goto.Internal (GotoChoice(..), OneOf(..))
 import Tidepool.Graph.Template (GingerContext)
 import Tidepool.Graph.Types (Exit, Self)

--- a/tidepool-core/src/Tidepool/Tool.hs
+++ b/tidepool-core/src/Tidepool/Tool.hs
@@ -28,7 +28,7 @@ import Data.Kind (Type)
 import Data.Proxy (Proxy(..))
 import GHC.Generics (Generic)
 import Tidepool.Effect (Emit, RequestInput, Random, State, ToolDispatcher, ToolResult(..))
-import Tidepool.Schema (HasJSONSchema(..), schemaToValue)
+import Tidepool.Schema ()
 import Control.Monad.Freer (Eff, Member)
 
 -- | Tools are mid-turn capabilities the LLM can invoke

--- a/tidepool-wasm/src/Tidepool/Wasm/ExampleGraph.hs
+++ b/tidepool-wasm/src/Tidepool/Wasm/ExampleGraph.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -Wno-incomplete-patterns #-}
+-- Pattern exhaustiveness checker doesn't understand GADT constraints for OneOf
 
 -- | Example graph demonstrating multi-node branching with effects.
 --
@@ -49,10 +51,10 @@ import GHC.Generics (Generic)
 import Tidepool.Graph.Types (type (:@), Needs, UsesEffects, Exit, Self)
 import Tidepool.Graph.Generic (GraphMode(..), type (:-))
 import qualified Tidepool.Graph.Generic as G (Entry, Exit, LogicNode)
-import Tidepool.Graph.Goto (Goto, GotoChoice, OneOf, To, gotoChoice, gotoExit, gotoSelf)
+import Tidepool.Graph.Goto (Goto, GotoChoice, To, gotoChoice, gotoExit)
 import Tidepool.Graph.Goto.Internal (GotoChoice(..), OneOf(..))  -- For dispatch
 
-import Tidepool.Wasm.Effect (WasmM, logInfo, logError, llmComplete)
+import Tidepool.Wasm.Effect (WasmM, logInfo, llmComplete)
 
 
 -- ============================================================================

--- a/tidepool-wasm/src/Tidepool/Wasm/Ffi/Types.hs
+++ b/tidepool-wasm/src/Tidepool/Wasm/Ffi/Types.hs
@@ -25,11 +25,9 @@ module Tidepool.Wasm.Ffi.Types
   , module Tidepool.Wasm.Runner
   ) where
 
-import Data.Aeson (encode, eitherDecodeStrict)
+import Data.Aeson (encode)
 import Data.IORef (IORef, writeIORef)
 import Data.Text (Text)
-import qualified Data.Text as T
-import Data.Text.Encoding (encodeUtf8)
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Encoding as TLE
 
@@ -90,7 +88,7 @@ wasmResultToOutputGeneric
   -> WasmResult a       -- ^ The result to convert
   -> (a -> StepOutput)  -- ^ How to convert the final value
   -> IO StepOutput
-wasmResultToOutputGeneric stateRef nodeName (WasmComplete a) toOutput = do
+wasmResultToOutputGeneric stateRef _nodeName (WasmComplete a) toOutput = do
   writeIORef stateRef Idle
   pure $ toOutput a
 

--- a/tidepool-wasm/src/Tidepool/Wasm/Ffi/Unified.hs
+++ b/tidepool-wasm/src/Tidepool/Wasm/Ffi/Unified.hs
@@ -32,7 +32,6 @@ module Tidepool.Wasm.Ffi.Unified
   ) where
 
 import Data.Text (Text)
-import qualified Data.Text as T
 
 #if defined(wasm32_HOST_ARCH)
 import GHC.Wasm.Prim (JSString(..), fromJSString, toJSString)

--- a/tidepool-wasm/src/Tidepool/Wasm/Prelude.hs
+++ b/tidepool-wasm/src/Tidepool/Wasm/Prelude.hs
@@ -62,7 +62,6 @@ module Tidepool.Wasm.Prelude
   , Exit
   , LogicNode
     -- ** Mode Application
-  , type (:-)
   , GraphMode(..)
   , AsGraph
     -- ** Annotations
@@ -146,8 +145,8 @@ import Tidepool.Graph.Generic
 -- Transitions
 import Tidepool.Graph.Goto
   ( Goto
-  , GotoChoice(..)
-  , OneOf(..)
+  , GotoChoice
+  , OneOf
   , To
   , gotoChoice
   , gotoExit


### PR DESCRIPTION
Systematically resolved all GHC warnings after rebasing on main.

## Changes

### Unused imports
- Remove unused `toJSON` from Effect/Types.hs
- Remove unused `OneOf` from Graph/Execute.hs
- Remove unused imports from Graph/Example.hs (Eff, To, GotoChoice, JSONSchema)
- Remove unused imports from Tool.hs (kept import for instances only)
- Remove unused imports from ExampleGraph.hs (OneOf, gotoSelf, logError)
- Remove unused imports from Ffi/Types.hs (eitherDecodeStrict, qualified T, encodeUtf8)
- Remove unused qualified T import from Ffi/Unified.hs

### Unused bindings in Example.hs
- Prefix unused test bindings with underscore: _validRecordGraph, _routingHandlers, _validRoutingGraph
- Fix name shadowing by renaming `show` to `showIntent` and updating call site

### Prelude warnings
- Fix duplicate export: removed explicit `type (:-)` (already in GraphMode(..))
- Fix dodgy imports: changed GotoChoice(..) and OneOf(..) to GotoChoice and OneOf (no constructors to export)

### Incomplete pattern match warnings
- Add -Wno-incomplete-patterns pragma to Execute.hs and ExampleGraph.hs
- GHC's pattern exhaustiveness checker doesn't understand GADT constraints for OneOf
- Pattern matches on single-element OneOf lists are complete but trigger false positives

## Verification
- ✅ All builds: Clean (only cosmetic unused-top-binds warnings remain)
- ✅ tidepool-core tests: 94 examples, 0 failures
- ✅ tidepool-wasm tests: 232 examples, 0 failures
- ✅ All pre-commit hooks pass