### PR TITLE
feat: Improve v2 graph DX based on DM port feedback

### DIFF
--- a/tidepool-core/src/Tidepool/Graph.hs
+++ b/tidepool-core/src/Tidepool/Graph.hs
@@ -158,6 +158,7 @@ module Tidepool.Graph
   , GetSchema
   , GetUsesEffects
   , GetGotoTargets
+  , GotosToTos
   , GetMemory
   , GetGlobal
 

--- a/tidepool-core/test/golden/ToInUsesEffects.hs
+++ b/tidepool-core/test/golden/ToInUsesEffects.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+-- | Golden test for using 'To' markers in UsesEffects instead of 'Goto' effects.
+--
+-- This should produce:
+--   Wrong type in UsesEffects
+--   UsesEffects contains 'To' markers, but needs 'Goto' effects.
+--
+-- This is a common mistake when maintaining parallel type aliases for
+-- graph definitions (Goto) and handler signatures (To).
+module ToInUsesEffects where
+
+import GHC.Generics (Generic)
+
+import Tidepool.Graph.Types (type (:@), Needs, UsesEffects, Exit)
+import Tidepool.Graph.Generic (GraphMode(..), type (:-), LogicNode, ValidGraphRecord)
+import qualified Tidepool.Graph.Generic as G (Entry, Exit)
+import Tidepool.Graph.Goto (To)  -- Imported to demonstrate incorrect usage in UsesEffects
+
+data Input
+data Output
+data Result
+
+-- | Wrong: Using 'To' markers in UsesEffects
+--
+-- The correct approach is to use 'Goto' effects:
+--   UsesEffects '[Goto "handler" Output, Goto Exit Result]
+type WrongEffects = '[To "handler" Output, To Exit Result]
+
+-- | Graph with wrong effect type - should produce a helpful error
+data BadGraph mode = BadGraph
+  { entry   :: mode :- G.Entry Input
+  , router  :: mode :- LogicNode :@ Needs '[Input] :@ UsesEffects WrongEffects
+  , handler :: mode :- LogicNode :@ Needs '[Output] :@ UsesEffects '[To Exit Result]
+  , exit    :: mode :- G.Exit Result
+  }
+  deriving Generic
+
+check :: ()
+check = validGraph @BadGraph
+
+validGraph :: forall g. ValidGraphRecord g => ()
+validGraph = ()


### PR DESCRIPTION
## Summary

Implements improvements to the v2 graph system based on feedback from porting the DM graph (~1500 lines, 10 handlers):

- **GotosToTos type alias**: Converts `Goto` effects to `To` markers, eliminating the need for parallel type aliases when defining handler signatures
- **unwrapSingleChoice helper**: Extracts payload from single-target `GotoChoice` without incomplete pattern match warnings  
- **ValidateNoToInEffects constraint**: Catches the common mistake of using `To` markers in `UsesEffects` (should use `Goto` effects) with a clear, actionable error message
- **Documentation**: Added "Handler Signature Patterns" section to CLAUDE.md explaining three approaches

## Test plan

- [x] All 94 tidepool-core tests pass
- [x] All tidepool-wasm tests pass
- [x] All tidepool-habitica tests pass
- [x] `cabal build all` succeeds
- [ ] Golden test `ToInUsesEffects.hs` demonstrates error message (not wired into test suite yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)