### PR TITLE
feat(bd): Add write operations to BD effect

### DIFF
--- a/tidepool-core/src/Tidepool/Effects/BD.hs
+++ b/tidepool-core/src/Tidepool/Effects/BD.hs
@@ -1,12 +1,12 @@
--- | BD (Beads) effect for querying issue/task tracking data.
+-- | BD (Beads) effect for issue/task tracking.
 --
 -- Effect type only - executors live in tidepool-bd-executor.
--- Enables graphs to read bead info, dependencies, and labels.
+-- Enables graphs to read and write bead info, dependencies, and labels.
 --
 -- = Example Usage
 --
 -- @
--- import Tidepool.Effects.BD (BD, getBead, getDeps, getLabels)
+-- import Tidepool.Effects.BD
 --
 -- myHandler :: Member BD effs => Text -> Eff effs ()
 -- myHandler beadId = do
@@ -17,16 +17,44 @@
 --       deps <- getDeps beadId
 --       labels <- getLabels beadId
 --       -- process bead info...
+--
+-- createTask :: Member BD effs => Text -> Eff effs Text
+-- createTask parentId = do
+--   newId <- createBead $ defaultCreateInput
+--     { cbiTitle = "Subtask"
+--     , cbiParent = Just parentId
+--     }
+--   addLabel newId "auto-created"
+--   pure newId
 -- @
 module Tidepool.Effects.BD
   ( -- * Effect
     BD(..)
+
+    -- * Read Operations
   , getBead
   , getDeps
   , getBlocking
   , getLabels
+  , getChildren
 
-    -- * Types
+    -- * Write Operations
+  , createBead
+  , updateBead
+  , closeBead
+  , reopenBead
+  , addLabel
+  , removeLabel
+  , addDep
+  , removeDep
+
+    -- * Input Types
+  , CreateBeadInput(..)
+  , defaultCreateInput
+  , UpdateBeadInput(..)
+  , emptyUpdateInput
+
+    -- * Data Types
   , BeadInfo(..)
   , BeadStatus(..)
   , BeadType(..)
@@ -226,13 +254,68 @@ instance FromJSON BeadInfo where
 
 
 -- ════════════════════════════════════════════════════════════════════════════
+-- INPUT TYPES
+-- ════════════════════════════════════════════════════════════════════════════
+
+-- | Input for creating a new bead.
+data CreateBeadInput = CreateBeadInput
+  { cbiTitle       :: Text              -- ^ Required: bead title
+  , cbiDescription :: Maybe Text        -- ^ Optional description
+  , cbiType        :: BeadType          -- ^ Bead type (default: Task)
+  , cbiPriority    :: Int               -- ^ Priority 0-4 (default: 2)
+  , cbiParent      :: Maybe Text        -- ^ Parent bead ID for hierarchy
+  , cbiLabels      :: [Text]            -- ^ Initial labels
+  , cbiAssignee    :: Maybe Text        -- ^ Assignee
+  , cbiDeps        :: [(Text, DependencyType)]  -- ^ Dependencies: (beadId, depType)
+  }
+  deriving (Show, Eq, Generic)
+
+-- | Default create input with just a title.
+defaultCreateInput :: CreateBeadInput
+defaultCreateInput = CreateBeadInput
+  { cbiTitle       = ""
+  , cbiDescription = Nothing
+  , cbiType        = TypeTask
+  , cbiPriority    = 2
+  , cbiParent      = Nothing
+  , cbiLabels      = []
+  , cbiAssignee    = Nothing
+  , cbiDeps        = []
+  }
+
+
+-- | Input for updating an existing bead.
+--
+-- All fields are optional - 'Nothing' means "don't change".
+data UpdateBeadInput = UpdateBeadInput
+  { ubiTitle       :: Maybe Text        -- ^ New title
+  , ubiDescription :: Maybe Text        -- ^ New description
+  , ubiStatus      :: Maybe BeadStatus  -- ^ New status
+  , ubiPriority    :: Maybe Int         -- ^ New priority
+  , ubiAssignee    :: Maybe Text        -- ^ New assignee
+  }
+  deriving (Show, Eq, Generic)
+
+-- | Empty update input (no changes).
+emptyUpdateInput :: UpdateBeadInput
+emptyUpdateInput = UpdateBeadInput
+  { ubiTitle       = Nothing
+  , ubiDescription = Nothing
+  , ubiStatus      = Nothing
+  , ubiPriority    = Nothing
+  , ubiAssignee    = Nothing
+  }
+
+
+-- ════════════════════════════════════════════════════════════════════════════
 -- EFFECT
 -- ════════════════════════════════════════════════════════════════════════════
 
--- | BD (Beads) effect for querying issue/task tracking.
+-- | BD (Beads) effect for issue/task tracking.
 --
--- Read-only queries against the beads database.
+-- Supports both read and write operations against the beads database.
 data BD r where
+  -- Read operations
   -- | Get full bead info by ID.
   GetBead :: Text -> BD (Maybe BeadInfo)
 
@@ -245,9 +328,37 @@ data BD r where
   -- | Get labels attached to a bead.
   GetLabels :: Text -> BD [Text]
 
+  -- | Get child beads (beads with this as parent).
+  GetChildren :: Text -> BD [BeadInfo]
+
+  -- Write operations
+  -- | Create a new bead, returns the generated ID.
+  CreateBead :: CreateBeadInput -> BD Text
+
+  -- | Update an existing bead.
+  UpdateBead :: Text -> UpdateBeadInput -> BD ()
+
+  -- | Close a bead (set status to closed).
+  CloseBead :: Text -> BD ()
+
+  -- | Reopen a bead (set status to open).
+  ReopenBead :: Text -> BD ()
+
+  -- | Add a label to a bead.
+  AddLabel :: Text -> Text -> BD ()
+
+  -- | Remove a label from a bead.
+  RemoveLabel :: Text -> Text -> BD ()
+
+  -- | Add a dependency between beads.
+  AddDep :: Text -> Text -> DependencyType -> BD ()
+
+  -- | Remove a dependency between beads.
+  RemoveDep :: Text -> Text -> BD ()
+
 
 -- ════════════════════════════════════════════════════════════════════════════
--- SMART CONSTRUCTORS
+-- SMART CONSTRUCTORS - READ
 -- ════════════════════════════════════════════════════════════════════════════
 
 -- | Get bead info by ID.
@@ -265,3 +376,66 @@ getBlocking = send . GetBlocking
 -- | Get labels for a bead.
 getLabels :: Member BD effs => Text -> Eff effs [Text]
 getLabels = send . GetLabels
+
+-- | Get child beads (beads with this as parent).
+getChildren :: Member BD effs => Text -> Eff effs [BeadInfo]
+getChildren = send . GetChildren
+
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- SMART CONSTRUCTORS - WRITE
+-- ════════════════════════════════════════════════════════════════════════════
+
+-- | Create a new bead, returns the generated ID.
+--
+-- Example:
+--
+-- @
+-- newId <- createBead $ defaultCreateInput
+--   { cbiTitle = "Fix bug in login"
+--   , cbiType = TypeBug
+--   , cbiPriority = 1
+--   , cbiLabels = ["urgent", "auth"]
+--   }
+-- @
+createBead :: Member BD effs => CreateBeadInput -> Eff effs Text
+createBead = send . CreateBead
+
+-- | Update an existing bead.
+--
+-- Example:
+--
+-- @
+-- updateBead "bd-123" $ emptyUpdateInput
+--   { ubiStatus = Just StatusInProgress
+--   , ubiAssignee = Just "alice"
+--   }
+-- @
+updateBead :: Member BD effs => Text -> UpdateBeadInput -> Eff effs ()
+updateBead beadId input = send $ UpdateBead beadId input
+
+-- | Close a bead (set status to closed).
+closeBead :: Member BD effs => Text -> Eff effs ()
+closeBead = send . CloseBead
+
+-- | Reopen a closed bead (set status to open).
+reopenBead :: Member BD effs => Text -> Eff effs ()
+reopenBead = send . ReopenBead
+
+-- | Add a label to a bead.
+addLabel :: Member BD effs => Text -> Text -> Eff effs ()
+addLabel beadId label = send $ AddLabel beadId label
+
+-- | Remove a label from a bead.
+removeLabel :: Member BD effs => Text -> Text -> Eff effs ()
+removeLabel beadId label = send $ RemoveLabel beadId label
+
+-- | Add a dependency between beads.
+--
+-- @addDep fromId toId depType@ creates a dependency where @fromId@ depends on @toId@.
+addDep :: Member BD effs => Text -> Text -> DependencyType -> Eff effs ()
+addDep fromId toId depType = send $ AddDep fromId toId depType
+
+-- | Remove a dependency between beads.
+removeDep :: Member BD effs => Text -> Text -> Eff effs ()
+removeDep fromId toId = send $ RemoveDep fromId toId

--- a/tidepool-native-gui/bd-executor/src/Tidepool/BD/Executor.hs
+++ b/tidepool-native-gui/bd-executor/src/Tidepool/BD/Executor.hs
@@ -1,21 +1,23 @@
 -- | BD (Beads) effect executor - CLI client.
 --
 -- Implements BD effect by calling the bd CLI tool.
--- All queries are read-only and use @bd show --json@.
+-- Supports both read and write operations.
 --
 -- = Usage
 --
 -- @
 -- import Tidepool.BD.Executor (runBD, runBDIO, BDConfig(..))
--- import Tidepool.Effects.BD (BD, getBead, getDeps)
+-- import Tidepool.Effects.BD
 --
 -- main = do
---   let config = BDConfig { bcBeadsDir = Nothing }  -- use auto-discovery
+--   let config = BDConfig { bcBeadsDir = Nothing, bcQuiet = True }
 --   runM $ runBDIO config $ do
+--     -- Read
 --     maybeBead <- getBead "gt-hda.2.2"
---     case maybeBead of
---       Nothing -> pure ()
---       Just bead -> print bead.biTitle
+--     -- Write
+--     newId <- createBead $ defaultCreateInput { cbiTitle = "New task" }
+--     addLabel newId "auto-created"
+--     closeBead newId
 -- @
 module Tidepool.BD.Executor
   ( -- * Executor
@@ -26,32 +28,45 @@ module Tidepool.BD.Executor
   , BDConfig(..)
   , defaultBDConfig
 
-    -- * Low-Level CLI Access
+    -- * Low-Level CLI Access (Read)
   , bdShow
   , bdDeps
   , bdBlocking
   , bdLabels
+  , bdChildren
+
+    -- * Low-Level CLI Access (Write)
+  , bdCreate
+  , bdUpdate
+  , bdClose
+  , bdReopen
+  , bdAddLabel
+  , bdRemoveLabel
+  , bdAddDep
+  , bdRemoveDep
   ) where
 
 import Control.Exception (try, SomeException)
+import Control.Monad (forM_)
 import Control.Monad.Freer (Eff, LastMember, interpret, sendM)
 import Data.Aeson (eitherDecode)
 import Data.ByteString.Lazy qualified as LBS
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.Encoding qualified as TE
-import System.Process
-  ( readProcessWithExitCode
-  , proc
-  , CreateProcess(..)
-  , StdStream(..)
-  , withCreateProcess
-  , waitForProcess
-  )
-import GHC.IO.Handle (hGetContents)
+import System.Process (readProcessWithExitCode)
 import System.Exit (ExitCode(..))
 
-import Tidepool.Effects.BD (BD(..), BeadInfo(..), DependencyInfo(..))
+import Tidepool.Effects.BD
+  ( BD(..)
+  , BeadInfo(..)
+  , BeadType(..)
+  , BeadStatus(..)
+  , DependencyInfo(..)
+  , DependencyType(..)
+  , CreateBeadInput(..)
+  , UpdateBeadInput(..)
+  )
 
 
 -- ════════════════════════════════════════════════════════════════════════════
@@ -101,6 +116,7 @@ runBD hGetBead hGetDeps hGetBlocking hGetLabels = interpret $ \case
 -- This interpreter shells out to the bd command for each operation.
 runBDIO :: LastMember IO effs => BDConfig -> Eff (BD ': effs) a -> Eff effs a
 runBDIO config = interpret $ \case
+  -- Read operations
   GetBead beadId -> sendM $ bdShow config beadId
 
   GetDeps beadId -> sendM $ do
@@ -124,6 +140,18 @@ runBDIO config = interpret $ \case
         pure $ [b | Just b <- beads]
 
   GetLabels beadId -> sendM $ bdLabels config beadId
+
+  GetChildren parentId -> sendM $ bdChildren config parentId
+
+  -- Write operations
+  CreateBead input -> sendM $ bdCreate config input
+  UpdateBead beadId input -> sendM $ bdUpdate config beadId input
+  CloseBead beadId -> sendM $ bdClose config beadId
+  ReopenBead beadId -> sendM $ bdReopen config beadId
+  AddLabel beadId label -> sendM $ bdAddLabel config beadId label
+  RemoveLabel beadId label -> sendM $ bdRemoveLabel config beadId label
+  AddDep fromId toId depType -> sendM $ bdAddDep config fromId toId depType
+  RemoveDep fromId toId -> sendM $ bdRemoveDep config fromId toId
 
 
 -- ════════════════════════════════════════════════════════════════════════════
@@ -201,6 +229,155 @@ bdLabels config beadId = do
         Left _ -> pure []  -- Parse error, return empty
 
 
+-- | Get child beads (beads with this as parent).
+--
+-- Uses @bd list --parent <id> --json@ command.
+bdChildren :: BDConfig -> Text -> IO [BeadInfo]
+bdChildren config parentId = do
+  let args = ["list", "--parent", T.unpack parentId, "--json"]
+            ++ maybe [] (\d -> ["--db", d]) config.bcBeadsDir
+
+  result <- runBdCommand config args
+  case result of
+    Left _err -> pure []
+    Right output ->
+      case eitherDecode (LBS.fromStrict $ TE.encodeUtf8 output) of
+        Right beads -> pure beads
+        Left _ -> pure []
+
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- CLI FUNCTIONS - WRITE
+-- ════════════════════════════════════════════════════════════════════════════
+
+-- | Create a new bead.
+--
+-- Uses @bd create@ command. Returns the generated bead ID.
+bdCreate :: BDConfig -> CreateBeadInput -> IO Text
+bdCreate config input = do
+  let baseArgs = ["create", T.unpack input.cbiTitle, "--silent"]
+                ++ maybe [] (\d -> ["--db", d]) config.bcBeadsDir
+                ++ ["--type", beadTypeToArg input.cbiType]
+                ++ ["--priority", show input.cbiPriority]
+                ++ maybe [] (\desc -> ["--description", T.unpack desc]) input.cbiDescription
+                ++ maybe [] (\p -> ["--parent", T.unpack p]) input.cbiParent
+                ++ maybe [] (\a -> ["--assignee", T.unpack a]) input.cbiAssignee
+                ++ concatMap (\l -> ["--labels", T.unpack l]) input.cbiLabels
+                ++ concatMap depToArg input.cbiDeps
+
+  result <- runBdCommand config baseArgs
+  case result of
+    Left err -> error $ "bd create failed: " <> T.unpack err
+    Right output -> pure $ T.strip output
+
+
+-- | Update an existing bead.
+--
+-- Uses @bd update@ command.
+bdUpdate :: BDConfig -> Text -> UpdateBeadInput -> IO ()
+bdUpdate config beadId input = do
+  let args = ["update", T.unpack beadId]
+            ++ maybe [] (\d -> ["--db", d]) config.bcBeadsDir
+            ++ maybe [] (\t -> ["--title", T.unpack t]) input.ubiTitle
+            ++ maybe [] (\d -> ["--description", T.unpack d]) input.ubiDescription
+            ++ maybe [] (\s -> ["--status", beadStatusToArg s]) input.ubiStatus
+            ++ maybe [] (\p -> ["--priority", show p]) input.ubiPriority
+            ++ maybe [] (\a -> ["--assignee", T.unpack a]) input.ubiAssignee
+
+  -- Only run if there are actual changes
+  if null (drop 2 args)  -- Just "update" and beadId
+    then pure ()
+    else do
+      result <- runBdCommand config args
+      case result of
+        Left err -> error $ "bd update failed: " <> T.unpack err
+        Right _ -> pure ()
+
+
+-- | Close a bead.
+--
+-- Uses @bd close@ command.
+bdClose :: BDConfig -> Text -> IO ()
+bdClose config beadId = do
+  let args = ["close", T.unpack beadId]
+            ++ maybe [] (\d -> ["--db", d]) config.bcBeadsDir
+
+  result <- runBdCommand config args
+  case result of
+    Left err -> error $ "bd close failed: " <> T.unpack err
+    Right _ -> pure ()
+
+
+-- | Reopen a closed bead.
+--
+-- Uses @bd reopen@ command.
+bdReopen :: BDConfig -> Text -> IO ()
+bdReopen config beadId = do
+  let args = ["reopen", T.unpack beadId]
+            ++ maybe [] (\d -> ["--db", d]) config.bcBeadsDir
+
+  result <- runBdCommand config args
+  case result of
+    Left err -> error $ "bd reopen failed: " <> T.unpack err
+    Right _ -> pure ()
+
+
+-- | Add a label to a bead.
+--
+-- Uses @bd label add@ command.
+bdAddLabel :: BDConfig -> Text -> Text -> IO ()
+bdAddLabel config beadId label = do
+  let args = ["label", "add", T.unpack beadId, T.unpack label]
+            ++ maybe [] (\d -> ["--db", d]) config.bcBeadsDir
+
+  result <- runBdCommand config args
+  case result of
+    Left err -> error $ "bd label add failed: " <> T.unpack err
+    Right _ -> pure ()
+
+
+-- | Remove a label from a bead.
+--
+-- Uses @bd label remove@ command.
+bdRemoveLabel :: BDConfig -> Text -> Text -> IO ()
+bdRemoveLabel config beadId label = do
+  let args = ["label", "remove", T.unpack beadId, T.unpack label]
+            ++ maybe [] (\d -> ["--db", d]) config.bcBeadsDir
+
+  result <- runBdCommand config args
+  case result of
+    Left err -> error $ "bd label remove failed: " <> T.unpack err
+    Right _ -> pure ()
+
+
+-- | Add a dependency between beads.
+--
+-- Uses @bd dep add@ command.
+bdAddDep :: BDConfig -> Text -> Text -> DependencyType -> IO ()
+bdAddDep config fromId toId depType = do
+  let args = ["dep", "add", T.unpack fromId, depTypeToArg depType <> ":" <> T.unpack toId]
+            ++ maybe [] (\d -> ["--db", d]) config.bcBeadsDir
+
+  result <- runBdCommand config args
+  case result of
+    Left err -> error $ "bd dep add failed: " <> T.unpack err
+    Right _ -> pure ()
+
+
+-- | Remove a dependency between beads.
+--
+-- Uses @bd dep remove@ command.
+bdRemoveDep :: BDConfig -> Text -> Text -> IO ()
+bdRemoveDep config fromId toId = do
+  let args = ["dep", "remove", T.unpack fromId, T.unpack toId]
+            ++ maybe [] (\d -> ["--db", d]) config.bcBeadsDir
+
+  result <- runBdCommand config args
+  case result of
+    Left err -> error $ "bd dep remove failed: " <> T.unpack err
+    Right _ -> pure ()
+
+
 -- ════════════════════════════════════════════════════════════════════════════
 -- HELPERS
 -- ════════════════════════════════════════════════════════════════════════════
@@ -219,7 +396,41 @@ runBdCommand config args = do
         ExitFailure code ->
           -- bd often returns non-zero with warnings but valid output
           -- Check if we got valid JSON despite exit code
-          if not (null stdout) && ("id" `T.isInfixOf` T.pack stdout || "{" `T.isPrefixOf` T.pack stdout)
+          if not (null stdout) && ("id" `T.isInfixOf` T.pack stdout || "{" `T.isPrefixOf` T.pack stdout || "[" `T.isPrefixOf` T.pack stdout)
             then pure $ Right $ T.pack stdout
             else pure $ Left $ "bd exited with code " <> T.pack (show code)
                              <> if config.bcQuiet then "" else ": " <> T.pack stderr
+
+
+-- | Convert BeadType to CLI argument.
+beadTypeToArg :: BeadType -> String
+beadTypeToArg TypeTask         = "task"
+beadTypeToArg TypeBug          = "bug"
+beadTypeToArg TypeFeature      = "feature"
+beadTypeToArg TypeEpic         = "epic"
+beadTypeToArg TypeMergeRequest = "merge-request"
+beadTypeToArg TypeMessage      = "message"
+beadTypeToArg TypeMolecule     = "molecule"
+beadTypeToArg TypeAgent        = "agent"
+beadTypeToArg (TypeOther t)    = T.unpack t
+
+
+-- | Convert BeadStatus to CLI argument.
+beadStatusToArg :: BeadStatus -> String
+beadStatusToArg StatusOpen       = "open"
+beadStatusToArg StatusInProgress = "in_progress"
+beadStatusToArg StatusClosed     = "closed"
+beadStatusToArg StatusHooked     = "hooked"
+beadStatusToArg StatusBlocked    = "blocked"
+
+
+-- | Convert DependencyType to CLI argument prefix.
+depTypeToArg :: DependencyType -> String
+depTypeToArg DepParentChild = "parent-child"
+depTypeToArg DepBlocks      = "blocks"
+depTypeToArg DepDependsOn   = "depends-on"
+
+
+-- | Convert dependency tuple to CLI arguments for --deps.
+depToArg :: (Text, DependencyType) -> [String]
+depToArg (beadId, depType) = ["--deps", depTypeToArg depType <> ":" <> T.unpack beadId]


### PR DESCRIPTION
## Summary
- Add write operations to BD effect (createBead, updateBead, closeBead, reopenBead)
- Add label and dependency management (addLabel, removeLabel, addDep, removeDep)
- Add getChildren for parent-child hierarchy queries
- Update skill documentation with write patterns

## Test plan
- [x] All 39 tests pass (23 JSON + 5 mock + 6 read + 5 write)

🤖 Generated with [Claude Code](https://claude.com/claude-code)