### PR TITLE
feat(graphcli): Add runGraphCLIPure for wiring logic-only graphs to CLI

### DIFF
--- a/tidepool-core/test/CLIGraphSpec.hs
+++ b/tidepool-core/test/CLIGraphSpec.hs
@@ -32,8 +32,9 @@ import Tidepool.Graph.CLI
   ( deriveCLIParser
   , formatOutput
   , OutputFormat(..)
+  , runGraphCLIPure
   )
-import Tidepool.Graph.Execute (DispatchGoto(..))
+import Tidepool.Graph.Execute (runGraph)
 import Tidepool.Graph.Generic (GraphMode(..), type (:-), AsHandler)
 import Tidepool.Graph.Generic.Core (Entry)
 import Tidepool.Graph.Goto (gotoExit, Goto)
@@ -72,11 +73,20 @@ counterHandlers = CounterGraph
 
 -- | Execute the counter graph.
 --
--- Takes CounterInput and returns CounterOutput via GotoChoice dispatch.
+-- Uses runGraph which automatically finds the entry handler via FindEntryHandler
+-- and dispatches through the graph until Exit is reached.
 runCounterGraph :: CounterInput -> CounterOutput
-runCounterGraph input = run $ do
-  choice <- counterHandlers.cgCompute input
-  dispatchGoto counterHandlers choice
+runCounterGraph input = run $ runGraph counterHandlers input
+
+-- | Compile-time test that runGraphCLIPure type constraints resolve correctly.
+--
+-- This function is never called (prefixed with _), but if it compiles,
+-- it proves that the type machinery works for our CounterGraph.
+_counterCLI :: IO ()
+_counterCLI = runGraphCLIPure
+  "Counter graph CLI"
+  counterParser
+  counterHandlers
 
 -- ════════════════════════════════════════════════════════════════════════════
 -- CLI PARSER (TH-derived)


### PR DESCRIPTION
## Summary

- Adds `runGraphCLIPure` function that automatically wires graphs with empty effect stack `'[]` to CLI
- Uses `FindEntryHandler` type family to discover entry point, `DispatchGoto` for dispatch
- Simplifies E2E test to use `runGraph` instead of manual dispatch wiring
- Adds compile-time test validating the type machinery works

## Usage

```haskell
main = runGraphCLIPure
  "Counter graph CLI"
  $(deriveCLIParser ''CounterInput)
  counterHandlers
```

No manual `runGraph` or dispatch wiring needed - it's all derived from type constraints.

## Test plan

- [x] All 121 existing tests pass
- [x] Compile-time test (`_counterCLI`) validates type constraints resolve
- [x] Skill file updated with documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)