### PR TITLE
feat(graph): Add Backend and ClaudeCode annotations

### DIFF
--- a/tidepool-core/src/Tidepool/Graph.hs
+++ b/tidepool-core/src/Tidepool/Graph.hs
@@ -73,6 +73,18 @@ module Tidepool.Graph
   , Groups
   , Requires
   , Global
+  , Backend
+
+    -- * API Backend Types
+  , CloudflareAI
+  , NativeAnthropic
+
+    -- * ClaudeCode Annotation
+  , ClaudeCode
+  , ModelChoice(..)
+  , Haiku
+  , Sonnet
+  , Opus
 
     -- * The Goto Effect
   , Goto(..)
@@ -161,6 +173,12 @@ module Tidepool.Graph
   , GotosToTos
   , GetMemory
   , GetGlobal
+  , GetBackend
+  , GetClaudeCode
+  , HasClaudeCode
+
+    -- * Backend Compatibility Validation
+  , ClaudeCodeCFBackendError
 
     -- * Tools
   , ToolDef(..)


### PR DESCRIPTION
## Summary

Add support for API backend selection and Claude Code subprocess execution in the Graph DSL:

- **Backend annotation**: Graph-level selection between `CloudflareAI` and `NativeAnthropic` backends
- **ClaudeCode annotation**: Marks LLM nodes for execution via zellij-cc subprocess
  - Model selection: `Haiku`, `Sonnet`, `Opus`
  - Optional working directory for file access
- **Compile-time validation**: Using ClaudeCode with CloudflareAI produces a helpful type error

## Usage

```haskell
-- Graph with Native backend (allows ClaudeCode)
type MyGraph = Graph
  '[ Entry :~> BeadId
   , "work" := LLM :@ Needs '[BeadInfo] :@ Template WorkTpl :@ Schema Result
                   :@ ClaudeCode 'Sonnet ('Just "/path/to/worktree")
   , Exit :<~ Result
   ]
  :& Backend NativeAnthropic
```

## Files Changed

- `Types.hs`: Add Backend, ClaudeCode, ModelChoice types
- `Edges.hs`: Add GetBackend, GetClaudeCode, HasClaudeCode extraction
- `Validate.hs`: Add ClaudeCodeCFBackendError type error
- `Graph.hs`: Export new types
- `CLAUDE.md`: Document new annotations

## Test plan

- [x] `cabal build tidepool-core` compiles successfully

## Out of scope (future PRs)

- Executor implementation (zellij-cc integration)
- Handler variants for ClaudeCode nodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)