### PR TITLE
feat(github-executor): Add GitHub effect with gh CLI executor

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,6 +14,7 @@ packages:
     tidepool-native-gui/issue-executor
     tidepool-native-gui/lsp-executor
     tidepool-native-gui/bd-executor
+    tidepool-native-gui/github-executor
     tidepool-native-gui/claude-code-executor
     tidepool-native-gui/server
 

--- a/tidepool-core/src/Tidepool/Effects/GitHub.hs
+++ b/tidepool-core/src/Tidepool/Effects/GitHub.hs
@@ -1,97 +1,373 @@
 -- | GitHub integration effect
 --
--- = ⚠️  STUB IMPLEMENTATION - Not Yet Functional
+-- Provides typed access to GitHub issues and pull requests via the @gh@ CLI.
 --
--- This module provides type signatures for GitHub API integration
--- but all runner functions call @error@ at runtime.
---
--- __Intended use:__
---
--- * Type checking and effect composition
--- * Template for implementing real GitHub integration
---
--- __Not suitable for:__
---
--- * Production use
--- * Runtime execution (will crash with @error@)
---
--- == Implementation TODO
---
--- To make this functional, implement a real runner using the GitHub API:
+-- = Usage
 --
 -- @
--- runGitHubAPI :: GitHubToken -> Eff (GitHub : es) a -> Eff es a
--- runGitHubAPI token = interpret $ \\case
---   CreateIssue repo title body labels -> do
---     -- Call GitHub REST API
---     ...
---   ListIssues repo labels -> do
---     -- Call GitHub REST API
---     ...
+-- import Tidepool.Effects.GitHub
+-- import Tidepool.GitHub.Executor (runGitHubIO, defaultGitHubConfig)
+--
+-- main = runM $ runGitHubIO defaultGitHubConfig $ do
+--   issues <- listIssues (Repo "owner/repo") defaultIssueFilter
+--   prs <- listPullRequests (Repo "owner/repo") defaultPRFilter
+--   ...
 -- @
+--
+-- = Implementation
+--
+-- Read operations are implemented via the @gh@ CLI tool in
+-- @tidepool-github-executor@. Write operations (CreateIssue) remain stubbed.
 module Tidepool.Effects.GitHub
   ( -- * Effect
     GitHub(..)
   , createIssue
+  , getIssue
   , listIssues
+  , getPullRequest
+  , listPullRequests
+  , checkAuth
 
-    -- * Types
-  , IssueUrl(..)
+    -- * Types - Core
   , Repo(..)
-  , Label(..)
+  , Author(..)
+  , Comment(..)
+
+    -- * Types - Issues
   , Issue(..)
+  , IssueState(..)
+  , IssueFilter(..)
+  , defaultIssueFilter
+
+    -- * Types - Pull Requests
+  , PullRequest(..)
+  , PRState(..)
+  , PRFilter(..)
+  , defaultPRFilter
+  , Review(..)
+  , ReviewState(..)
+
+    -- * Types - Legacy (kept for compatibility)
+  , IssueUrl(..)
+  , Label(..)
 
     -- * Runner (stub)
   , runGitHubStub
   ) where
 
 import Data.Text (Text)
-import Data.Aeson (FromJSON, ToJSON)
+import qualified Data.Text
+import Data.Time (UTCTime)
+import Data.Aeson (FromJSON(..), ToJSON(..), withObject, withText, (.:), (.:?))
 import GHC.Generics (Generic)
 import Control.Monad.Freer (Eff, Member, send, interpret)
 
 import Tidepool.Effect (Log, logInfo)
 
--- Types
 
-newtype IssueUrl = IssueUrl { unIssueUrl :: Text }
-  deriving (Show, Eq, Generic)
-  deriving newtype (FromJSON, ToJSON)
+-- ════════════════════════════════════════════════════════════════════════════
+-- CORE TYPES
+-- ════════════════════════════════════════════════════════════════════════════
 
+-- | Repository identifier in "owner/repo" format.
 newtype Repo = Repo { unRepo :: Text }
   deriving (Show, Eq, Generic)
   deriving newtype (FromJSON, ToJSON)
 
+-- | GitHub user/author info.
+data Author = Author
+  { authorLogin :: Text
+  , authorName  :: Maybe Text
+  }
+  deriving (Show, Eq, Generic, ToJSON)
+
+instance FromJSON Author where
+  parseJSON = withObject "Author" $ \v ->
+    Author
+      <$> v .: "login"
+      <*> v .:? "name"
+
+-- | Comment on an issue or PR.
+data Comment = Comment
+  { commentAuthor    :: Author
+  , commentBody      :: Text
+  , commentCreatedAt :: UTCTime
+  }
+  deriving (Show, Eq, Generic, ToJSON)
+
+instance FromJSON Comment where
+  parseJSON = withObject "Comment" $ \v ->
+    Comment
+      <$> v .: "author"
+      <*> v .: "body"
+      <*> v .: "createdAt"
+
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- ISSUE TYPES
+-- ════════════════════════════════════════════════════════════════════════════
+
+-- | Issue state.
+data IssueState = IssueOpen | IssueClosed
+  deriving (Show, Eq, Generic, Enum, Bounded)
+
+instance ToJSON IssueState where
+  toJSON IssueOpen   = "OPEN"
+  toJSON IssueClosed = "CLOSED"
+
+instance FromJSON IssueState where
+  parseJSON = withText "IssueState" $ \case
+    "OPEN"   -> pure IssueOpen
+    "CLOSED" -> pure IssueClosed
+    t        -> fail $ "Unknown issue state: " ++ show t
+
+-- | GitHub issue.
+data Issue = Issue
+  { issueNumber   :: Int
+  , issueTitle    :: Text
+  , issueBody     :: Text
+  , issueAuthor   :: Author
+  , issueLabels   :: [Text]
+  , issueState    :: IssueState
+  , issueUrl      :: Text
+  , issueComments :: [Comment]
+  }
+  deriving (Show, Eq, Generic, ToJSON)
+
+instance FromJSON Issue where
+  parseJSON = withObject "Issue" $ \v -> do
+    labels <- v .: "labels"
+    labelNames <- mapM (.: "name") labels
+    Issue
+      <$> v .: "number"
+      <*> v .: "title"
+      <*> v .: "body"
+      <*> v .: "author"
+      <*> pure labelNames
+      <*> v .: "state"
+      <*> v .: "url"
+      <*> (v .:? "comments" >>= \case
+            Nothing -> pure []
+            Just cs -> pure cs)
+
+-- | Filter for listing issues.
+data IssueFilter = IssueFilter
+  { ifLabels :: [Text]
+  , ifState  :: Maybe IssueState
+  , ifLimit  :: Maybe Int
+  }
+  deriving (Show, Eq, Generic, ToJSON, FromJSON)
+
+-- | Default issue filter (no filtering, no limit).
+defaultIssueFilter :: IssueFilter
+defaultIssueFilter = IssueFilter [] Nothing Nothing
+
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- PULL REQUEST TYPES
+-- ════════════════════════════════════════════════════════════════════════════
+
+-- | Pull request state.
+data PRState = PROpen | PRClosed | PRMerged
+  deriving (Show, Eq, Generic, Enum, Bounded)
+
+instance ToJSON PRState where
+  toJSON PROpen   = "OPEN"
+  toJSON PRClosed = "CLOSED"
+  toJSON PRMerged = "MERGED"
+
+instance FromJSON PRState where
+  parseJSON = withText "PRState" $ \case
+    "OPEN"   -> pure PROpen
+    "CLOSED" -> pure PRClosed
+    "MERGED" -> pure PRMerged
+    t        -> fail $ "Unknown PR state: " ++ show t
+
+-- | Review state.
+data ReviewState
+  = ReviewPending
+  | ReviewCommented
+  | ReviewApproved
+  | ReviewChangesRequested
+  | ReviewDismissed
+  deriving (Show, Eq, Generic, Enum, Bounded)
+
+instance ToJSON ReviewState where
+  toJSON ReviewPending          = "PENDING"
+  toJSON ReviewCommented        = "COMMENTED"
+  toJSON ReviewApproved         = "APPROVED"
+  toJSON ReviewChangesRequested = "CHANGES_REQUESTED"
+  toJSON ReviewDismissed        = "DISMISSED"
+
+instance FromJSON ReviewState where
+  parseJSON = withText "ReviewState" $ \case
+    "PENDING"           -> pure ReviewPending
+    "COMMENTED"         -> pure ReviewCommented
+    "APPROVED"          -> pure ReviewApproved
+    "CHANGES_REQUESTED" -> pure ReviewChangesRequested
+    "DISMISSED"         -> pure ReviewDismissed
+    t                   -> fail $ "Unknown review state: " ++ show t
+
+-- | PR review.
+data Review = Review
+  { reviewAuthor :: Author
+  , reviewBody   :: Text
+  , reviewState  :: ReviewState
+  }
+  deriving (Show, Eq, Generic, ToJSON)
+
+instance FromJSON Review where
+  parseJSON = withObject "Review" $ \v ->
+    Review
+      <$> v .: "author"
+      <*> v .: "body"
+      <*> v .: "state"
+
+-- | GitHub pull request.
+data PullRequest = PullRequest
+  { prNumber      :: Int
+  , prTitle       :: Text
+  , prBody        :: Text
+  , prAuthor      :: Author
+  , prLabels      :: [Text]
+  , prState       :: PRState
+  , prUrl         :: Text
+  , prHeadRefName :: Text
+  , prBaseRefName :: Text
+  , prComments    :: [Comment]
+  , prReviews     :: [Review]
+  }
+  deriving (Show, Eq, Generic, ToJSON)
+
+instance FromJSON PullRequest where
+  parseJSON = withObject "PullRequest" $ \v -> do
+    labels <- v .: "labels"
+    labelNames <- mapM (.: "name") labels
+    PullRequest
+      <$> v .: "number"
+      <*> v .: "title"
+      <*> v .: "body"
+      <*> v .: "author"
+      <*> pure labelNames
+      <*> v .: "state"
+      <*> v .: "url"
+      <*> v .: "headRefName"
+      <*> v .: "baseRefName"
+      <*> (v .:? "comments" >>= \case
+            Nothing -> pure []
+            Just cs -> pure cs)
+      <*> (v .:? "reviews" >>= \case
+            Nothing -> pure []
+            Just rs -> pure rs)
+
+-- | Filter for listing pull requests.
+data PRFilter = PRFilter
+  { pfState :: Maybe PRState
+  , pfBase  :: Maybe Text
+  , pfLimit :: Maybe Int
+  }
+  deriving (Show, Eq, Generic, ToJSON, FromJSON)
+
+-- | Default PR filter (no filtering, no limit).
+defaultPRFilter :: PRFilter
+defaultPRFilter = PRFilter Nothing Nothing Nothing
+
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- LEGACY TYPES (kept for compatibility)
+-- ════════════════════════════════════════════════════════════════════════════
+
+-- | Issue URL (legacy, for CreateIssue return type).
+newtype IssueUrl = IssueUrl { unIssueUrl :: Text }
+  deriving (Show, Eq, Generic)
+  deriving newtype (FromJSON, ToJSON)
+
+-- | Label (legacy, for CreateIssue parameter).
 newtype Label = Label { unLabel :: Text }
   deriving (Show, Eq, Generic)
   deriving newtype (FromJSON, ToJSON)
 
-data Issue = Issue
-  { issueUrl    :: IssueUrl
-  , issueTitle  :: Text
-  , issueLabels :: [Label]
-  }
-  deriving (Show, Eq, Generic, FromJSON, ToJSON)
 
--- Effect
+-- ════════════════════════════════════════════════════════════════════════════
+-- EFFECT
+-- ════════════════════════════════════════════════════════════════════════════
 
 data GitHub r where
+  -- Legacy (stub - errors at runtime)
   CreateIssue :: Repo -> Text -> Text -> [Label] -> GitHub IssueUrl
-  ListIssues  :: Repo -> [Label] -> GitHub [Issue]
+
+  -- Issue operations
+  GetIssue    :: Repo -> Int -> Bool -> GitHub (Maybe Issue)
+    -- ^ Get issue by number. Bool = include comments.
+  ListIssues  :: Repo -> IssueFilter -> GitHub [Issue]
+    -- ^ List issues with filter.
+
+  -- Pull request operations
+  GetPullRequest    :: Repo -> Int -> Bool -> GitHub (Maybe PullRequest)
+    -- ^ Get PR by number. Bool = include comments and reviews.
+  ListPullRequests  :: Repo -> PRFilter -> GitHub [PullRequest]
+    -- ^ List PRs with filter.
+
+  -- Auth
+  CheckAuth :: GitHub Bool
+    -- ^ Check if gh CLI is authenticated.
+
+
+-- Smart constructors
 
 createIssue :: Member GitHub effs => Repo -> Text -> Text -> [Label] -> Eff effs IssueUrl
 createIssue repo title body labels = send (CreateIssue repo title body labels)
 
-listIssues :: Member GitHub effs => Repo -> [Label] -> Eff effs [Issue]
-listIssues repo labels = send (ListIssues repo labels)
+getIssue :: Member GitHub effs => Repo -> Int -> Bool -> Eff effs (Maybe Issue)
+getIssue repo number includeComments = send (GetIssue repo number includeComments)
 
--- Stub runner (errors on call)
+listIssues :: Member GitHub effs => Repo -> IssueFilter -> Eff effs [Issue]
+listIssues repo filt = send (ListIssues repo filt)
 
+getPullRequest :: Member GitHub effs => Repo -> Int -> Bool -> Eff effs (Maybe PullRequest)
+getPullRequest repo number includeDetails = send (GetPullRequest repo number includeDetails)
+
+listPullRequests :: Member GitHub effs => Repo -> PRFilter -> Eff effs [PullRequest]
+listPullRequests repo filt = send (ListPullRequests repo filt)
+
+checkAuth :: Member GitHub effs => Eff effs Bool
+checkAuth = send CheckAuth
+
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- STUB RUNNER
+-- ════════════════════════════════════════════════════════════════════════════
+
+-- | Stub runner that logs calls and errors on write operations.
+--
+-- Read operations return empty results; use @runGitHubIO@ from
+-- @tidepool-github-executor@ for real implementation.
 runGitHubStub :: Member Log effs => Eff (GitHub ': effs) a -> Eff effs a
 runGitHubStub = interpret $ \case
   CreateIssue (Repo repo) title _ _ -> do
     logInfo $ "[GitHub:stub] CreateIssue called: " <> repo <> " - " <> title
     error "GitHub.createIssue: not implemented"
+
+  GetIssue (Repo repo) num _ -> do
+    logInfo $ "[GitHub:stub] GetIssue called: " <> repo <> " #" <> showT num
+    pure Nothing
+
   ListIssues (Repo repo) _ -> do
     logInfo $ "[GitHub:stub] ListIssues called: " <> repo
-    error "GitHub.listIssues: not implemented"
+    pure []
+
+  GetPullRequest (Repo repo) num _ -> do
+    logInfo $ "[GitHub:stub] GetPullRequest called: " <> repo <> " #" <> showT num
+    pure Nothing
+
+  ListPullRequests (Repo repo) _ -> do
+    logInfo $ "[GitHub:stub] ListPullRequests called: " <> repo
+    pure []
+
+  CheckAuth -> do
+    logInfo "[GitHub:stub] CheckAuth called"
+    pure False
+
+  where
+    showT :: Show a => a -> Text
+    showT = Data.Text.pack . show

--- a/tidepool-native-gui/github-executor/src/Tidepool/GitHub/Executor.hs
+++ b/tidepool-native-gui/github-executor/src/Tidepool/GitHub/Executor.hs
@@ -1,0 +1,282 @@
+-- | GitHub effect executor - gh CLI client.
+--
+-- Implements GitHub effect by calling the gh CLI tool.
+-- Supports read operations for issues and pull requests.
+--
+-- = Usage
+--
+-- @
+-- import Tidepool.GitHub.Executor (runGitHubIO, defaultGitHubConfig)
+-- import Tidepool.Effects.GitHub
+--
+-- main = runM $ runGitHubIO defaultGitHubConfig $ do
+--   issues <- listIssues (Repo "owner/repo") defaultIssueFilter
+--   prs <- listPullRequests (Repo "owner/repo") defaultPRFilter
+--   ...
+-- @
+--
+-- = Requirements
+--
+-- Requires the @gh@ CLI tool to be installed and authenticated:
+--
+-- @
+-- gh auth login
+-- @
+module Tidepool.GitHub.Executor
+  ( -- * Executor
+    runGitHubIO
+
+    -- * Configuration
+  , GitHubConfig(..)
+  , defaultGitHubConfig
+
+    -- * Low-Level CLI Access
+  , ghIssueList
+  , ghIssueView
+  , ghPrList
+  , ghPrView
+  , ghAuthCheck
+  ) where
+
+import Control.Exception (try, SomeException)
+import Control.Monad (when, unless)
+import Control.Monad.Freer (Eff, LastMember, interpret, sendM)
+import Data.Aeson (eitherDecode)
+import Data.ByteString.Lazy qualified as LBS
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as TE
+import System.IO (hPutStrLn, stderr)
+import System.Process (readProcessWithExitCode)
+import System.Exit (ExitCode(..))
+
+import Tidepool.Effects.GitHub
+  ( GitHub(..)
+  , Issue(..)
+  , IssueFilter(..)
+  , IssueState(..)
+  , PullRequest(..)
+  , PRFilter(..)
+  , PRState(..)
+  , Repo(..)
+  , IssueUrl(..)
+  )
+
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- CONFIGURATION
+-- ════════════════════════════════════════════════════════════════════════════
+
+-- | Configuration for GitHub executor.
+data GitHubConfig = GitHubConfig
+  { ghcQuiet :: Bool
+    -- ^ Suppress stderr warnings from gh CLI.
+  }
+  deriving (Show, Eq)
+
+-- | Default configuration (suppress warnings).
+defaultGitHubConfig :: GitHubConfig
+defaultGitHubConfig = GitHubConfig
+  { ghcQuiet = True
+  }
+
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- EXECUTOR
+-- ════════════════════════════════════════════════════════════════════════════
+
+-- | Run GitHub effects using the gh CLI.
+--
+-- This interpreter shells out to the gh command for each operation.
+runGitHubIO :: LastMember IO effs => GitHubConfig -> Eff (GitHub ': effs) a -> Eff effs a
+runGitHubIO config = interpret $ \case
+  -- Legacy (stub - still errors)
+  CreateIssue (Repo repo) title _ _ -> do
+    sendM $ error $ "GitHub.createIssue: not implemented for " <> T.unpack repo <> " - " <> T.unpack title
+
+  -- Issue operations
+  GetIssue (Repo repo) num includeComments ->
+    sendM $ ghIssueView config repo num includeComments
+
+  ListIssues (Repo repo) filt ->
+    sendM $ ghIssueList config repo filt
+
+  -- PR operations
+  GetPullRequest (Repo repo) num includeDetails ->
+    sendM $ ghPrView config repo num includeDetails
+
+  ListPullRequests (Repo repo) filt ->
+    sendM $ ghPrList config repo filt
+
+  -- Auth
+  CheckAuth ->
+    sendM $ ghAuthCheck
+
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- CLI FUNCTIONS - ISSUES
+-- ════════════════════════════════════════════════════════════════════════════
+
+-- | List issues using gh CLI.
+ghIssueList :: GitHubConfig -> Text -> IssueFilter -> IO [Issue]
+ghIssueList config repo filt = do
+  let baseFields = "number,title,body,author,labels,state,url"
+      args = ["issue", "list", "--repo", T.unpack repo, "--json", baseFields]
+            ++ stateArgs filt.ifState
+            ++ labelArgs filt.ifLabels
+            ++ limitArgs filt.ifLimit
+
+  result <- runGhCommand config args
+  case result of
+    Left err -> do
+      logDebug config $ "ghIssueList: gh command failed: " <> T.unpack err
+      pure []
+    Right output ->
+      case eitherDecode (LBS.fromStrict $ TE.encodeUtf8 output) of
+        Right issues -> pure issues
+        Left decodeErr -> do
+          logDebug config $ "ghIssueList: JSON decode failed: " <> decodeErr
+          pure []
+
+  where
+    stateArgs Nothing           = []
+    stateArgs (Just IssueOpen)   = ["--state", "open"]
+    stateArgs (Just IssueClosed) = ["--state", "closed"]
+
+    labelArgs [] = []
+    labelArgs ls = concatMap (\l -> ["--label", T.unpack l]) ls
+
+    limitArgs Nothing  = []
+    limitArgs (Just n) = ["--limit", show n]
+
+
+-- | View a single issue using gh CLI.
+ghIssueView :: GitHubConfig -> Text -> Int -> Bool -> IO (Maybe Issue)
+ghIssueView config repo num includeComments = do
+  let baseFields = "number,title,body,author,labels,state,url"
+      fields = if includeComments then baseFields <> ",comments" else baseFields
+      args = ["issue", "view", show num, "--repo", T.unpack repo, "--json", fields]
+
+  result <- runGhCommand config args
+  case result of
+    Left err -> do
+      logDebug config $ "ghIssueView: gh command failed: " <> T.unpack err
+      pure Nothing
+    Right output
+      | T.null (T.strip output) -> pure Nothing
+      | otherwise ->
+          case eitherDecode (LBS.fromStrict $ TE.encodeUtf8 output) of
+            Right issue -> pure $ Just issue
+            Left decodeErr -> do
+              logDebug config $ "ghIssueView: JSON decode failed: " <> decodeErr
+              pure Nothing
+
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- CLI FUNCTIONS - PULL REQUESTS
+-- ════════════════════════════════════════════════════════════════════════════
+
+-- | List pull requests using gh CLI.
+ghPrList :: GitHubConfig -> Text -> PRFilter -> IO [PullRequest]
+ghPrList config repo filt = do
+  let baseFields = "number,title,body,author,labels,state,url,headRefName,baseRefName"
+      args = ["pr", "list", "--repo", T.unpack repo, "--json", baseFields]
+            ++ stateArgs filt.pfState
+            ++ baseArgs filt.pfBase
+            ++ limitArgs filt.pfLimit
+
+  result <- runGhCommand config args
+  case result of
+    Left err -> do
+      logDebug config $ "ghPrList: gh command failed: " <> T.unpack err
+      pure []
+    Right output ->
+      case eitherDecode (LBS.fromStrict $ TE.encodeUtf8 output) of
+        Right prs -> pure prs
+        Left decodeErr -> do
+          logDebug config $ "ghPrList: JSON decode failed: " <> decodeErr
+          pure []
+
+  where
+    stateArgs Nothing         = []
+    stateArgs (Just PROpen)   = ["--state", "open"]
+    stateArgs (Just PRClosed) = ["--state", "closed"]
+    stateArgs (Just PRMerged) = ["--state", "merged"]
+
+    baseArgs Nothing  = []
+    baseArgs (Just b) = ["--base", T.unpack b]
+
+    limitArgs Nothing  = []
+    limitArgs (Just n) = ["--limit", show n]
+
+
+-- | View a single pull request using gh CLI.
+ghPrView :: GitHubConfig -> Text -> Int -> Bool -> IO (Maybe PullRequest)
+ghPrView config repo num includeDetails = do
+  let baseFields = "number,title,body,author,labels,state,url,headRefName,baseRefName"
+      fields = if includeDetails
+               then baseFields <> ",comments,reviews"
+               else baseFields
+      args = ["pr", "view", show num, "--repo", T.unpack repo, "--json", fields]
+
+  result <- runGhCommand config args
+  case result of
+    Left err -> do
+      logDebug config $ "ghPrView: gh command failed: " <> T.unpack err
+      pure Nothing
+    Right output
+      | T.null (T.strip output) -> pure Nothing
+      | otherwise ->
+          case eitherDecode (LBS.fromStrict $ TE.encodeUtf8 output) of
+            Right pr -> pure $ Just pr
+            Left decodeErr -> do
+              logDebug config $ "ghPrView: JSON decode failed: " <> decodeErr
+              pure Nothing
+
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- CLI FUNCTIONS - AUTH
+-- ════════════════════════════════════════════════════════════════════════════
+
+-- | Check if gh CLI is authenticated.
+ghAuthCheck :: IO Bool
+ghAuthCheck = do
+  result <- try $ readProcessWithExitCode "gh" ["auth", "status"] ""
+  case result of
+    Left (_ :: SomeException) -> pure False
+    Right (exitCode, _, _) ->
+      case exitCode of
+        ExitSuccess   -> pure True
+        ExitFailure _ -> pure False
+
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- HELPERS
+-- ════════════════════════════════════════════════════════════════════════════
+
+-- | Run a gh command and return stdout or error.
+runGhCommand :: GitHubConfig -> [String] -> IO (Either Text Text)
+runGhCommand config args = do
+  result <- try $ readProcessWithExitCode "gh" args ""
+  case result of
+    Left (e :: SomeException) ->
+      pure $ Left $ "gh command failed: " <> T.pack (show e)
+
+    Right (exitCode, stdout, stderr) ->
+      case exitCode of
+        ExitSuccess -> pure $ Right $ T.pack stdout
+        ExitFailure code
+          -- gh returns non-zero for "not found" which is OK (return empty)
+          | "not found" `T.isInfixOf` T.toLower (T.pack stderr) ->
+              pure $ Right ""
+          -- Auth errors get special messaging
+          | "authentication" `T.isInfixOf` T.toLower (T.pack stderr) ->
+              pure $ Left $ "Not authenticated. Run: gh auth login"
+          | otherwise ->
+              pure $ Left $ "gh exited with code " <> T.pack (show code)
+                          <> if config.ghcQuiet then "" else ": " <> T.pack stderr
+
+
+-- | Log debug message to stderr when not in quiet mode.
+logDebug :: GitHubConfig -> String -> IO ()
+logDebug config msg = unless config.ghcQuiet $ hPutStrLn stderr msg

--- a/tidepool-native-gui/github-executor/test/Main.hs
+++ b/tidepool-native-gui/github-executor/test/Main.hs
@@ -1,0 +1,151 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+-- | Tests for GitHub executor JSON parsing.
+--
+-- These tests verify that we correctly parse the JSON output from gh CLI.
+module Main where
+
+import Data.Aeson (eitherDecode)
+import Data.ByteString.Lazy.Char8 qualified as LBS
+import Test.Hspec
+
+import Tidepool.Effects.GitHub
+
+
+main :: IO ()
+main = hspec $ do
+  describe "Issue JSON parsing" $ do
+    it "parses a minimal issue" $ do
+      let json = LBS.pack $ unlines
+            [ "{"
+            , "  \"number\": 123,"
+            , "  \"title\": \"Test issue\","
+            , "  \"body\": \"Issue body\","
+            , "  \"author\": { \"login\": \"testuser\", \"name\": \"Test User\" },"
+            , "  \"labels\": [],"
+            , "  \"state\": \"OPEN\","
+            , "  \"url\": \"https://github.com/owner/repo/issues/123\""
+            , "}"
+            ]
+      case eitherDecode json :: Either String Issue of
+        Left err -> expectationFailure $ "Failed to parse: " <> err
+        Right issue -> do
+          issue.issueNumber `shouldBe` 123
+          issue.issueTitle `shouldBe` "Test issue"
+          issue.issueAuthor.authorLogin `shouldBe` "testuser"
+          issue.issueState `shouldBe` IssueOpen
+
+    it "parses issue with labels" $ do
+      let json = LBS.pack $ unlines
+            [ "{"
+            , "  \"number\": 456,"
+            , "  \"title\": \"Bug report\","
+            , "  \"body\": \"Something broke\","
+            , "  \"author\": { \"login\": \"reporter\" },"
+            , "  \"labels\": ["
+            , "    { \"name\": \"bug\", \"color\": \"d73a4a\" },"
+            , "    { \"name\": \"priority:high\", \"color\": \"ff0000\" }"
+            , "  ],"
+            , "  \"state\": \"CLOSED\","
+            , "  \"url\": \"https://github.com/owner/repo/issues/456\""
+            , "}"
+            ]
+      case eitherDecode json :: Either String Issue of
+        Left err -> expectationFailure $ "Failed to parse: " <> err
+        Right issue -> do
+          issue.issueLabels `shouldBe` ["bug", "priority:high"]
+          issue.issueState `shouldBe` IssueClosed
+
+    it "parses issue with comments" $ do
+      let json = LBS.pack $ unlines
+            [ "{"
+            , "  \"number\": 789,"
+            , "  \"title\": \"With comments\","
+            , "  \"body\": \"Body\","
+            , "  \"author\": { \"login\": \"author\" },"
+            , "  \"labels\": [],"
+            , "  \"state\": \"OPEN\","
+            , "  \"url\": \"https://github.com/owner/repo/issues/789\","
+            , "  \"comments\": ["
+            , "    {"
+            , "      \"author\": { \"login\": \"commenter\" },"
+            , "      \"body\": \"First comment\","
+            , "      \"createdAt\": \"2024-01-15T10:30:00Z\""
+            , "    }"
+            , "  ]"
+            , "}"
+            ]
+      case eitherDecode json :: Either String Issue of
+        Left err -> expectationFailure $ "Failed to parse: " <> err
+        Right issue -> do
+          length issue.issueComments `shouldBe` 1
+          (head issue.issueComments).commentAuthor.authorLogin `shouldBe` "commenter"
+
+  describe "PullRequest JSON parsing" $ do
+    it "parses a minimal PR" $ do
+      let json = LBS.pack $ unlines
+            [ "{"
+            , "  \"number\": 100,"
+            , "  \"title\": \"Add feature\","
+            , "  \"body\": \"PR body\","
+            , "  \"author\": { \"login\": \"contributor\" },"
+            , "  \"labels\": [],"
+            , "  \"state\": \"OPEN\","
+            , "  \"url\": \"https://github.com/owner/repo/pull/100\","
+            , "  \"headRefName\": \"feature-branch\","
+            , "  \"baseRefName\": \"main\""
+            , "}"
+            ]
+      case eitherDecode json :: Either String PullRequest of
+        Left err -> expectationFailure $ "Failed to parse: " <> err
+        Right pr -> do
+          pr.prNumber `shouldBe` 100
+          pr.prHeadRefName `shouldBe` "feature-branch"
+          pr.prBaseRefName `shouldBe` "main"
+          pr.prState `shouldBe` PROpen
+
+    it "parses PR with reviews" $ do
+      let json = LBS.pack $ unlines
+            [ "{"
+            , "  \"number\": 200,"
+            , "  \"title\": \"Reviewed PR\","
+            , "  \"body\": \"Body\","
+            , "  \"author\": { \"login\": \"author\" },"
+            , "  \"labels\": [],"
+            , "  \"state\": \"MERGED\","
+            , "  \"url\": \"https://github.com/owner/repo/pull/200\","
+            , "  \"headRefName\": \"fix\","
+            , "  \"baseRefName\": \"main\","
+            , "  \"reviews\": ["
+            , "    {"
+            , "      \"author\": { \"login\": \"reviewer\" },"
+            , "      \"body\": \"LGTM\","
+            , "      \"state\": \"APPROVED\""
+            , "    }"
+            , "  ]"
+            , "}"
+            ]
+      case eitherDecode json :: Either String PullRequest of
+        Left err -> expectationFailure $ "Failed to parse: " <> err
+        Right pr -> do
+          pr.prState `shouldBe` PRMerged
+          length pr.prReviews `shouldBe` 1
+          (head pr.prReviews).reviewState `shouldBe` ReviewApproved
+
+  describe "Author JSON parsing" $ do
+    it "parses author with name" $ do
+      let json = "{ \"login\": \"user\", \"name\": \"Full Name\" }"
+      case eitherDecode json :: Either String Author of
+        Left err -> expectationFailure $ "Failed to parse: " <> err
+        Right author -> do
+          author.authorLogin `shouldBe` "user"
+          author.authorName `shouldBe` Just "Full Name"
+
+    it "parses author without name" $ do
+      let json = "{ \"login\": \"bot\" }"
+      case eitherDecode json :: Either String Author of
+        Left err -> expectationFailure $ "Failed to parse: " <> err
+        Right author -> do
+          author.authorLogin `shouldBe` "bot"
+          author.authorName `shouldBe` Nothing

--- a/tidepool-native-gui/github-executor/tidepool-github-executor.cabal
+++ b/tidepool-native-gui/github-executor/tidepool-github-executor.cabal
@@ -1,0 +1,54 @@
+cabal-version:      3.0
+name:               tidepool-github-executor
+version:            0.1.0.0
+synopsis:           GitHub effect executor - gh CLI client
+description:
+    Implements GitHub effect by calling the gh CLI tool.
+    .
+    Enables graphs to query GitHub issues, pull requests, comments, and reviews
+    for context construction in agent templates.
+license:            MIT
+author:             Inanna
+build-type:         Simple
+
+library
+    exposed-modules:
+        Tidepool.GitHub.Executor
+    build-depends:
+        base >= 4.17 && < 5,
+        freer-simple >= 1.2 && < 2,
+        text >= 2.0 && < 3,
+        aeson >= 2.1 && < 3,
+        bytestring >= 0.11 && < 1,
+        process >= 1.6 && < 2,
+        time >= 1.12 && < 2,
+        tidepool-core
+    hs-source-dirs:   src
+    default-language: GHC2021
+    default-extensions:
+        DataKinds
+        DeriveAnyClass
+        DeriveGeneric
+        DerivingStrategies
+        GADTs
+        LambdaCase
+        OverloadedStrings
+        OverloadedRecordDot
+        TypeFamilies
+        TypeOperators
+
+test-suite github-executor-test
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    default-language: GHC2021
+    default-extensions:
+        OverloadedStrings
+        OverloadedRecordDot
+    build-depends:
+        base >= 4.17 && < 5,
+        tidepool-core,
+        aeson >= 2.1 && < 3,
+        bytestring >= 0.11 && < 1,
+        hspec >= 2.10 && < 3
+    ghc-options:      -threaded -rtsopts -with-rtsopts=-N


### PR DESCRIPTION
## Summary

- Extend GitHub effect with read capabilities for issues and PRs via `gh` CLI
- Add new executor package `tidepool-github-executor` following the BD executor pattern
- New types: `Author`, `Comment`, `Issue`, `PullRequest`, `Review`, filter types
- New operations: `GetIssue`, `ListIssues`, `GetPullRequest`, `ListPullRequests`, `CheckAuth`

## Usage

```haskell
import Tidepool.Effects.GitHub
import Tidepool.GitHub.Executor (runGitHubIO, defaultGitHubConfig)

-- List issues
issues <- listIssues (Repo "owner/repo") defaultIssueFilter { ifLabels = ["bug"], ifLimit = Just 10 }

-- Get PR with comments and reviews
pr <- getPullRequest (Repo "owner/repo") 123 True
```

## Test plan

- [x] Tested `ghAuthCheck` - returns `True` when authenticated
- [x] Tested `ghIssueList` - correctly lists issues with filters
- [x] Tested `ghPrList` - correctly lists PRs with filters  
- [x] Tested `ghIssueView` with comments - correctly parses comments and authors
- [x] Tested `ghPrView` - correctly returns PR details
- [x] Build passes for `tidepool-core` and `tidepool-github-executor`

🤖 Generated with [Claude Code](https://claude.com/claude-code)