### PR TITLE
feat(devlog): Add session-scoped dev logging for debugging agents

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -16,6 +16,7 @@ packages:
     tidepool-native-gui/bd-executor
     tidepool-native-gui/github-executor
     tidepool-native-gui/claude-code-executor
+    tidepool-native-gui/devlog-executor
     tidepool-native-gui/server
 
     -- Tooling packages (Agent 8)

--- a/tidepool-core/src/Tidepool/Effect.hs
+++ b/tidepool-core/src/Tidepool/Effect.hs
@@ -6,6 +6,9 @@
 module Tidepool.Effect
   ( -- * Effect Stacks
     module Tidepool.Effect.Types
+    -- * DevLog
+  , module Tidepool.Effect.DevLog
   ) where
 
 import Tidepool.Effect.Types
+import Tidepool.Effect.DevLog

--- a/tidepool-core/src/Tidepool/Effect/DevLog.hs
+++ b/tidepool-core/src/Tidepool/Effect/DevLog.hs
@@ -1,0 +1,211 @@
+{-# LANGUAGE StrictData #-}
+
+-- | Development logging effect for LLM-friendly debugging.
+--
+-- Separate from 'Log' (internal) and 'Observability' (Loki/production).
+-- Designed for greppable, session-scoped log files during local development.
+--
+-- == Log Format
+--
+-- @
+-- ═══ SESSION f47ac10b ═══════════════════════════════════════════════
+-- [12:00:00.000] CONNECT ws://localhost:8080
+--
+-- [12:00:00.050] GRAPH entry → resumeRouter
+--   input: PlayerInput { piActionText = "attack" }
+--
+-- [12:00:00.051] STATE.mood: MoodScene Encounter (unchanged)
+-- [12:00:00.051] STATE.dicePool: [4,4,3]
+--
+-- [12:00:00.100] LLM.REQUEST dm_scene
+--   model: claude-sonnet-4-20250514
+--   tokens: 1,847 prompt
+--   tools: [engage, end_scene]
+-- @
+--
+-- == Greppable Patterns
+--
+-- @
+-- grep "GRAPH" latest.log        # Transitions
+-- grep "STATE\\." latest.log     # State changes
+-- grep "LLM\\." latest.log       # LLM calls
+-- grep "ERROR" latest.log        # Errors
+-- @
+module Tidepool.Effect.DevLog
+  ( -- * Effect
+    DevLog (..)
+
+    -- * Smart Constructors
+  , devLogGraph
+  , devLogState
+  , devLogLLMRequest
+  , devLogLLMResponse
+  , devLogError
+  , devLogRaw
+
+    -- * Event Types
+  , DevLogEvent (..)
+  , GraphTransitionInfo (..)
+  , StateSnapshotInfo (..)
+  , LLMRequestInfo (..)
+  , LLMResponseInfo (..)
+  , ErrorContextInfo (..)
+
+    -- * Configuration
+  , Verbosity (..)
+
+    -- * Runners
+  , runDevLogPure
+  ) where
+
+import Control.Monad.Freer (Eff, Member, interpret, send)
+import Data.Aeson (ToJSON (..), Value)
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+-- | Verbosity levels for filtering log output.
+--
+-- Higher levels include all lower level output.
+data Verbosity
+  = VQuiet    -- ^ Errors only
+  | VNormal   -- ^ Transitions, state deltas, LLM summaries (default)
+  | VVerbose  -- ^ Full LLM prompts/responses
+  | VTrace    -- ^ Handler internal decisions
+  deriving (Eq, Ord, Show, Enum, Bounded, Generic)
+
+instance ToJSON Verbosity
+
+-- | Core DevLog effect.
+--
+-- Single operation to emit any event type. The interpreter
+-- filters based on verbosity and formats for output.
+data DevLog r where
+  LogDevEvent :: DevLogEvent -> DevLog ()
+
+-- | All DevLog event variants.
+--
+-- Each event carries its minimum verbosity level.
+data DevLogEvent
+  = EventGraph      Verbosity GraphTransitionInfo
+  | EventState      Verbosity StateSnapshotInfo
+  | EventLLMRequest Verbosity LLMRequestInfo
+  | EventLLMResponse Verbosity LLMResponseInfo
+  | EventError      ErrorContextInfo  -- Always emitted (VQuiet)
+  | EventRaw        Verbosity Text
+  deriving (Show, Generic)
+
+instance ToJSON DevLogEvent
+
+-- | Graph transition info.
+--
+-- Logged automatically by instrumented dispatch.
+-- Timestamps are added by the executor, not the caller.
+data GraphTransitionInfo = GraphTransitionInfo
+  { gtiFromNode :: Text
+  , gtiToNode   :: Text
+  , gtiPayload  :: Value    -- ^ Input to next handler (JSON-encoded)
+  }
+  deriving (Show, Generic)
+
+instance ToJSON GraphTransitionInfo
+
+-- | State snapshot with diff info.
+--
+-- Logged after each transition for changed fields.
+data StateSnapshotInfo = StateSnapshotInfo
+  { ssiField   :: Text   -- ^ e.g., "mood", "dicePool"
+  , ssiBefore  :: Value
+  , ssiAfter   :: Value
+  , ssiChanged :: Bool   -- ^ Quick check for "(unchanged)"
+  }
+  deriving (Show, Generic)
+
+instance ToJSON StateSnapshotInfo
+
+-- | LLM request info.
+--
+-- At VNormal: metadata only (model, tokens, tools).
+-- At VVerbose: includes full prompts.
+-- Timestamps are added by the executor, not the caller.
+data LLMRequestInfo = LLMRequestInfo
+  { lriNodeName     :: Text
+  , lriModel        :: Text
+  , lriPromptTokens :: Int
+  , lriTools        :: [Text]  -- ^ Tool names available
+  -- Full content (only at VVerbose)
+  , lriSystemPrompt :: Maybe Text
+  , lriUserPrompt   :: Maybe Text
+  }
+  deriving (Show, Generic)
+
+instance ToJSON LLMRequestInfo
+
+-- | LLM response info.
+-- Timestamps are added by the executor, not the caller.
+data LLMResponseInfo = LLMResponseInfo
+  { lroNodeName         :: Text
+  , lroCompletionTokens :: Int
+  , lroToolCalls        :: Int
+  , lroLatencyMs        :: Int
+  -- Full content (only at VVerbose)
+  , lroResponse         :: Maybe Text
+  }
+  deriving (Show, Generic)
+
+instance ToJSON LLMResponseInfo
+
+-- | Error context for debugging.
+--
+-- Includes state snapshot and last LLM call for context.
+data ErrorContextInfo = ErrorContextInfo
+  { eciMessage     :: Text
+  , eciNode        :: Maybe Text
+  , eciState       :: Value        -- ^ Current state snapshot
+  , eciTransitions :: [(Text, Text)]  -- ^ Last N transitions (from, to)
+  , eciLastLLM     :: Maybe LLMResponseInfo
+  , eciStackTrace  :: Maybe Text
+  }
+  deriving (Show, Generic)
+
+instance ToJSON ErrorContextInfo
+
+-- ══════════════════════════════════════════════════════════════
+-- SMART CONSTRUCTORS
+-- ══════════════════════════════════════════════════════════════
+
+-- | Log a graph transition (auto-instrumented).
+devLogGraph :: Member DevLog effs => GraphTransitionInfo -> Eff effs ()
+devLogGraph = send . LogDevEvent . EventGraph VNormal
+
+-- | Log a state field change.
+devLogState :: Member DevLog effs => StateSnapshotInfo -> Eff effs ()
+devLogState = send . LogDevEvent . EventState VNormal
+
+-- | Log an LLM request.
+--
+-- Pass 'VNormal' for metadata only, 'VVerbose' to include prompts.
+devLogLLMRequest :: Member DevLog effs => Verbosity -> LLMRequestInfo -> Eff effs ()
+devLogLLMRequest v = send . LogDevEvent . EventLLMRequest v
+
+-- | Log an LLM response.
+devLogLLMResponse :: Member DevLog effs => Verbosity -> LLMResponseInfo -> Eff effs ()
+devLogLLMResponse v = send . LogDevEvent . EventLLMResponse v
+
+-- | Log an error with context.
+devLogError :: Member DevLog effs => ErrorContextInfo -> Eff effs ()
+devLogError = send . LogDevEvent . EventError
+
+-- | Log a raw message at specified verbosity.
+devLogRaw :: Member DevLog effs => Verbosity -> Text -> Eff effs ()
+devLogRaw v = send . LogDevEvent . EventRaw v
+
+-- ══════════════════════════════════════════════════════════════
+-- RUNNERS
+-- ══════════════════════════════════════════════════════════════
+
+-- | Pure runner that discards all events.
+--
+-- Use for tests or when DevLog is in the effect stack but not needed.
+runDevLogPure :: Eff (DevLog ': effs) a -> Eff effs a
+runDevLogPure = interpret $ \case
+  LogDevEvent _ -> pure ()

--- a/tidepool-core/tidepool-core.cabal
+++ b/tidepool-core/tidepool-core.cabal
@@ -17,6 +17,7 @@ library
         Tidepool.Platform
         Tidepool.Effect
         Tidepool.Effect.LSP
+        Tidepool.Effect.DevLog
         Tidepool.Effect.Metadata
         Tidepool.Effect.Types
         Tidepool.Graph
@@ -27,6 +28,7 @@ library
         Tidepool.Graph.Goto.Internal
         Tidepool.Graph.Errors
         Tidepool.Graph.Execute
+        Tidepool.Graph.Execute.Instrumented
         Tidepool.Graph.Edges
         Tidepool.Graph.Validate
         Tidepool.Graph.Validate.RecordStructure

--- a/tidepool-native-gui/devlog-executor/src/Tidepool/DevLog/Config.hs
+++ b/tidepool-native-gui/devlog-executor/src/Tidepool/DevLog/Config.hs
@@ -1,0 +1,48 @@
+-- | Configuration types for DevLog executor.
+module Tidepool.DevLog.Config
+  ( DevLogConfig (..)
+  , DevLogOutput (..)
+  , defaultDevLogConfig
+  ) where
+
+import Data.Text (Text)
+import Data.UUID (UUID)
+import GHC.Generics (Generic)
+
+import Tidepool.Effect.DevLog (Verbosity (..))
+
+-- | Where to send log output.
+data DevLogOutput
+  = OutputStderr            -- ^ Write to stderr (for quick debugging)
+  | OutputFile FilePath     -- ^ Write to session-scoped file in directory
+  | OutputBoth FilePath     -- ^ Write to both stderr and file
+  deriving (Show, Eq, Generic)
+
+-- | DevLog executor configuration.
+data DevLogConfig = DevLogConfig
+  { dcVerbosity     :: Verbosity
+    -- ^ Minimum verbosity level to emit
+
+  , dcOutput        :: DevLogOutput
+    -- ^ Where to write logs
+
+  , dcSymlinkLatest :: Bool
+    -- ^ Create latest.log symlink (only for file output)
+
+  , dcSessionId     :: Maybe UUID
+    -- ^ Override session ID (auto-generated if Nothing)
+
+  , dcSessionName   :: Maybe Text
+    -- ^ Optional session name for log header
+  }
+  deriving (Show, Eq, Generic)
+
+-- | Default configuration: Normal verbosity, stderr output.
+defaultDevLogConfig :: DevLogConfig
+defaultDevLogConfig = DevLogConfig
+  { dcVerbosity     = VNormal
+  , dcOutput        = OutputStderr
+  , dcSymlinkLatest = False
+  , dcSessionId     = Nothing
+  , dcSessionName   = Nothing
+  }

--- a/tidepool-native-gui/devlog-executor/src/Tidepool/DevLog/Executor.hs
+++ b/tidepool-native-gui/devlog-executor/src/Tidepool/DevLog/Executor.hs
@@ -1,0 +1,163 @@
+-- | DevLog effect executor - session-scoped file logging.
+--
+-- = Usage
+--
+-- @
+-- import Tidepool.Effect.DevLog
+-- import Tidepool.DevLog.Executor
+-- import Tidepool.DevLog.Config
+--
+-- main :: IO ()
+-- main = do
+--   let config = defaultDevLogConfig
+--         { dcOutput = OutputFile "./logs"
+--         , dcSymlinkLatest = True
+--         }
+--   runM $ runDevLog config $ do
+--     devLogGraph GraphTransitionInfo { ... }
+--     devLogLLMRequest VNormal LLMRequestInfo { ... }
+-- @
+--
+-- = Greppable Patterns
+--
+-- @
+-- grep "GRAPH" logs/latest.log        # All graph transitions
+-- grep "STATE\\." logs/latest.log     # All state changes
+-- grep "LLM\\." logs/latest.log       # All LLM calls
+-- grep "ERROR" logs/latest.log        # All errors
+-- grep "→ bargain" logs/latest.log    # Transitions to specific node
+-- @
+module Tidepool.DevLog.Executor
+  ( -- * Executor
+    runDevLog
+  , runDevLogWithHandle
+
+    -- * Re-exports
+  , module Tidepool.DevLog.Config
+  ) where
+
+import Control.Monad (when)
+import Control.Monad.Freer (Eff, LastMember, interpret, sendM)
+import Data.IORef (IORef, newIORef, readIORef, modifyIORef')
+import Data.Text (Text)
+import qualified Data.Text.IO as TIO
+import Data.Time (getCurrentTime)
+import Data.UUID (UUID)
+import qualified Data.UUID.V4 as UUID
+import System.Directory (createDirectoryIfMissing, removeFile)
+import System.FilePath ((</>))
+import System.IO (Handle, hPutStrLn, stderr, openFile, IOMode(..), hFlush, hClose)
+import System.Posix.Files (createSymbolicLink)
+import Control.Exception (catch, SomeException)
+
+import Tidepool.Effect.DevLog
+import Tidepool.DevLog.Config
+import Tidepool.DevLog.Formatter
+
+-- | Run DevLog effect with the given configuration.
+--
+-- Creates session-scoped log file if configured, writes header,
+-- filters events by verbosity, and formats output.
+runDevLog :: LastMember IO effs => DevLogConfig -> Eff (DevLog ': effs) a -> Eff effs a
+runDevLog config action = do
+  -- Generate session ID
+  sessionId <- sendM $ maybe UUID.nextRandom pure config.dcSessionId
+  now <- sendM getCurrentTime
+
+  case config.dcOutput of
+    OutputStderr -> do
+      sendM $ TIO.hPutStr stderr $ formatSessionHeader sessionId config.dcSessionName now
+      runDevLogWithHandle config stderr action
+
+    OutputFile logDir -> do
+      (handle, sessionFile) <- sendM $ openSessionFile logDir sessionId
+      sendM $ TIO.hPutStr handle $ formatSessionHeader sessionId config.dcSessionName now
+      result <- runDevLogWithHandle config handle action
+      sendM $ do
+        hClose handle
+        when config.dcSymlinkLatest $
+          createLatestSymlink logDir sessionFile
+      pure result
+
+    OutputBoth logDir -> do
+      (handle, sessionFile) <- sendM $ openSessionFile logDir sessionId
+      let header = formatSessionHeader sessionId config.dcSessionName now
+      sendM $ do
+        TIO.hPutStr stderr header
+        TIO.hPutStr handle header
+      result <- runDevLogWithHandleBoth config stderr handle action
+      sendM $ do
+        hClose handle
+        when config.dcSymlinkLatest $
+          createLatestSymlink logDir sessionFile
+      pure result
+
+-- | Core interpreter that writes to a handle.
+runDevLogWithHandle
+  :: LastMember IO effs
+  => DevLogConfig
+  -> Handle
+  -> Eff (DevLog ': effs) a
+  -> Eff effs a
+runDevLogWithHandle config handle = interpret $ \case
+  LogDevEvent event ->
+    when (eventVerbosity event >= config.dcVerbosity) $ sendM $ do
+      now <- getCurrentTime
+      let formatted = formatEvent now event
+      TIO.hPutStrLn handle formatted
+      hFlush handle
+
+-- | Interpreter that writes to both stderr and file.
+runDevLogWithHandleBoth
+  :: LastMember IO effs
+  => DevLogConfig
+  -> Handle  -- stderr
+  -> Handle  -- file
+  -> Eff (DevLog ': effs) a
+  -> Eff effs a
+runDevLogWithHandleBoth config stderrH fileH = interpret $ \case
+  LogDevEvent event ->
+    when (eventVerbosity event >= config.dcVerbosity) $ sendM $ do
+      now <- getCurrentTime
+      let formatted = formatEvent now event
+      TIO.hPutStrLn stderrH formatted
+      TIO.hPutStrLn fileH formatted
+      hFlush stderrH
+      hFlush fileH
+
+-- | Extract verbosity requirement from event.
+eventVerbosity :: DevLogEvent -> Verbosity
+eventVerbosity = \case
+  EventGraph v _      -> v
+  EventState v _      -> v
+  EventLLMRequest v _ -> v
+  EventLLMResponse v _ -> v
+  EventError _        -> VQuiet  -- Always emit errors
+  EventRaw v _        -> v
+
+-- | Open a new session log file.
+openSessionFile :: FilePath -> UUID -> IO (Handle, FilePath)
+openSessionFile logDir sessionId = do
+  createDirectoryIfMissing True logDir
+  now <- getCurrentTime
+  let filename = formatSessionFilename sessionId now
+      sessionFile = logDir </> filename
+  handle <- openFile sessionFile WriteMode
+  pure (handle, sessionFile)
+
+-- | Format session filename: session-{uuid8}-{timestamp}.log
+formatSessionFilename :: UUID -> a -> FilePath
+formatSessionFilename sessionId _ =
+  "session-" <> take 8 (show sessionId) <> ".log"
+
+-- | Create latest.log symlink.
+createLatestSymlink :: FilePath -> FilePath -> IO ()
+createLatestSymlink logDir sessionFile = do
+  let latestLink = logDir </> "latest.log"
+  -- Remove existing symlink if present
+  removeFile latestLink `catch` \(_ :: SomeException) -> pure ()
+  -- Create relative symlink
+  let target = takeFileName' sessionFile
+  createSymbolicLink target latestLink
+  where
+    takeFileName' = reverse . takeWhile (/= '/') . reverse

--- a/tidepool-native-gui/devlog-executor/src/Tidepool/DevLog/Formatter.hs
+++ b/tidepool-native-gui/devlog-executor/src/Tidepool/DevLog/Formatter.hs
@@ -1,0 +1,125 @@
+-- | Log line formatting for DevLog.
+--
+-- Produces greppable output like:
+--
+-- @
+-- [12:00:00.050] GRAPH entry → resumeRouter
+--   input: PlayerInput { piActionText = "attack" }
+--
+-- [12:00:00.051] STATE.mood: MoodScene Encounter (unchanged)
+--
+-- [12:00:00.100] LLM.REQUEST dm_scene
+--   model: claude-sonnet-4-20250514
+--   tokens: 1,847 prompt
+--   tools: [engage, end_scene]
+-- @
+module Tidepool.DevLog.Formatter
+  ( formatEvent
+  , formatSessionHeader
+  , formatTimestamp
+  , compactJSON
+  ) where
+
+import Data.Aeson (Value, encode)
+import Data.Maybe (catMaybes)
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Lazy as TL
+import qualified Data.Text.Lazy.Encoding as TLE
+import Data.Time (UTCTime, formatTime, defaultTimeLocale)
+import Data.UUID (UUID)
+import qualified Data.UUID as UUID
+
+import Tidepool.Effect.DevLog
+
+-- | Format a DevLog event as a log line.
+--
+-- The current time is passed in so the executor can add timestamps.
+formatEvent :: UTCTime -> DevLogEvent -> Text
+formatEvent now = \case
+  EventGraph _ info      -> formatGraphTransition now info
+  EventState _ info      -> formatStateSnapshot now info
+  EventLLMRequest _ info -> formatLLMRequest now info
+  EventLLMResponse _ info -> formatLLMResponse now info
+  EventError info        -> formatError now info
+  EventRaw _ msg         -> "[" <> formatTimestamp now <> "] " <> msg
+
+-- | Format a graph transition.
+formatGraphTransition :: UTCTime -> GraphTransitionInfo -> Text
+formatGraphTransition now info = T.unlines
+  [ "[" <> formatTimestamp now <> "] GRAPH " <> info.gtiFromNode <> " → " <> info.gtiToNode
+  , "  input: " <> compactJSON info.gtiPayload
+  ]
+
+-- | Format a state snapshot/diff.
+formatStateSnapshot :: UTCTime -> StateSnapshotInfo -> Text
+formatStateSnapshot now info =
+  "[" <> formatTimestamp now <> "] STATE." <> info.ssiField <> ": "
+  <> compactJSON info.ssiBefore
+  <> if info.ssiChanged
+       then " → " <> compactJSON info.ssiAfter
+       else " (unchanged)"
+
+-- | Format an LLM request.
+formatLLMRequest :: UTCTime -> LLMRequestInfo -> Text
+formatLLMRequest now info = T.unlines $ catMaybes
+  [ Just $ "[" <> formatTimestamp now <> "] LLM.REQUEST " <> info.lriNodeName
+  , Just $ "  model: " <> info.lriModel
+  , Just $ "  tokens: " <> T.pack (show info.lriPromptTokens) <> " prompt"
+  , Just $ "  tools: [" <> T.intercalate ", " info.lriTools <> "]"
+  , info.lriSystemPrompt >>= \p -> Just $ formatPromptSection "SYSTEM" p
+  , info.lriUserPrompt >>= \p -> Just $ formatPromptSection "USER" p
+  ]
+
+-- | Format an LLM response.
+formatLLMResponse :: UTCTime -> LLMResponseInfo -> Text
+formatLLMResponse now info = T.unlines $ catMaybes
+  [ Just $ "[" <> formatTimestamp now <> "] LLM.RESPONSE " <> info.lroNodeName
+         <> " (" <> T.pack (show info.lroLatencyMs) <> "ms)"
+  , Just $ "  tokens: " <> T.pack (show info.lroCompletionTokens) <> " completion"
+  , Just $ "  tool_calls: " <> T.pack (show info.lroToolCalls)
+  , info.lroResponse >>= \r -> Just $ formatPromptSection "RESPONSE" r
+  ]
+
+-- | Format an error with context.
+formatError :: UTCTime -> ErrorContextInfo -> Text
+formatError _now info = T.unlines $ catMaybes
+  [ Just "═══ ERROR DUMP ═══════════════════════════════════════════════════"
+  , Just $ "Exception: " <> info.eciMessage
+  , info.eciNode >>= \n -> Just $ "Node: " <> n
+  , Just ""
+  , Just "── Last transitions ──"
+  , Just $ T.unlines $ map (\(f, t) -> "  " <> f <> " → " <> t) info.eciTransitions
+  , Just ""
+  , Just "── Current state ──"
+  , Just $ compactJSON info.eciState
+  , info.eciStackTrace >>= \st -> Just $ "\n── Stack trace ──\n" <> st
+  , Just "═══════════════════════════════════════════════════════════════════"
+  ]
+
+-- | Format a prompt section with delimiters.
+formatPromptSection :: Text -> Text -> Text
+formatPromptSection label content = T.unlines
+  [ "  ───" <> label <> "───"
+  , T.unlines $ map ("  " <>) $ T.lines content
+  , "  ───/" <> label <> "───"
+  ]
+
+-- | Format session header.
+formatSessionHeader :: UUID -> Maybe Text -> UTCTime -> Text
+formatSessionHeader sessionId mName now = T.unlines
+  [ "═══ SESSION " <> shortUUID sessionId <> nameLabel <> " ════════════════════════════════════════════"
+  , "[" <> formatTimestamp now <> "] SESSION START"
+  , ""
+  ]
+  where
+    shortUUID = T.take 8 . UUID.toText
+    nameLabel = maybe "" (\n -> " (" <> n <> ")") mName
+
+-- | Format timestamp as HH:MM:SS.mmm.
+formatTimestamp :: UTCTime -> Text
+formatTimestamp = T.pack . formatTime defaultTimeLocale "%H:%M:%S.%03q"
+
+-- | Compact JSON (single line, truncated to 200 chars).
+compactJSON :: Value -> Text
+compactJSON = T.take 200 . T.replace "\n" " " . TL.toStrict . TLE.decodeUtf8 . encode

--- a/tidepool-native-gui/devlog-executor/tidepool-devlog-executor.cabal
+++ b/tidepool-native-gui/devlog-executor/tidepool-devlog-executor.cabal
@@ -1,0 +1,37 @@
+cabal-version:      3.0
+name:               tidepool-devlog-executor
+version:            0.1.0.0
+synopsis:           DevLog effect executor - session-scoped file logging for dev debugging
+license:            MIT
+author:             Inanna
+build-type:         Simple
+
+library
+    exposed-modules:
+        Tidepool.DevLog.Executor
+        Tidepool.DevLog.Config
+        Tidepool.DevLog.Formatter
+    build-depends:
+        base >= 4.17 && < 5,
+        freer-simple >= 1.2 && < 2,
+        text >= 2.0 && < 3,
+        aeson >= 2.1 && < 3,
+        time >= 1.12 && < 2,
+        directory >= 1.3 && < 2,
+        filepath >= 1.4 && < 2,
+        uuid >= 1.3 && < 2,
+        unix >= 2.7 && < 3,
+        tidepool-core
+    hs-source-dirs:   src
+    default-language: GHC2021
+    default-extensions:
+        DataKinds
+        DeriveAnyClass
+        DeriveGeneric
+        DerivingStrategies
+        GADTs
+        LambdaCase
+        OverloadedStrings
+        OverloadedRecordDot
+        TypeApplications
+        StrictData

--- a/tidepool-native-gui/server/app/Main.hs
+++ b/tidepool-native-gui/server/app/Main.hs
@@ -2,7 +2,7 @@
 module Main where
 
 import System.Environment (lookupEnv)
-import Tidepool.Server (runServer, ServerConfig(..), ServerMode(..))
+import Tidepool.Server (runServer, ServerConfig(..), ServerMode(..), simpleAgent)
 import Tidepool.Server.EffectRunner (loadExecutorConfig)
 
 main :: IO ()
@@ -23,4 +23,5 @@ main = do
     , scHost = "0.0.0.0"
     , scExecutorConfig = executorConfig
     , scMode = mode
+    , scAgent = simpleAgent
     }

--- a/tidepool-native-gui/server/src/Tidepool/Server.hs
+++ b/tidepool-native-gui/server/src/Tidepool/Server.hs
@@ -95,6 +95,7 @@ import Tidepool.Effects.Habitica (Habitica)
 import Tidepool.Effects.LLMProvider (LLMComplete)
 import Tidepool.Effects.Observability (Observability)
 import Tidepool.ClaudeCode.Effect (ClaudeCodeExec)
+import Tidepool.Effect.DevLog (DevLog)
 
 
 -- ════════════════════════════════════════════════════════════════════════════
@@ -107,8 +108,8 @@ data ServerMode
   | DevProxy Int           -- ^ Proxy to Vite dev server on given port (development)
   deriving (Show, Eq)
 
--- | Agent type - a computation using UI, LLM, and Observability effects.
-type Agent = Eff '[UI, Habitica, LLMComplete, ClaudeCodeExec, Observability, IO] ()
+-- | Agent type - a computation using UI, LLM, DevLog, and Observability effects.
+type Agent = Eff '[UI, Habitica, LLMComplete, ClaudeCodeExec, DevLog, Observability, IO] ()
 
 -- | Server configuration.
 data ServerConfig = ServerConfig

--- a/tidepool-native-gui/server/tidepool-native-server.cabal
+++ b/tidepool-native-gui/server/tidepool-native-server.cabal
@@ -40,7 +40,8 @@ library
         tidepool-habitica-executor,
         tidepool-observability-executor,
         tidepool-llm-executor,
-        tidepool-claude-code-executor
+        tidepool-claude-code-executor,
+        tidepool-devlog-executor
     hs-source-dirs:   src
     default-language: GHC2021
     default-extensions:


### PR DESCRIPTION
## Summary
- Introduces new `DevLog` effect for LLM-friendly debugging
- Adds `tidepool-devlog-executor` package with file-based interpreter
- Auto-instrumented dispatch via `Tidepool.Graph.Execute.Instrumented`
- Environment config: `DEVLOG_DIR`, `DEVLOG_VERBOSITY`, `DEVLOG_LATEST`

## Log Format
```
GRAPH entry → greeting
STATE.mood: MoodScene (unchanged)
LLM.REQUEST dm_scene (1847 tokens)
LLM.RESPONSE dm_scene (2240ms, 243 tokens)
```

## Files Changed
- `tidepool-core/src/Tidepool/Effect/DevLog.hs` - effect + event types
- `tidepool-core/src/Tidepool/Graph/Execute/Instrumented.hs` - auto-instrumentation
- `tidepool-native-gui/devlog-executor/` - new package with executor, config, formatter
- Server files updated to wire DevLog into effect stack

## Test plan
- [x] Build passes (`cabal build tidepool-native-server`)
- [ ] Manual test: run server with `DEVLOG_DIR=./logs` and verify log output

🤖 Generated with [Claude Code](https://claude.com/claude-code)