### PR TITLE
refactor(LLMHandler): Use record syntax for improved readability

### DIFF
--- a/.claude/skills/tidepool-v2-graph/SKILL.md
+++ b/.claude/skills/tidepool-v2-graph/SKILL.md
@@ -24,29 +24,29 @@ data MyGraph mode = MyGraph
 
 ## LLMHandler
 
-LLM handlers use the `LLMHandler` constructor with four arguments:
+LLM handlers use the `LLMHandler` constructor with named record fields:
 
 ```haskell
 sgProcess = LLMHandler
-  Nothing                           -- optional system template
-  (templateCompiled @ProcessTpl)    -- user template (required)
-  (\input -> do                     -- before: build context
-    st <- get @SessionState
-    pure ProcessContext
-      { topic = msgContent input
-      , history = take 3 $ stPastTopics st
-      })
-  (\output -> do                    -- after: route based on output
-    case output of
+  { llmSystem = Nothing
+  , llmUser   = templateCompiled @ProcessTpl
+  , llmBefore = \input -> do
+      st <- get @SessionState
+      pure ProcessContext
+        { topic = msgContent input
+        , history = take 3 $ stPastTopics st
+        }
+  , llmAfter  = \output -> case output of
       RefundIntent -> pure $ gotoChoice @"refund" output
-      _ -> pure $ gotoExit response)
+      _ -> pure $ gotoExit response
+  }
 ```
 
-All four components are required:
-1. System template (optional, use `Nothing` if not needed)
-2. User template (required)
-3. Before handler: builds template context from input
-4. After handler: routes based on LLM output
+All four fields are required:
+- `llmSystem`: System template (use `Nothing` if not needed)
+- `llmUser`: User template (required)
+- `llmBefore`: Builds template context from input
+- `llmAfter`: Routes based on LLM output
 
 ## Typed Routing
 

--- a/template/CLAUDE.md
+++ b/template/CLAUDE.md
@@ -122,16 +122,15 @@ See `tidepool-core/src/Tidepool/Graph/CLAUDE.md` for comprehensive DSL documenta
 
 ### LLM Node Handlers
 
-LLM handlers use the `LLMHandler` constructor with four arguments:
+LLM handlers use the `LLMHandler` constructor with named record fields:
 
 ```haskell
 sgProcess = LLMHandler
-  Nothing                    -- optional system template
-  (templateCompiled @MyTpl)  -- user template
-  (\input -> do              -- before: build context
-    pure ContextType { ... })
-  (\output -> do             -- after: route based on output
-    pure $ gotoExit result)
+  { llmSystem = Nothing
+  , llmUser   = templateCompiled @MyTpl
+  , llmBefore = \input -> pure ContextType { ... }
+  , llmAfter  = \output -> pure $ gotoExit result
+  }
 ```
 
 ### Logic Node Handlers

--- a/template/src/Template/Handlers.hs
+++ b/template/src/Template/Handlers.hs
@@ -31,15 +31,16 @@ simpleHandlers = SimpleGraph
 
     -- LLMHandler: Build template context, call LLM, then route to exit
   , sgProcess = LLMHandler
-      Nothing  -- no system template
-      (templateCompiled @ProcessTpl)
-      (\input -> do
-        msgs <- getHistory
-        pure ProcessContext
-          { input = T.pack input.inputText
-          , history = formatHistory msgs
-          })
-      (\output -> pure $ gotoExit (Result output.outputText))
+      { llmSystem = Nothing
+      , llmUser   = templateCompiled @ProcessTpl
+      , llmBefore = \input -> do
+          msgs <- getHistory
+          pure ProcessContext
+            { input = T.pack input.inputText
+            , history = formatHistory msgs
+            }
+      , llmAfter  = \output -> pure $ gotoExit (Result output.outputText)
+      }
 
   , sgExit    = Proxy @Result
   }

--- a/tidepool-core/CLAUDE.md
+++ b/tidepool-core/CLAUDE.md
@@ -314,24 +314,25 @@ Node shapes:
 
 ## LLM Handler
 
-LLM handlers use the `LLMHandler` constructor with four arguments:
+LLM handlers use the `LLMHandler` constructor with named record fields:
 
 ```haskell
 gProcess = LLMHandler
-  Nothing                           -- optional system template
-  (templateCompiled @ProcessTpl)    -- user template (required)
-  (\input -> do                     -- before: build context
-    st <- get @SessionState
-    pure ProcessContext { ... })
-  (\output -> do                    -- after: route based on output
-    pure $ gotoExit result)
+  { llmSystem = Nothing                           -- optional system template
+  , llmUser   = templateCompiled @ProcessTpl      -- user template (required)
+  , llmBefore = \input -> do                      -- builds template context
+      st <- get @SessionState
+      pure ProcessContext { ... }
+  , llmAfter  = \output -> do                     -- routes based on output
+      pure $ gotoExit result
+  }
 ```
 
-All four components are required:
-1. System template (optional, use `Nothing` if not needed)
-2. User template (required)
-3. Before handler: builds template context from input
-4. After handler: routes based on LLM output
+All four fields are required:
+- `llmSystem`: System template (use `Nothing` if not needed)
+- `llmUser`: User template (required)
+- `llmBefore`: Builds template context from input
+- `llmAfter`: Routes based on LLM output
 
 ## Validation
 


### PR DESCRIPTION
## Summary

Changes the `LLMHandler` GADT to use named record fields instead of positional arguments for better readability at construction sites.

## Before
```haskell
sgProcess = LLMHandler
  Nothing
  (templateCompiled @ProcessTpl)
  (\input -> pure context)
  (\output -> pure $ gotoExit result)
```

## After
```haskell
sgProcess = LLMHandler
  { llmSystem = Nothing
  , llmUser   = templateCompiled @ProcessTpl
  , llmBefore = \input -> pure context
  , llmAfter  = \output -> pure $ gotoExit result
  }
```

## Fields
- `llmSystem`: Optional system prompt template
- `llmUser`: Required user prompt template  
- `llmBefore`: Builds template context from input
- `llmAfter`: Routes based on LLM output

## Test plan

- [x] `cabal build tidepool-core` passes
- [x] `cabal test tidepool-core` passes (119 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)