### PR TITLE
ci: Disable automatic CI while bootstrapping container cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,9 @@
 name: CI
 
+# TEMPORARILY DISABLED - manual trigger only while we bootstrap container cache
+# After container is built, will re-enable with: push: branches: [main]
 on:
-  pull_request:
-    types: [opened, ready_for_review]  # Only run when PR is opened or marked ready
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - '.github/README.md'
-  push:
-    branches: [main]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - '.github/README.md'
+  workflow_dispatch:
 
 jobs:
   haskell:


### PR DESCRIPTION
## Summary

Temporarily disable automatic CI triggers while we bootstrap the container cache infrastructure.

## Problem

CI was burning ~7 min on dependency downloads/builds because the pre-built container image (`ghcr.io/.../ci-cache:latest`) was never successfully bootstrapped. This wasted GitHub Actions credits on every PR/push.

## What This PR Does

Changes CI from:
- `on: push to main + PR opened/ready_for_review`

To:
- `on: workflow_dispatch` (manual trigger only)

## Next Steps (After Merge)

1. **Add GitHub Actions credits**
2. **Trigger container build**: GitHub Actions → "Build CI Container" → "Run workflow"
   - This builds and pushes `ghcr.io/tidepool-labs/tidepool/ci-cache:latest`
   - Uses `GITHUB_TOKEN` (auto-provided) with `packages: write` - no extra secrets needed
   - Takes ~10-15 min once
3. **Follow-up PR**: Re-enable CI with slimmed-down config:
   - Remove WASM job (build locally before deploy)
   - Remove TypeScript job (lint locally)
   - Keep Haskell build + lint + quick tests only
   - Expected time: ~3-5 min per run (vs 20+ min currently)

## How the Container Cache Works

The `build-container.yml` workflow:
1. Builds a Docker image from `.github/Dockerfile.ci`
2. Pre-compiles all Haskell dependencies into `~/.cabal/store`
3. Pushes to GitHub Container Registry

When CI runs:
1. Uses that pre-built container
2. Only needs incremental compilation of changed modules
3. Deps are already cached in the container

## Workflows Status

| Workflow | Trigger | Status |
|----------|---------|--------|
| `ci.yml` | `workflow_dispatch` | **MANUAL ONLY** (this PR) |
| `build-container.yml` | `workflow_dispatch` + cabal file changes | Unchanged |
| `copilot-review.yml` | PR events | Unchanged |

🤖 Generated with [Claude Code](https://claude.com/claude-code)