### PR TITLE
feat(types-first-dev): Add skeleton template wiring

### DIFF
--- a/types-first-dev/src/TypesFirstDev/Context.hs
+++ b/types-first-dev/src/TypesFirstDev/Context.hs
@@ -12,6 +12,9 @@ module TypesFirstDev.Context
   ( TypesContext(..)
   , TestsContext(..)
   , ImplContext(..)
+  , SkeletonContext(..)
+  , SignatureInfo(..)
+  , TestPriority(..)
   ) where
 
 import Control.Monad.Writer (Writer)
@@ -99,4 +102,72 @@ instance ToGVal (Run SourcePos (Writer Text) Text) ImplContext where
     , ("dataType", toGVal dataType)
     , ("signatures", list $ map toGVal signatures)
     , ("moduleHeader", toGVal moduleHeader)
+    ]
+
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- SKELETON TEMPLATE CONTEXT
+-- ════════════════════════════════════════════════════════════════════════════
+
+-- | Information about a type signature.
+--
+-- Template variables:
+--   {{ sig.name }} - function name
+--   {{ sig.type }} - type signature
+--   {{ sig.doc }} - documentation string
+data SignatureInfo = SignatureInfo
+  { name :: Text
+  , sigType :: Text  -- ^ Called "type" in template
+  , doc :: Text
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToGVal (Run SourcePos (Writer Text) Text) SignatureInfo where
+  toGVal SignatureInfo{..} = dict
+    [ ("name", toGVal name)
+    , ("type", toGVal sigType)
+    , ("doc", toGVal doc)
+    ]
+
+-- | Test priority information.
+--
+-- Template variables:
+--   {{ priority.name }} - test name
+--   {{ priority.description }} - why this test matters
+data TestPriority = TestPriority
+  { name :: Text
+  , description :: Text
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToGVal (Run SourcePos (Writer Text) Text) TestPriority where
+  toGVal TestPriority{..} = dict
+    [ ("name", toGVal name)
+    , ("description", toGVal description)
+    ]
+
+-- | Context for skeleton templates (impl-skeleton, test-skeleton).
+--
+-- Template variables:
+--   {{ moduleName }} - e.g., "Data.Stack"
+--   {{ dataTypeName }} - e.g., "Stack"
+--   {{ dataType }} - full type definition
+--   {{ signatures }} - list of SignatureInfo
+--   {{ testPriorities }} - list of TestPriority
+data SkeletonContext = SkeletonContext
+  { moduleName :: Text
+  , dataTypeName :: Text
+  , dataType :: Text
+  , signatures :: [SignatureInfo]
+  , testPriorities :: [TestPriority]
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToGVal (Run SourcePos (Writer Text) Text) SkeletonContext where
+  toGVal SkeletonContext{..} = dict
+    [ ("moduleName", toGVal moduleName)
+    , ("dataTypeName", toGVal dataTypeName)
+    , ("dataType", toGVal dataType)
+    , ("signatures", list $ map toGVal signatures)
+    , ("testPriorities", list $ map toGVal testPriorities)
     ]

--- a/types-first-dev/src/TypesFirstDev/Templates.hs
+++ b/types-first-dev/src/TypesFirstDev/Templates.hs
@@ -9,18 +9,22 @@ module TypesFirstDev.Templates
     TypesTpl
   , TestsTpl
   , ImplTpl
+  , ImplSkeletonTpl
+  , TestSkeletonTpl
 
     -- * Compiled Templates
   , typesCompiled
   , testsCompiled
   , implCompiled
+  , implSkeletonCompiled
+  , testSkeletonCompiled
   ) where
 
 import Text.Parsec.Pos (SourcePos)
 
 import Tidepool.Graph.Template (TemplateDef(..), TypedTemplate, typedTemplateFile)
 
-import TypesFirstDev.Context (TypesContext(..), TestsContext(..), ImplContext(..))
+import TypesFirstDev.Context (TypesContext(..), TestsContext(..), ImplContext(..), SkeletonContext(..))
 
 
 -- ════════════════════════════════════════════════════════════════════════════
@@ -88,3 +92,47 @@ instance TemplateDef ImplTpl where
   templateCompiled = implCompiled
 
   buildContext = error "ImplTpl.buildContext should not be called for ClaudeCode handlers"
+
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- Impl Skeleton Template
+-- ════════════════════════════════════════════════════════════════════════════
+
+-- | Compile the impl-skeleton template at build time.
+implSkeletonCompiled :: TypedTemplate SkeletonContext SourcePos
+implSkeletonCompiled = $(typedTemplateFile ''SkeletonContext "templates/impl-skeleton.jinja")
+
+-- | Template type marker for the impl skeleton node.
+data ImplSkeletonTpl
+
+instance TemplateDef ImplSkeletonTpl where
+  type TemplateContext ImplSkeletonTpl = SkeletonContext
+  type TemplateConstraint ImplSkeletonTpl es = ()
+
+  templateName = "impl-skeleton"
+  templateDescription = "Generate implementation skeleton with stubs"
+  templateCompiled = implSkeletonCompiled
+
+  buildContext = error "ImplSkeletonTpl.buildContext should not be called for ClaudeCode handlers"
+
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- Test Skeleton Template
+-- ════════════════════════════════════════════════════════════════════════════
+
+-- | Compile the test-skeleton template at build time.
+testSkeletonCompiled :: TypedTemplate SkeletonContext SourcePos
+testSkeletonCompiled = $(typedTemplateFile ''SkeletonContext "templates/test-skeleton.jinja")
+
+-- | Template type marker for the test skeleton node.
+data TestSkeletonTpl
+
+instance TemplateDef TestSkeletonTpl where
+  type TemplateContext TestSkeletonTpl = SkeletonContext
+  type TemplateConstraint TestSkeletonTpl es = ()
+
+  templateName = "test-skeleton"
+  templateDescription = "Generate test skeleton with pending stubs"
+  templateCompiled = testSkeletonCompiled
+
+  buildContext = error "TestSkeletonTpl.buildContext should not be called for ClaudeCode handlers"

--- a/types-first-dev/templates/impl-skeleton.jinja
+++ b/types-first-dev/templates/impl-skeleton.jinja
@@ -1,0 +1,46 @@
+You are implementing a Haskell data structure skeleton.
+
+## Task
+
+Write implementation stubs for: {{ moduleName }}
+
+## Data Type
+
+```haskell
+{{ dataType }}
+```
+
+Data type name: {{ dataTypeName }}
+
+## Function Signatures
+
+{% for sig in signatures %}
+### {{ sig.name }}
+
+```haskell
+{{ sig.name }} :: {{ sig.type }}
+```
+
+{{ sig.doc }}
+
+{% endfor %}
+
+## Requirements
+
+1. Implement ALL functions listed above with `undefined` or `error "TODO"` bodies
+2. Each function MUST match its type signature exactly
+3. Include Haddock comments from the doc strings
+4. Use idiomatic Haskell patterns for the structure
+
+## Output Format
+
+Write a complete module skeleton with:
+
+1. Module header: `module {{ moduleName }} where`
+2. Necessary imports
+3. The {{ dataTypeName }} data type definition
+4. All function stubs with type signatures and placeholder implementations
+
+## Your Task
+
+Write the implementation skeleton for {{ moduleName }}.

--- a/types-first-dev/templates/test-skeleton.jinja
+++ b/types-first-dev/templates/test-skeleton.jinja
@@ -1,0 +1,50 @@
+You are writing a test skeleton for a Haskell data structure.
+
+## Task
+
+Write test stubs for: {{ moduleName }}
+
+## Data Type Under Test
+
+```haskell
+{{ dataType }}
+```
+
+Data type name: {{ dataTypeName }}
+
+## Functions to Test
+
+{% for sig in signatures %}
+- `{{ sig.name }} :: {{ sig.type }}`
+{% endfor %}
+
+## Test Priorities
+
+{% for priority in testPriorities %}
+### {{ priority.name }}
+
+{{ priority.description }}
+
+{% endfor %}
+
+## Requirements
+
+1. Create test stubs for each function
+2. Prioritize tests according to the test priorities above
+3. Use HSpec or Tasty test framework patterns
+4. Include property-based test placeholders where appropriate
+5. Each test should have a descriptive name and `pending` body
+
+## Output Format
+
+Write a complete test module skeleton with:
+
+1. Module header: `module {{ moduleName }}Spec where`
+2. Test framework imports (HSpec)
+3. Import of {{ moduleName }}
+4. Spec definition with describe/it blocks
+5. All test stubs with `pending` or `pendingWith "TODO"`
+
+## Your Task
+
+Write the test skeleton for {{ moduleName }}.


### PR DESCRIPTION
## Summary

- Add `SkeletonContext` with nested `SignatureInfo` and `TestPriority` types for richer template data
- Create `impl-skeleton.jinja` template for generating implementation stubs with `undefined` bodies
- Create `test-skeleton.jinja` template for generating test stubs with `pending` assertions
- Wire both templates in `Templates.hs` with `ImplSkeletonTpl` and `TestSkeletonTpl`

## Test plan

- [x] `cabal build types-first-dev` passes
- [ ] Manual verification of template rendering (future integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)