### PR TITLE
feat(zellij-cc): Add --inject-context flag for session resume

### DIFF
--- a/types-first-dev/src/TypesFirstDev/Context.hs
+++ b/types-first-dev/src/TypesFirstDev/Context.hs
@@ -177,7 +177,6 @@ instance ToGVal (Run SourcePos (Writer Text) Text) SkeletonContext where
     [ ("moduleName", toGVal moduleName)
     , ("typeName", toGVal typeName)
     , ("dataTypeName", toGVal dataTypeName)
-    , ("typeName", toGVal dataTypeName)  -- Alias for template compatibility
     , ("dataType", toGVal dataType)
     , ("signatures", list $ map toGVal signatures)
     , ("testPriorities", list $ map toGVal testPriorities)


### PR DESCRIPTION
## Summary

Enables context injection on session resume for the incremental crosstalk loop:
`invoke → complete → inject context → resume same session`

Since Claude Code's CLAUDE.md is frozen at session start, context updates must be passed explicitly via prompt prefix. This flag prepends the injected context to the prompt with a double newline separator.

## Usage

```bash
zellij-cc run --resume $sid --inject-context "CONTEXT: test agent committed..." --prompt "continue"
```

## Changes

### zellij-cc
- Add `--inject-context` CLI arg to Run command
- Add `build_prompt` helper function with 4 unit tests
- Prepend context to prompt when building claude args

### types-first-dev  
- Remove redundant `typeName` field from SkeletonContext (Copilot review feedback)
- Update templates to use `dataTypeName` directly

## Test plan

- [x] All zellij-cc tests pass (14 tests)
- [x] types-first-dev builds successfully
- [x] `--inject-context` appears in `--help` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)