### PR TITLE
feat(zellij-cc): Add ratatui TUI for interactive session monitoring

### DIFF
--- a/tools/zellij-cc/Cargo.lock
+++ b/tools/zellij-cc/Cargo.lock
@@ -27,6 +27,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,10 +406,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
 name = "castaway"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2698f953def977c68f935bb0dfa959375ad4638570e969e2f1e9f433cbf1af6"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
@@ -549,6 +570,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54261aba646433cb567ec89844be4c4825ca92a4f8afba52fc4dd88436e31bbd"
 
 [[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway 0.2.4",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,6 +664,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.10.0",
+ "crossterm_winapi",
+ "mio 1.1.1",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -686,6 +746,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8bfdaacb3c887a54d41bdf48d3af8873b3f5566469f8ba21b92057509f116e"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.113",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -919,6 +1013,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1038,6 +1138,17 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1219,6 +1330,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1279,6 +1396,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "inotify"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1296,6 +1422,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357b7205c6cd18dd2c86ed312d1e70add149aea98e7ef72b9fdf0270e555c11d"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -1350,7 +1489,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "334e04b4d781f436dc315cb1e7515bd96826426345d498149e4bde36b67f8ee9"
 dependencies = [
  "async-channel 1.9.0",
- "castaway",
+ "castaway 0.1.2",
  "crossbeam-utils",
  "curl",
  "curl-sys",
@@ -1375,6 +1514,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -1561,6 +1709,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "mac_address"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1627,7 +1784,7 @@ dependencies = [
  "terminal_size",
  "textwrap 0.15.2",
  "thiserror 1.0.69",
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -1694,6 +1851,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1923,6 +2081,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -2193,7 +2357,7 @@ checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
 dependencies = [
  "bytes",
  "heck 0.4.1",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "log",
  "multimap",
@@ -2214,7 +2378,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -2272,6 +2436,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.16",
+]
+
+[[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags 2.10.0",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools 0.13.0",
+ "lru",
+ "paste",
+ "strum 0.26.3",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -2552,6 +2737,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio 1.1.1",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2613,6 +2809,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strip-ansi-escapes"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2640,6 +2842,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7318c509b5ba57f18533982607f24070a55d353e90d4cae30c467cdb2ad5ac5c"
 
 [[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros 0.26.4",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2649,6 +2860,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -2825,7 +3049,7 @@ checksum = "b7b3e525a49ec206798b40326a44121291b530c963cfb01018f63e135bac543d"
 dependencies = [
  "smawk",
  "unicode-linebreak",
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -3053,10 +3277,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"
@@ -3699,8 +3940,10 @@ name = "zellij-cc"
 version = "0.1.0"
 dependencies = [
  "clap 4.5.54",
+ "crossterm",
  "nix 0.29.0",
  "openssl-sys",
+ "ratatui",
  "serde",
  "serde_json",
  "shell-escape",
@@ -3778,14 +4021,14 @@ dependencies = [
  "sha2",
  "shellexpand",
  "strip-ansi-escapes",
- "strum",
- "strum_macros",
+ "strum 0.20.0",
+ "strum_macros 0.20.1",
  "suggest",
  "tempfile",
  "termwiz",
  "thiserror 1.0.69",
  "tokio",
- "unicode-width",
+ "unicode-width 0.1.14",
  "url",
  "uuid",
 ]

--- a/tools/zellij-cc/Cargo.toml
+++ b/tools/zellij-cc/Cargo.toml
@@ -17,3 +17,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # Vendored OpenSSL to avoid system library mismatch
 openssl-sys = { version = "0.9", features = ["vendored"] }
+
+# TUI
+crossterm = "0.28"
+ratatui = "0.29"

--- a/tools/zellij-cc/src/error.rs
+++ b/tools/zellij-cc/src/error.rs
@@ -97,3 +97,9 @@ impl From<nix::Error> for ZellijCcError {
         ZellijCcError::Poll(e)
     }
 }
+
+impl From<std::io::Error> for ZellijCcError {
+    fn from(e: std::io::Error) -> Self {
+        ZellijCcError::Io(e)
+    }
+}

--- a/tools/zellij-cc/src/lib.rs
+++ b/tools/zellij-cc/src/lib.rs
@@ -42,6 +42,7 @@ pub mod events;
 pub mod fifo;
 pub mod humanize;
 pub mod supervisor;
+pub mod tui;
 
 // Re-export commonly used types at crate root
 pub use error::{Result, ZellijCcError};

--- a/tools/zellij-cc/src/main.rs
+++ b/tools/zellij-cc/src/main.rs
@@ -8,6 +8,8 @@ use shell_escape::escape;
 use std::borrow::Cow;
 use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
+use std::sync::mpsc;
+use std::thread;
 use std::time::Duration;
 use tracing::{debug, error, info, warn};
 use tracing_subscriber::EnvFilter;
@@ -20,6 +22,7 @@ use zellij_cc::events::{InterruptSignal, ResultEvent, RunResult, StreamEvent};
 use zellij_cc::fifo::{write_result, write_signal, ResultFifo, SignalFifo};
 use zellij_cc::humanize::{print_event_humanized, print_interrupt};
 use zellij_cc::supervisor::{build_claude_command, install_signal_handlers, Supervisor};
+use zellij_cc::tui::{run_tui, TuiEvent};
 
 // ============================================================================
 // CLI Types
@@ -105,6 +108,10 @@ enum Commands {
         #[arg(long, default_value = "0")]
         timeout: u64,
 
+        /// Disable TUI, use simple println output (for CI/headless)
+        #[arg(long)]
+        no_tui: bool,
+
         /// All remaining args passed to claude
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         claude_args: Vec<String>,
@@ -175,8 +182,9 @@ fn main() {
             cwd,
             session_tag,
             timeout,
+            no_tui,
             claude_args,
-        } => wrap_claude(&result_fifo, cwd.as_ref(), session_tag.as_deref(), timeout, &claude_args),
+        } => wrap_claude(&result_fifo, cwd.as_ref(), session_tag.as_deref(), timeout, no_tui, &claude_args),
         Commands::Signal {
             signal_type,
             state,
@@ -362,6 +370,7 @@ fn wrap_claude(
     cwd: Option<&PathBuf>,
     session_tag: Option<&str>,
     timeout_secs: u64,
+    no_tui: bool,
     claude_args: &[String],
 ) -> Result<()> {
     // Install signal handlers for SIGINT/SIGTERM forwarding
@@ -383,6 +392,24 @@ fn wrap_claude(
 
     // Take stdout for reading
     let stdout = supervisor.take_stdout();
+
+    if no_tui {
+        // Simple println mode for CI/headless
+        wrap_claude_simple(stdout, &signal_fifo, &mut supervisor, result_fifo, session_tag)
+    } else {
+        // Full TUI mode
+        wrap_claude_tui(stdout, &signal_fifo, &mut supervisor, result_fifo, session_tag)
+    }
+}
+
+/// Simple println mode (original behavior, for CI/headless)
+fn wrap_claude_simple(
+    stdout: std::process::ChildStdout,
+    signal_fifo: &SignalFifo,
+    supervisor: &mut Supervisor,
+    result_fifo: &PathBuf,
+    session_tag: Option<&str>,
+) -> Result<()> {
     let reader = BufReader::new(stdout);
 
     let mut events: Vec<StreamEvent> = Vec::new();
@@ -443,6 +470,115 @@ fn wrap_claude(
         exit_code,
         session_tag.map(|s| s.to_string()),
         interrupts,
+    );
+
+    // Write to result FIFO (unblocks the waiting `run` process)
+    write_result(result_fifo, &result)?;
+
+    Ok(())
+}
+
+/// TUI mode with interactive display
+fn wrap_claude_tui(
+    stdout: std::process::ChildStdout,
+    signal_fifo: &SignalFifo,
+    supervisor: &mut Supervisor,
+    result_fifo: &PathBuf,
+    session_tag: Option<&str>,
+) -> Result<()> {
+    // Create channel for TUI events
+    let (tx, rx) = mpsc::channel::<TuiEvent>();
+    let tx_signal = tx.clone();
+
+    // Spawn stdout reader thread
+    let stdout_handle = thread::spawn(move || {
+        let reader = BufReader::new(stdout);
+        for line in reader.lines() {
+            let line = match line {
+                Ok(l) => l,
+                Err(e) => {
+                    warn!(error = %e, "Error reading line from claude stdout");
+                    continue;
+                }
+            };
+
+            if line.trim().is_empty() {
+                continue;
+            }
+
+            match serde_json::from_str::<StreamEvent>(&line) {
+                Ok(event) => {
+                    if tx.send(TuiEvent::Claude(event)).is_err() {
+                        break; // TUI closed
+                    }
+                }
+                Err(e) => {
+                    let truncated: String = line.chars().take(50).collect();
+                    warn!(
+                        error = %e,
+                        line = %truncated,
+                        "JSON parse error"
+                    );
+                }
+            }
+        }
+        // Signal that stdout is done
+        let _ = tx.send(TuiEvent::ProcessExit);
+    });
+
+    // Clone signal_fifo path for the thread
+    let signal_path = signal_fifo.path().to_path_buf();
+
+    // Spawn signal reader thread
+    let signal_handle = thread::spawn(move || {
+        // Create a new SignalFifo for this thread using the same path
+        // We poll periodically to check for signals
+        loop {
+            // Try to read signal from the FIFO
+            if let Ok(contents) = std::fs::read_to_string(&signal_path) {
+                for line in contents.lines() {
+                    if let Ok(signal) = serde_json::from_str::<InterruptSignal>(line) {
+                        if tx_signal.send(TuiEvent::Interrupt(signal)).is_err() {
+                            return; // TUI closed
+                        }
+                    }
+                }
+                // Clear the file after reading
+                let _ = std::fs::write(&signal_path, "");
+            }
+            thread::sleep(Duration::from_millis(100));
+        }
+    });
+
+    // Run TUI (blocks until user quits)
+    let tui_result = run_tui(rx)?;
+
+    // Wait for stdout thread to finish
+    let _ = stdout_handle.join();
+
+    // Signal thread runs forever, so we don't join it - it'll be terminated when we exit
+    drop(signal_handle);
+
+    // Wait for the child process (non-blocking check in loop)
+    let exit_code = loop {
+        match supervisor.try_wait()? {
+            Some(status) => {
+                break status.code().unwrap_or(-1);
+            }
+            None => {
+                // Process still running, wait a bit
+                thread::sleep(Duration::from_millis(100));
+            }
+        }
+    };
+
+    // Build final result from TUI state
+    let result = RunResult::from_events(
+        tui_result.events,
+        tui_result.result_event,
+        exit_code,
+        session_tag.map(|s| s.to_string()),
+        tui_result.interrupts,
     );
 
     // Write to result FIFO (unblocks the waiting `run` process)

--- a/tools/zellij-cc/src/supervisor.rs
+++ b/tools/zellij-cc/src/supervisor.rs
@@ -263,6 +263,13 @@ impl Supervisor {
     pub fn pid(&self) -> Pid {
         self.child_pid
     }
+
+    /// Non-blocking check if child has exited.
+    ///
+    /// Returns `Ok(Some(status))` if exited, `Ok(None)` if still running.
+    pub fn try_wait(&mut self) -> Result<Option<ExitStatus>> {
+        self.child.try_wait().map_err(ZellijCcError::Io)
+    }
 }
 
 impl Drop for Supervisor {

--- a/tools/zellij-cc/src/tui/app.rs
+++ b/tools/zellij-cc/src/tui/app.rs
@@ -1,0 +1,273 @@
+//! Main TUI application using ratatui
+
+use super::events::TuiEvent;
+use super::state::{AppState, TuiResult};
+use crate::error::Result;
+
+use crossterm::{
+    event::{self, Event, KeyCode, KeyEventKind, KeyModifiers},
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+    ExecutableCommand,
+};
+use ratatui::{
+    backend::CrosstermBackend,
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Style},
+    widgets::{Block, Borders, List, ListItem, Paragraph},
+    Frame, Terminal,
+};
+use std::io::{stdout, Stdout};
+use std::sync::mpsc::Receiver;
+use std::time::Duration;
+
+/// Guard to ensure terminal is restored on drop (including panics)
+struct TerminalGuard {
+    terminal: Terminal<CrosstermBackend<Stdout>>,
+}
+
+impl TerminalGuard {
+    fn new() -> Result<Self> {
+        enable_raw_mode()?;
+        stdout().execute(EnterAlternateScreen)?;
+        let backend = CrosstermBackend::new(stdout());
+        let terminal = Terminal::new(backend)?;
+        Ok(Self { terminal })
+    }
+}
+
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        let _ = disable_raw_mode();
+        let _ = stdout().execute(LeaveAlternateScreen);
+    }
+}
+
+/// Action returned from input handling
+enum Action {
+    /// Continue running
+    Continue,
+    /// Quit the TUI
+    Quit,
+}
+
+/// Main entry point for the TUI
+pub fn run(event_rx: Receiver<TuiEvent>) -> Result<TuiResult> {
+    let mut guard = TerminalGuard::new()?;
+    let mut state = AppState::default();
+
+    loop {
+        // Draw current state
+        guard.terminal.draw(|frame| render(&state, frame))?;
+
+        // Poll for TUI events from channel (non-blocking)
+        while let Ok(tui_event) = event_rx.try_recv() {
+            handle_tui_event(&mut state, tui_event);
+        }
+
+        // Poll for keyboard input with timeout
+        if event::poll(Duration::from_millis(50))? {
+            if let Event::Key(key) = event::read()? {
+                // Only handle key press events, not release
+                if key.kind == KeyEventKind::Press {
+                    match handle_key(&mut state, key.code, key.modifiers) {
+                        Action::Continue => {}
+                        Action::Quit => break,
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(state.into_result())
+}
+
+/// Handle a TUI event from the Claude subprocess
+fn handle_tui_event(state: &mut AppState, event: TuiEvent) {
+    match event {
+        TuiEvent::Claude(stream_event) => {
+            state.process_event(stream_event);
+        }
+        TuiEvent::Interrupt(signal) => {
+            state.add_interrupt(signal);
+        }
+        TuiEvent::ProcessExit => {
+            state.channel_disconnected = true;
+        }
+    }
+}
+
+/// Handle keyboard input
+fn handle_key(state: &mut AppState, code: KeyCode, modifiers: KeyModifiers) -> Action {
+    // Ctrl-C always force quits
+    if code == KeyCode::Char('c') && modifiers.contains(KeyModifiers::CONTROL) {
+        return Action::Quit;
+    }
+
+    match code {
+        // Navigation
+        KeyCode::Char('j') | KeyCode::Down => state.scroll_down(),
+        KeyCode::Char('k') | KeyCode::Up => state.scroll_up(),
+        KeyCode::Char('J') | KeyCode::PageDown => {
+            for _ in 0..10 {
+                state.scroll_down();
+            }
+        }
+        KeyCode::Char('K') | KeyCode::PageUp => {
+            for _ in 0..10 {
+                state.scroll_up();
+            }
+        }
+        KeyCode::Char('g') => state.go_to_top(),
+        KeyCode::Char('G') => state.go_to_bottom(),
+
+        // Expand/collapse
+        KeyCode::Enter => state.toggle_expand(),
+        KeyCode::Char('e') => state.expand_all(),
+        KeyCode::Char('C') => state.collapse_all(), // Shift-C to avoid confusion
+
+        // Quit (only when complete or disconnected)
+        KeyCode::Char('q') => {
+            if state.is_complete || state.channel_disconnected {
+                return Action::Quit;
+            }
+        }
+        _ => {}
+    }
+    Action::Continue
+}
+
+/// Render the full TUI
+fn render(state: &AppState, frame: &mut Frame) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3), // Status bar
+            Constraint::Min(5),    // Event list
+            Constraint::Length(3), // Help bar
+        ])
+        .split(frame.area());
+
+    render_status_bar(state, frame, chunks[0]);
+    render_event_list(state, frame, chunks[1]);
+    render_help_bar(state, frame, chunks[2]);
+}
+
+/// Render the status bar at the top
+fn render_status_bar(state: &AppState, frame: &mut Frame, area: Rect) {
+    let session = state
+        .session_id
+        .as_ref()
+        .map(|s| {
+            let short: String = s.chars().take(8).collect();
+            short
+        })
+        .unwrap_or_else(|| "...".to_string());
+
+    let model = state
+        .model
+        .as_ref()
+        .map(|s| s.as_str())
+        .unwrap_or("...");
+
+    let status = if state.is_complete {
+        if state.is_error {
+            "ERROR"
+        } else {
+            "DONE"
+        }
+    } else if state.channel_disconnected {
+        "DISCONNECTED"
+    } else {
+        "RUNNING"
+    };
+
+    let text = format!(
+        " {} | {} | {} | Turns: {} | ${:.4}",
+        session, model, status, state.num_turns, state.total_cost_usd
+    );
+
+    let style = if state.is_error {
+        Style::default().fg(Color::Red)
+    } else if state.is_complete {
+        Style::default().fg(Color::Green)
+    } else if state.channel_disconnected {
+        Style::default().fg(Color::Yellow)
+    } else {
+        Style::default().fg(Color::Cyan)
+    };
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" Claude Code ")
+        .border_style(style);
+
+    let paragraph = Paragraph::new(text).block(block);
+    frame.render_widget(paragraph, area);
+}
+
+/// Render the scrollable event list
+fn render_event_list(state: &AppState, frame: &mut Frame, area: Rect) {
+    let mut items: Vec<ListItem> = Vec::new();
+
+    for (i, event) in state.display_events.iter().enumerate() {
+        let is_selected = i == state.selected_index;
+        let is_expanded = state.expanded_items.contains(&i);
+
+        // Prefix: arrow if expandable, bullet otherwise
+        let prefix = if event.expandable {
+            if is_expanded {
+                "▼ "
+            } else {
+                "▶ "
+            }
+        } else {
+            "• "
+        };
+
+        let style = if is_selected {
+            Style::default().bg(Color::DarkGray)
+        } else {
+            Style::default()
+        };
+
+        items.push(ListItem::new(format!("{}{}", prefix, event.summary)).style(style));
+
+        // Add details if expanded
+        if is_expanded {
+            for detail in &event.details {
+                items.push(ListItem::new(format!("  {}", detail)).style(Style::default().fg(Color::DarkGray)));
+            }
+        }
+    }
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(format!(" Events ({}) ", state.display_events.len()));
+
+    let list = List::new(items).block(block);
+    frame.render_widget(list, area);
+}
+
+/// Render the help bar at the bottom
+fn render_help_bar(state: &AppState, frame: &mut Frame, area: Rect) {
+    let quit_hint = if state.is_complete || state.channel_disconnected {
+        "q:quit"
+    } else {
+        "Ctrl-C:force quit"
+    };
+
+    let text = format!(
+        " j/k:scroll | J/K:page | g/G:top/bottom | Enter:expand | e/C:all | {} ",
+        quit_hint
+    );
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::DarkGray));
+
+    let paragraph = Paragraph::new(text)
+        .block(block)
+        .style(Style::default().fg(Color::DarkGray));
+
+    frame.render_widget(paragraph, area);
+}

--- a/tools/zellij-cc/src/tui/events.rs
+++ b/tools/zellij-cc/src/tui/events.rs
@@ -1,0 +1,14 @@
+//! Event types for Claude subprocess integration
+
+use crate::events::{InterruptSignal, StreamEvent};
+
+/// Events that can be received from external sources (Claude subprocess)
+#[derive(Clone, Debug)]
+pub enum TuiEvent {
+    /// A stream event from Claude
+    Claude(StreamEvent),
+    /// An interrupt signal
+    Interrupt(InterruptSignal),
+    /// The Claude process has exited
+    ProcessExit,
+}

--- a/tools/zellij-cc/src/tui/mod.rs
+++ b/tools/zellij-cc/src/tui/mod.rs
@@ -1,0 +1,41 @@
+//! Terminal UI (TUI) integration for `zellij-cc`.
+//!
+//! This module provides an interactive terminal user interface for monitoring
+//! Claude Code sessions inside a Zellij pane. It exposes:
+//!
+//! - [`TuiEvent`] - Events sent into the TUI (Claude events, interrupts, process exit)
+//! - [`TuiResult`] - The final aggregated state returned when the TUI exits
+//! - [`run_tui`] - The entry point that runs the TUI event loop
+//!
+//! ## Usage
+//!
+//! 1. Create an `mpsc::channel` for [`TuiEvent`]s
+//! 2. Spawn producer threads that send events as the Claude session progresses
+//! 3. Call [`run_tui`] with the receiver; it blocks until the user quits
+//! 4. Inspect the returned [`TuiResult`] for collected events and final state
+//!
+//! ## Keyboard Controls
+//!
+//! - `j`/`k` or arrows: Scroll up/down
+//! - `J`/`K` or Page Up/Down: Page scroll
+//! - `g`/`G`: Jump to top/bottom
+//! - `Enter`: Toggle expand/collapse on tool details
+//! - `e`/`C` (Shift): Expand all / Collapse all
+//! - `q`: Quit (only after session completes)
+//! - `Ctrl-C`: Force quit (even if session is running)
+
+mod app;
+mod events;
+mod state;
+
+use crate::error::Result;
+use std::sync::mpsc::Receiver;
+
+pub use events::TuiEvent;
+pub use state::TuiResult;
+
+/// Run the TUI with events from the given channel.
+/// Returns the collected state when the TUI exits.
+pub fn run_tui(event_rx: Receiver<TuiEvent>) -> Result<TuiResult> {
+    app::run(event_rx)
+}

--- a/tools/zellij-cc/src/tui/state.rs
+++ b/tools/zellij-cc/src/tui/state.rs
@@ -1,0 +1,270 @@
+//! Application state for the TUI
+
+use crate::events::{ContentBlock, InterruptSignal, ResultEvent, StreamEvent};
+use std::collections::HashSet;
+
+/// Result returned when TUI exits, containing collected data
+pub struct TuiResult {
+    /// All events received during the session
+    pub events: Vec<StreamEvent>,
+    /// The final result event (if received)
+    pub result_event: Option<ResultEvent>,
+    /// All interrupt signals received
+    pub interrupts: Vec<InterruptSignal>,
+}
+
+/// Display representation of an event for the TUI
+#[derive(Debug, Clone)]
+pub struct DisplayEvent {
+    /// Whether this event can be expanded (has collapsible details)
+    pub expandable: bool,
+    /// Summary line for collapsed display
+    pub summary: String,
+    /// Detailed lines for expanded display
+    pub details: Vec<String>,
+}
+
+impl DisplayEvent {
+    pub fn from_stream_event(event: &StreamEvent) -> Self {
+        let (expandable, summary, details) = match event {
+            StreamEvent::System(s) => {
+                // Use chars() to safely truncate UTF-8 strings without panicking
+                let short_id: String = s.session_id.chars().take(8).collect();
+                (
+                    false,
+                    format!("Session {} | Model: {}", short_id, s.model),
+                    vec![],
+                )
+            }
+            StreamEvent::Assistant(a) => {
+                let mut summaries = Vec::new();
+                let mut all_details = Vec::new();
+                let mut has_expandable = false;
+
+                for block in &a.message.content {
+                    match block {
+                        ContentBlock::Text { text } => {
+                            // Cache char count to avoid iterating twice
+                            let char_count = text.chars().count();
+                            let preview: String = text.chars().take(60).collect();
+                            if char_count > 60 {
+                                summaries.push(format!("{}...", preview));
+                            } else {
+                                summaries.push(preview);
+                            }
+                        }
+                        ContentBlock::ToolUse { name, input, .. } => {
+                            has_expandable = true;
+                            summaries.push(format!("Tool: {}", name));
+                            if let Some(obj) = input.as_object() {
+                                let total_params = obj.len();
+                                for (k, v) in obj.iter().take(5) {
+                                    let v_str = v.to_string();
+                                    // Cache char count to avoid iterating twice
+                                    let char_count = v_str.chars().count();
+                                    let preview: String = v_str.chars().take(60).collect();
+                                    if char_count > 60 {
+                                        all_details.push(format!("  {}: {}...", k, preview));
+                                    } else {
+                                        all_details.push(format!("  {}: {}", k, preview));
+                                    }
+                                }
+                                // Show truncation indicator if there are more parameters
+                                if total_params > 5 {
+                                    all_details.push(format!("  ... and {} more", total_params - 5));
+                                }
+                            }
+                        }
+                        ContentBlock::ToolResult { content, is_error, .. } => {
+                            let status = if is_error.unwrap_or(false) { "✗" } else { "✓" };
+                            // Cache char count to avoid iterating twice
+                            let char_count = content.chars().count();
+                            let preview: String = content.chars().take(50).collect();
+                            if char_count > 50 {
+                                summaries.push(format!("{} {}...", status, preview));
+                            } else {
+                                summaries.push(format!("{} {}", status, preview));
+                            }
+                        }
+                    }
+                }
+
+                (
+                    has_expandable,
+                    summaries.join(" | "),
+                    all_details,
+                )
+            }
+            StreamEvent::User(_) => (false, "User input".to_string(), vec![]),
+            StreamEvent::Result(r) => {
+                let status = if r.is_error { "Error" } else { "Success" };
+                (
+                    false,
+                    format!(
+                        "Complete: {} | Turns: {} | Cost: ${:.4}",
+                        status,
+                        r.num_turns.unwrap_or(0),
+                        r.total_cost_usd.unwrap_or(0.0)
+                    ),
+                    vec![],
+                )
+            }
+        };
+
+        Self {
+            expandable,
+            summary,
+            details,
+        }
+    }
+}
+
+/// Main application state
+pub struct AppState {
+    // Session info (from SystemEvent)
+    pub session_id: Option<String>,
+    pub model: Option<String>,
+
+    // Accumulated events
+    pub events: Vec<StreamEvent>,
+    pub display_events: Vec<DisplayEvent>,
+
+    // UI state
+    pub selected_index: usize,
+    pub expanded_items: HashSet<usize>,
+
+    // Stats (from ResultEvent)
+    pub total_cost_usd: f64,
+    pub num_turns: i64,
+    pub is_complete: bool,
+    pub is_error: bool,
+
+    // Channel state
+    pub channel_disconnected: bool,
+
+    // Interrupts
+    pub interrupts: Vec<InterruptSignal>,
+
+    // Result event for final output
+    pub result_event: Option<ResultEvent>,
+}
+
+impl Default for AppState {
+    fn default() -> Self {
+        Self {
+            session_id: None,
+            model: None,
+            events: Vec::new(),
+            display_events: Vec::new(),
+            selected_index: 0,
+            expanded_items: HashSet::new(),
+            total_cost_usd: 0.0,
+            num_turns: 0,
+            is_complete: false,
+            is_error: false,
+            channel_disconnected: false,
+            interrupts: Vec::new(),
+            result_event: None,
+        }
+    }
+}
+
+impl AppState {
+    /// Process a new event and update state
+    pub fn process_event(&mut self, event: StreamEvent) {
+        // Update session info from System event
+        if let StreamEvent::System(ref s) = event {
+            self.session_id = Some(s.session_id.clone());
+            self.model = Some(s.model.clone());
+        }
+
+        // Update stats from Result event
+        if let StreamEvent::Result(ref r) = event {
+            self.total_cost_usd = r.total_cost_usd.unwrap_or(0.0);
+            self.num_turns = r.num_turns.unwrap_or(0);
+            self.is_complete = true;
+            self.is_error = r.is_error;
+            self.result_event = Some(r.clone());
+        }
+
+        // Add display event
+        let display_event = DisplayEvent::from_stream_event(&event);
+        self.display_events.push(display_event);
+        self.events.push(event);
+
+        // Auto-scroll to bottom
+        if !self.display_events.is_empty() {
+            self.selected_index = self.display_events.len() - 1;
+        }
+    }
+
+    /// Add an interrupt signal
+    pub fn add_interrupt(&mut self, signal: InterruptSignal) {
+        self.interrupts.push(signal);
+    }
+
+    /// Convert to TuiResult for return to caller
+    pub fn into_result(self) -> TuiResult {
+        TuiResult {
+            events: self.events,
+            result_event: self.result_event,
+            interrupts: self.interrupts,
+        }
+    }
+
+    /// Toggle expansion of the currently selected item
+    pub fn toggle_expand(&mut self) {
+        if self.selected_index < self.display_events.len()
+            && self.display_events[self.selected_index].expandable
+        {
+            if self.expanded_items.contains(&self.selected_index) {
+                self.expanded_items.remove(&self.selected_index);
+            } else {
+                self.expanded_items.insert(self.selected_index);
+            }
+        }
+    }
+
+    /// Expand all expandable items
+    pub fn expand_all(&mut self) {
+        for (i, event) in self.display_events.iter().enumerate() {
+            if event.expandable {
+                self.expanded_items.insert(i);
+            }
+        }
+    }
+
+    /// Collapse all items
+    pub fn collapse_all(&mut self) {
+        self.expanded_items.clear();
+    }
+
+    /// Move selection up
+    pub fn scroll_up(&mut self) {
+        if self.selected_index > 0 {
+            self.selected_index -= 1;
+        }
+    }
+
+    /// Move selection down
+    pub fn scroll_down(&mut self) {
+        if self.selected_index + 1 < self.display_events.len() {
+            self.selected_index += 1;
+        }
+    }
+
+    /// Jump to top
+    pub fn go_to_top(&mut self) {
+        // Check empty for consistency with go_to_bottom()
+        if !self.display_events.is_empty() {
+            self.selected_index = 0;
+        }
+    }
+
+    /// Jump to bottom
+    pub fn go_to_bottom(&mut self) {
+        if !self.display_events.is_empty() {
+            self.selected_index = self.display_events.len() - 1;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add interactive TUI using ratatui for monitoring Claude Code sessions
- Scrollable event list with expand/collapse for tool call details
- Status bar showing session ID, model, turns, and cost
- Keyboard navigation (j/k scroll, Enter expand, q quit)
- `--no-tui` flag for CI/headless environments

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` - all 36 tests pass
- [x] `cargo clippy` - no warnings
- [ ] Manual testing with actual Claude Code session

🤖 Generated with [Claude Code](https://claude.com/claude-code)