### PR TITLE
feat(types-first-dev): Add zellij-cc resume/fork support for parallel agents

### DIFF
--- a/types-first-dev/src/TypesFirstDev/Types.hs
+++ b/types-first-dev/src/TypesFirstDev/Types.hs
@@ -276,6 +276,8 @@ data SkeletonGenerated = SkeletonGenerated
     -- ^ Project root path.
   , sgModuleName :: Text
     -- ^ Module name (e.g., "Data.Stack").
+  , sgSessionId :: Text
+    -- ^ Session ID from types agent (for forking parallel agents).
   }
   deriving stock (Show, Eq, Generic)
 
@@ -303,6 +305,8 @@ data StubsGenerated = StubsGenerated
     -- ^ Project root path.
   , stgModuleName :: Text
     -- ^ Module name (e.g., "UrlShortener").
+  , stgSessionId :: Text
+    -- ^ Session ID from stubs agent (for forking parallel agents).
   }
   deriving stock (Show, Eq, Generic)
   deriving anyclass (FromJSON, ToJSON)
@@ -453,6 +457,7 @@ instance StructuredOutput ForkInput
 -- | Results from parallel agents.
 --
 -- Combined output from tests and impl agents for merging.
+-- Includes session IDs and costs for tracking and aggregation.
 data ParallelResults = ParallelResults
   { prTestsWorktree :: WorktreePath
     -- ^ Path to tests worktree.
@@ -462,6 +467,16 @@ data ParallelResults = ParallelResults
     -- ^ Result metadata from tests agent.
   , prImplResult :: ImplResult
     -- ^ Result metadata from impl agent.
+  , prTestsSessionId :: Text
+    -- ^ Session ID from tests agent.
+  , prImplSessionId :: Text
+    -- ^ Session ID from impl agent.
+  , prTestsCost :: Double
+    -- ^ Cost (USD) from tests agent.
+  , prImplCost :: Double
+    -- ^ Cost (USD) from impl agent.
+  , prParentSessionId :: Text
+    -- ^ Parent session ID (from types/stubs agent) for lineage tracking.
   }
   deriving stock (Show, Eq, Generic)
 


### PR DESCRIPTION
## Summary
- Wire zellij-cc session resume and fork capabilities into types-first-dev
- Parallel agents (tests/impl) now fork from parent session (types/stubs)
- Add cost tracking from ClaudeCodeResult to RunMetadata

## Changes
- **Types.hs**: Add `sgSessionId` to `SkeletonGenerated`, `stgSessionId` to `StubsGenerated`, session/cost fields to `ParallelResults`
- **Handlers.hs**: Add `resumeSession`/`forkSession` params to agent runners; parallel agents fork with `(Just parentSessionId) True`
- **Stats.hs**: Add `AggregateStats` type and `aggregateCosts` for session chain tracking
- **Baseline.hs**: Use actual costs from `ClaudeCodeResult` in `RunMetadata`

## Test plan
- [ ] Run `cabal build types-first-dev` - verified locally
- [ ] Run baseline experiment to verify session forking works

🤖 Generated with [Claude Code](https://claude.com/claude-code)