### PR TITLE
feat(graph-dsl): Add ForkNode + BarrierNode for parallel execution

### DIFF
--- a/tidepool-core/src/Tidepool/Graph/Execute.hs
+++ b/tidepool-core/src/Tidepool/Graph/Execute.hs
@@ -71,7 +71,7 @@ import qualified Tidepool.Graph.Generic.Core as G (Exit)
 import Tidepool.Graph.Goto (GotoChoice, To, LLMHandler(..), ClaudeCodeLLMHandler(..), ClaudeCodeResult(..))
 import Tidepool.Graph.Goto.Internal (GotoChoice(..), OneOf(..))
 import Tidepool.Graph.Template (GingerContext)
-import Tidepool.Graph.Types (Exit, Self, SingModelChoice(..), KnownMaybeCwd(..))
+import Tidepool.Graph.Types (Exit, Self, Arrive, SingModelChoice(..), KnownMaybeCwd(..))
 import Tidepool.Schema (schemaToValue)
 import Tidepool.StructuredOutput (StructuredOutput(..), formatDiagnostic)
 
@@ -551,6 +551,31 @@ instance {-# OVERLAPPABLE #-}
 
 
 -- ════════════════════════════════════════════════════════════════════════════
+-- ARRIVE INSTANCES (for ForkNode workers)
+-- ════════════════════════════════════════════════════════════════════════════
+
+-- | Base case: Arrive is the only target.
+--
+-- When a parallel worker can only Arrive, it terminates and returns the result.
+-- The full Fork/Barrier orchestration layer collects these results at the barrier.
+--
+-- Note: In standalone dispatch (outside Fork context), Arrive behaves like Exit
+-- for that path. The fork orchestration layer interprets this differently.
+instance {-# OVERLAPPING #-} DispatchGoto graph '[To Arrive resultType] es resultType where
+  dispatchGoto _ (GotoChoice (Here result)) = pure result
+
+-- | Arrive is first, but there are more targets.
+--
+-- Handle the Arrive case (return result) or skip to rest of targets.
+instance {-# OVERLAPPABLE #-}
+  ( DispatchGoto graph rest es exitType
+  ) => DispatchGoto graph (To Arrive exitType ': rest) es exitType where
+  dispatchGoto _ (GotoChoice (Here result)) = pure result
+  dispatchGoto graph (GotoChoice (There rest)) =
+    dispatchGoto @graph @rest graph (GotoChoice rest)
+
+
+-- ════════════════════════════════════════════════════════════════════════════
 -- SELF-LOOP INSTANCES (error guidance)
 -- ════════════════════════════════════════════════════════════════════════════
 
@@ -754,6 +779,14 @@ instance
 instance
   ( DispatchGotoWithSelf graph selfPayload allTargets rest es exitType
   ) => DispatchGotoWithSelf graph selfPayload allTargets (To Exit exitType ': rest) es exitType where
+  dispatchGotoWithSelf _ _ (GotoChoice (Here result)) = pure result
+  dispatchGotoWithSelf selfHandler graph (GotoChoice (There rest)) =
+    dispatchGotoWithSelf @graph @selfPayload @allTargets @rest selfHandler graph (GotoChoice rest)
+
+-- | Arrive in current position: return result or skip (like Exit for parallel workers).
+instance
+  ( DispatchGotoWithSelf graph selfPayload allTargets rest es exitType
+  ) => DispatchGotoWithSelf graph selfPayload allTargets (To Arrive exitType ': rest) es exitType where
   dispatchGotoWithSelf _ _ (GotoChoice (Here result)) = pure result
   dispatchGotoWithSelf selfHandler graph (GotoChoice (There rest)) =
     dispatchGotoWithSelf @graph @selfPayload @allTargets @rest selfHandler graph (GotoChoice rest)

--- a/tidepool-core/src/Tidepool/Graph/Export.hs
+++ b/tidepool-core/src/Tidepool/Graph/Export.hs
@@ -283,6 +283,8 @@ kindToText :: RuntimeNodeKind -> Text
 kindToText RuntimeLLM = "LLM"
 kindToText RuntimeClaudeCode = "ClaudeCode"
 kindToText RuntimeLogic = "Logic"
+kindToText RuntimeFork = "Fork"
+kindToText RuntimeBarrier = "Barrier"
 
 -- | Convert RuntimeEdgeKind to text.
 edgeKindToText :: RuntimeEdgeKind -> Text

--- a/tidepool-core/src/Tidepool/Graph/Goto.hs
+++ b/tidepool-core/src/Tidepool/Graph/Goto.hs
@@ -46,6 +46,10 @@ module Tidepool.Graph.Goto
     Goto(..)
   , goto
 
+    -- * The Arrive Effect (for ForkNode workers)
+    -- Note: Arrive type is exported from Tidepool.Graph.Types
+  , arrive
+
     -- * OneOf Sum Type (constructors hidden - use smart constructors)
   , OneOf       -- Type only, constructors in Goto.Internal
   , NonEmptyList
@@ -62,6 +66,7 @@ module Tidepool.Graph.Goto
   , gotoChoice
   , gotoExit
   , gotoSelf
+  , gotoArrive
   , unwrapSingleChoice
 
     -- * LLM Handler Variants
@@ -88,7 +93,7 @@ import Tidepool.Graph.Errors
 import Text.Ginger.TH (TypedTemplate)
 import Text.Parsec.Pos (SourcePos)
 
-import Tidepool.Graph.Types (Exit, Self, ModelChoice(..), SingModelChoice(..), KnownMaybeCwd(..))
+import Tidepool.Graph.Types (Exit, Self, Arrive(..), ModelChoice(..), SingModelChoice(..), KnownMaybeCwd(..))
 
 -- Import from Internal (re-exports types, we hide constructors in this module's exports)
 import Tidepool.Graph.Goto.Internal (OneOf(..), GotoChoice(..), To, Payloads, PayloadOf)
@@ -214,6 +219,25 @@ goto :: forall {k} (target :: k) a effs. Member (Goto target a) effs => a -> Eff
 goto x = send (GotoOp x :: Goto target a ())
 
 -- ════════════════════════════════════════════════════════════════════════════
+-- ARRIVE EFFECT (FOR FORKNODE WORKERS)
+-- ════════════════════════════════════════════════════════════════════════════
+
+-- | Deposit a result at the barrier and suspend this path.
+--
+-- Workers spawned by ForkNode use this to deposit results at the barrier.
+-- Unlike 'goto @Exit' which terminates the entire graph, 'arrive' just
+-- completes the current parallel path.
+--
+-- @
+-- arrive @MyResult value
+-- @
+--
+-- Note: The 'Arrive' type is defined in "Tidepool.Graph.Types" with the
+-- 'ArriveOp' constructor.
+arrive :: forall result effs. Member (Arrive result) effs => result -> Eff effs ()
+arrive r = send (ArriveOp r)
+
+-- ════════════════════════════════════════════════════════════════════════════
 -- JSON SERIALIZATION
 -- ════════════════════════════════════════════════════════════════════════════
 
@@ -337,6 +361,24 @@ gotoSelf
      )
   => payload -> GotoChoice targets
 gotoSelf payload = GotoChoice (injectTarget @(To Self payload) @targets payload)
+
+-- | Construct a 'GotoChoice' for arriving at a barrier.
+--
+-- Workers spawned by ForkNode use this to deposit their result at the barrier
+-- and suspend their path. Unlike 'gotoExit' which terminates the entire graph,
+-- 'gotoArrive' only completes the current parallel path.
+--
+-- @
+-- gotoArrive myResult
+-- @
+gotoArrive
+  :: forall payload targets.
+     ( NonEmptyList targets
+     , InjectTarget (To Arrive payload) targets
+     , GotoElemC (To Arrive payload) targets
+     )
+  => payload -> GotoChoice targets
+gotoArrive payload = GotoChoice (injectTarget @(To Arrive payload) @targets payload)
 
 -- | Extract the payload from a single-target 'GotoChoice'.
 --

--- a/tidepool-core/src/Tidepool/Graph/Mermaid.hs
+++ b/tidepool-core/src/Tidepool/Graph/Mermaid.hs
@@ -186,6 +186,8 @@ renderNodeComments node = filter (not . T.null)
     kindText RuntimeLLM = "LLM"
     kindText RuntimeClaudeCode = "ClaudeCode"
     kindText RuntimeLogic = "Logic"
+    kindText RuntimeFork = "Fork"
+    kindText RuntimeBarrier = "Barrier"
 
 -- | Render template comment.
 renderTemplateComment :: Maybe TemplateInfo -> Text
@@ -245,9 +247,11 @@ renderNode config node =
             then node.niName <> "<br/>" <> kindLabel node
             else node.niName
     shape = case node.niKind of
-      RuntimeLLM       -> "[[\"" <> label <> "\"]]"
+      RuntimeLLM        -> "[[\"" <> label <> "\"]]"
       RuntimeClaudeCode -> "[[\"" <> label <> "\"]]"  -- Same shape as LLM
-      RuntimeLogic     -> "{{\"" <> label <> "\"}}"
+      RuntimeLogic      -> "{{\"" <> label <> "\"}}"
+      RuntimeFork       -> "{\"" <> label <> "\"}"     -- Diamond for fork
+      RuntimeBarrier    -> "[/\"" <> label <> "\"/]"   -- Trapezoid for barrier
 
     -- For ClaudeCode nodes, include the model name in the label
     kindLabel n = case n.niKind of
@@ -256,6 +260,8 @@ renderNode config node =
         Just cci -> "CC " <> cci.cciModel  -- e.g., "CC Sonnet"
         Nothing  -> "ClaudeCode"
       RuntimeLogic -> "Logic"
+      RuntimeFork -> "Fork"
+      RuntimeBarrier -> "Barrier"
 
 -- | Generate group (subgraph) declarations.
 groupDeclarations :: GraphInfo -> [Text]
@@ -415,6 +421,8 @@ renderState config node =
         Just cci -> "CC " <> cci.cciModel
         Nothing  -> "ClaudeCode"
       RuntimeLogic -> "Logic"
+      RuntimeFork -> "Fork"
+      RuntimeBarrier -> "Barrier"
 
 -- | Generate state transitions.
 stateTransitions :: MermaidConfig -> GraphInfo -> [Text]


### PR DESCRIPTION
## Summary

- Adds `ForkNode` and `BarrierNode` node markers for parallel execution patterns
- Adds `Spawn`, `Barrier`, `Awaits`, `Arrive` annotations for fork/barrier configuration
- Adds `HList` GADT for type-indexed heterogeneous lists
- Adds `SpawnPayloads` and `AwaitsHList` type families using HList (enables recursive dispatch instances)
- Adds `arrive` effect and `gotoArrive` smart constructor
- Updates validation to recognize `Arrive` as valid exit path for workers
- Adds Mermaid visualization (diamond for Fork, trapezoid for Barrier)

Example DSL usage:
```haskell
, fork :: mode :- ForkNode
    :@ Input Task
    :@ Spawn '[To "w1" Task, To "w2" Task]
    :@ Barrier "merge"

, w1 :: mode :- LLMNode :@ Input Task :@ Schema StepResult
    :@ UsesEffects '[Goto Self Task, Arrive Result]

, merge :: mode :- BarrierNode
    :@ Awaits '[Result, Result]
    :@ UsesEffects '[Goto Exit (Result, Result)]
```

HList-based handler types:
```haskell
-- ForkNode handler returns HList:
forkHandler :: Task -> Eff es (HList '[TaskA, TaskB])
forkHandler task = pure (taskA ::: taskB ::: HNil)

-- BarrierNode handler receives HList:
barrierHandler :: HList '[ResultA, ResultB] -> Eff es (GotoChoice targets)
barrierHandler (ra ::: rb ::: HNil) = pure $ gotoExit (ra, rb)
```

Using HList instead of tuples enables recursive type class instances for parallel dispatch without per-arity boilerplate.

**Note:** This PR provides the type-level infrastructure. Actual concurrent execution orchestration (running workers via `concurrently`, collecting results, feeding to barrier) is future work.

## Test plan

- [x] All 190 existing tests pass
- [x] Build compiles cleanly
- [ ] Manual verification of Mermaid diagram generation for fork/barrier graphs

🤖 Generated with [Claude Code](https://claude.com/claude-code)