### PR TITLE
feat(solid-frontend): Add generic UI components and DM wire types

### DIFF
--- a/tidepool-native-gui/solid-frontend/src/components/HintCard.tsx
+++ b/tidepool-native-gui/solid-frontend/src/components/HintCard.tsx
@@ -1,0 +1,86 @@
+import { Show, type Component } from "solid-js";
+
+interface Props {
+  value: string | number;
+  label?: string;
+  labelColor?: string;    // Tailwind text color class (e.g., "text-green-400")
+  hint?: string;
+  selected?: boolean;
+  disabled?: boolean;
+  onClick?: () => void;
+  shortcut?: string;      // Keyboard shortcut shown in corner (e.g., "1")
+}
+
+/**
+ * HintCard renders a selectable card with:
+ * - A prominent value (number or text)
+ * - An optional colored label below
+ * - An optional hint/description text
+ * - Selection and disabled states
+ * - Optional keyboard shortcut indicator
+ */
+const HintCard: Component<Props> = (props) => {
+  const handleClick = () => {
+    if (!props.disabled && props.onClick) {
+      props.onClick();
+    }
+  };
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if ((e.key === "Enter" || e.key === " ") && !props.disabled) {
+      e.preventDefault();
+      props.onClick?.();
+    }
+  };
+
+  return (
+    <div
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      tabIndex={props.disabled ? -1 : 0}
+      role="button"
+      aria-pressed={props.selected}
+      aria-disabled={props.disabled}
+      class={`
+        relative flex flex-col items-center p-4 rounded-lg cursor-pointer transition-all
+        min-w-[120px] max-w-[160px]
+        border-2 ${props.selected ? "border-blue-500 bg-blue-900/30" : "border-gray-600 bg-gray-800"}
+        ${props.disabled ? "opacity-50 cursor-not-allowed" : "hover:bg-gray-700 hover:border-gray-500"}
+        focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-900
+      `}
+    >
+      {/* Keyboard shortcut indicator */}
+      <Show when={props.shortcut}>
+        <span class="absolute top-1 right-2 text-xs text-gray-500 font-mono">
+          {props.shortcut}
+        </span>
+      </Show>
+
+      {/* Main value */}
+      <span class="text-3xl font-bold text-gray-100 mb-1">
+        {props.value}
+      </span>
+
+      {/* Label */}
+      <Show when={props.label}>
+        <span class={`text-sm font-semibold uppercase tracking-wide ${props.labelColor ?? "text-gray-400"}`}>
+          {props.label}
+        </span>
+      </Show>
+
+      {/* Divider */}
+      <Show when={props.hint}>
+        <div class="w-full border-t border-gray-600 my-2" />
+      </Show>
+
+      {/* Hint text */}
+      <Show when={props.hint}>
+        <p class="text-xs text-gray-400 text-center italic leading-relaxed">
+          "{props.hint}"
+        </p>
+      </Show>
+    </div>
+  );
+};
+
+export default HintCard;

--- a/tidepool-native-gui/solid-frontend/src/components/HintCardGroup.tsx
+++ b/tidepool-native-gui/solid-frontend/src/components/HintCardGroup.tsx
@@ -1,0 +1,95 @@
+import { For, onCleanup, onMount, Show, type Component } from "solid-js";
+import HintCard from "./HintCard";
+
+interface CardData {
+  value: string | number;
+  label?: string;
+  labelColor?: string;
+  hint?: string;
+  disabled?: boolean;
+}
+
+interface Props {
+  cards: CardData[];
+  onSelect: (index: number) => void;
+  disabled?: boolean;
+  header?: string;
+  subheader?: string;
+  enableNumberKeys?: boolean;  // Enable 1-9 keyboard shortcuts (default: true)
+}
+
+/**
+ * HintCardGroup renders a horizontal group of HintCards with:
+ * - Optional header and subheader
+ * - Keyboard navigation (1-9 keys select cards)
+ * - Proper accessibility attributes
+ */
+const HintCardGroup: Component<Props> = (props) => {
+  const handleKeyDown = (e: KeyboardEvent) => {
+    // Check reactive props inside handler (Solid proxies are live)
+    if (props.disabled) return;
+    if (props.enableNumberKeys === false) return;
+
+    // Check for number keys 1-9
+    const num = parseInt(e.key, 10);
+    if (num >= 1 && num <= 9) {
+      const index = num - 1;
+      if (index < props.cards.length && !props.cards[index]?.disabled) {
+        e.preventDefault();
+        props.onSelect(index);
+      }
+    }
+  };
+
+  onMount(() => {
+    document.addEventListener("keydown", handleKeyDown);
+  });
+
+  onCleanup(() => {
+    document.removeEventListener("keydown", handleKeyDown);
+  });
+
+  return (
+    <div class="bg-gray-800 border-t border-gray-700 p-4">
+      {/* Header */}
+      <Show when={props.header}>
+        <h3 class="text-sm font-medium text-gray-300 mb-1">{props.header}</h3>
+      </Show>
+
+      {/* Subheader */}
+      <Show when={props.subheader}>
+        <p class="text-xs text-gray-500 mb-3">{props.subheader}</p>
+      </Show>
+
+      {/* Cards */}
+      <div
+        class="flex flex-wrap gap-3 justify-center"
+        role="group"
+        aria-label={props.header ?? "Select an option"}
+      >
+        <For each={props.cards}>
+          {(card, index) => (
+            <HintCard
+              value={card.value}
+              label={card.label}
+              labelColor={card.labelColor}
+              hint={card.hint}
+              disabled={props.disabled || card.disabled}
+              onClick={() => props.onSelect(index())}
+              shortcut={props.enableNumberKeys !== false && index() < 9 ? String(index() + 1) : undefined}
+            />
+          )}
+        </For>
+      </div>
+
+      {/* Keyboard hint */}
+      <Show when={props.enableNumberKeys !== false && props.cards.length > 0}>
+        <p class="text-xs text-gray-600 text-center mt-3">
+          Press 1-{Math.min(props.cards.length, 9)} to select
+        </p>
+      </Show>
+    </div>
+  );
+};
+
+export default HintCardGroup;

--- a/tidepool-native-gui/solid-frontend/src/components/ProgressClock.tsx
+++ b/tidepool-native-gui/solid-frontend/src/components/ProgressClock.tsx
@@ -1,0 +1,96 @@
+import { For, Show, type Component } from "solid-js";
+
+interface Props {
+  segments: number;       // Total segments (commonly 4, 6, or 8)
+  filled: number;         // Filled segments
+  label?: string;         // Label below clock
+  fillColor?: string;     // SVG fill color (default: "#ef4444" - red)
+  emptyColor?: string;    // SVG stroke color (default: "#374151" - gray-700)
+  size?: number;          // Diameter in pixels (default: 48)
+  urgent?: boolean;       // Show glow effect when nearly full
+}
+
+/**
+ * ProgressClock renders an SVG pie/segment clock.
+ * Each segment is a pie slice of the circle.
+ */
+const ProgressClock: Component<Props> = (props) => {
+  const size = () => props.size ?? 48;
+  const radius = () => size() / 2 - 2; // Leave room for stroke
+  const center = () => size() / 2;
+  const safeSegments = () => Math.max(1, props.segments); // Prevent division by zero
+
+  // Calculate the SVG path for a pie segment
+  const segmentPath = (index: number, total: number) => {
+    const safeTotal = Math.max(1, total);
+    const anglePerSegment = (2 * Math.PI) / safeTotal;
+    const startAngle = index * anglePerSegment - Math.PI / 2; // Start from top
+    const endAngle = startAngle + anglePerSegment;
+    const gap = 0.03; // Small gap between segments
+
+    const r = radius();
+    const cx = center();
+    const cy = center();
+
+    const x1 = cx + r * Math.cos(startAngle + gap);
+    const y1 = cy + r * Math.sin(startAngle + gap);
+    const x2 = cx + r * Math.cos(endAngle - gap);
+    const y2 = cy + r * Math.sin(endAngle - gap);
+
+    const largeArc = anglePerSegment > Math.PI ? 1 : 0;
+
+    return `M ${cx} ${cy} L ${x1} ${y1} A ${r} ${r} 0 ${largeArc} 1 ${x2} ${y2} Z`;
+  };
+
+  const isUrgent = () => props.urgent && props.filled >= safeSegments() - 1;
+  const fillColor = () => props.fillColor ?? "#ef4444";
+
+  return (
+    <div class="flex flex-col items-center">
+      <svg
+        width={size()}
+        height={size()}
+        class={`transition-all ${isUrgent() ? "drop-shadow-lg" : ""}`}
+        style={isUrgent() ? { filter: `drop-shadow(0 0 8px ${fillColor()})` } : {}}
+      >
+        {/* Background circle */}
+        <circle
+          cx={center()}
+          cy={center()}
+          r={radius()}
+          fill="none"
+          stroke={props.emptyColor ?? "#374151"}
+          stroke-width="1"
+        />
+
+        {/* Segments */}
+        <For each={Array.from({ length: safeSegments() }, (_, i) => i)}>
+          {(index) => (
+            <path
+              d={segmentPath(index, safeSegments())}
+              fill={index < props.filled ? fillColor() : "transparent"}
+              stroke={props.emptyColor ?? "#374151"}
+              stroke-width="1"
+            />
+          )}
+        </For>
+      </svg>
+
+      {/* Label */}
+      <Show when={props.label}>
+        <span class="text-xs text-gray-400 mt-1 text-center max-w-[80px] truncate">
+          {props.label}
+        </span>
+      </Show>
+
+      {/* Urgent indicator */}
+      <Show when={isUrgent()}>
+        <span class="text-xs font-semibold mt-0.5" style={{ color: fillColor() }}>
+          URGENT
+        </span>
+      </Show>
+    </div>
+  );
+};
+
+export default ProgressClock;

--- a/tidepool-native-gui/solid-frontend/src/components/SegmentedBar.tsx
+++ b/tidepool-native-gui/solid-frontend/src/components/SegmentedBar.tsx
@@ -1,0 +1,67 @@
+import { For, Show, type Component } from "solid-js";
+
+interface Props {
+  total: number;          // Total segments
+  filled: number;         // Filled count
+  label?: string;         // Optional label above bar
+  color?: string;         // Tailwind fill color (default: "bg-blue-500")
+  emptyColor?: string;    // Tailwind empty color (default: "bg-gray-700")
+  showCount?: boolean;    // Show "5/9" (default: true)
+  size?: "sm" | "md" | "lg";
+}
+
+/**
+ * SegmentedBar renders a horizontal bar with N segments, some filled.
+ * Useful for stress, heat, HP, mana, or any numeric tracker with a max.
+ */
+const SegmentedBar: Component<Props> = (props) => {
+  const sizeClasses = () => {
+    switch (props.size) {
+      case "sm": return { segment: "h-2", gap: "gap-0.5" };
+      case "lg": return { segment: "h-5", gap: "gap-1.5" };
+      default: return { segment: "h-3", gap: "gap-1" };
+    }
+  };
+
+  // Clamp values to valid ranges
+  const safeTotal = () => Math.max(1, props.total);
+  const safeFilled = () => Math.max(0, Math.min(props.filled, safeTotal()));
+  const segments = () => Array.from({ length: safeTotal() }, (_, i) => i < safeFilled());
+
+  return (
+    <div class="flex flex-col">
+      {/* Label */}
+      <Show when={props.label}>
+        <span class="text-xs font-medium text-gray-400 uppercase tracking-wide mb-1">
+          {props.label}
+        </span>
+      </Show>
+
+      <div class="flex items-center gap-2">
+        {/* Segments */}
+        <div class={`flex ${sizeClasses().gap} flex-1`}>
+          <For each={segments()}>
+            {(isFilled) => (
+              <div
+                class={`
+                  flex-1 rounded-sm transition-colors
+                  ${sizeClasses().segment}
+                  ${isFilled ? (props.color ?? "bg-blue-500") : (props.emptyColor ?? "bg-gray-700")}
+                `}
+              />
+            )}
+          </For>
+        </div>
+
+        {/* Count */}
+        <Show when={props.showCount !== false}>
+          <span class="text-xs text-gray-500 font-mono min-w-[32px] text-right">
+            {safeFilled()}/{safeTotal()}
+          </span>
+        </Show>
+      </div>
+    </div>
+  );
+};
+
+export default SegmentedBar;

--- a/tidepool-native-gui/solid-frontend/src/components/StatusBadge.tsx
+++ b/tidepool-native-gui/solid-frontend/src/components/StatusBadge.tsx
@@ -1,0 +1,51 @@
+import { Show, type Component } from "solid-js";
+
+type BadgeColor = "blue" | "green" | "yellow" | "orange" | "red" | "purple" | "amber" | "gray";
+
+interface Props {
+  label: string;
+  variant?: string;       // Secondary text after ":"
+  color?: BadgeColor;
+  glow?: boolean;
+  size?: "sm" | "md";
+}
+
+const colorClasses: Record<BadgeColor, { bg: string; text: string; glow: string }> = {
+  blue: { bg: "bg-blue-900/50", text: "text-blue-300", glow: "shadow-blue-500/50" },
+  green: { bg: "bg-green-900/50", text: "text-green-300", glow: "shadow-green-500/50" },
+  yellow: { bg: "bg-yellow-900/50", text: "text-yellow-300", glow: "shadow-yellow-500/50" },
+  orange: { bg: "bg-orange-900/50", text: "text-orange-300", glow: "shadow-orange-500/50" },
+  red: { bg: "bg-red-900/50", text: "text-red-300", glow: "shadow-red-500/50" },
+  purple: { bg: "bg-purple-900/50", text: "text-purple-300", glow: "shadow-purple-500/50" },
+  amber: { bg: "bg-amber-900/50", text: "text-amber-300", glow: "shadow-amber-500/50" },
+  gray: { bg: "bg-gray-700", text: "text-gray-300", glow: "shadow-gray-500/50" },
+};
+
+/**
+ * StatusBadge renders a color-coded badge/chip.
+ * Format: [Label: Variant] or [Label] if no variant.
+ */
+const StatusBadge: Component<Props> = (props) => {
+  const color = () => colorClasses[props.color ?? "gray"];
+  const sizeClasses = () => props.size === "sm" ? "px-2 py-0.5 text-xs" : "px-3 py-1 text-sm";
+
+  return (
+    <span
+      class={`
+        inline-flex items-center rounded-full font-medium
+        border border-current/20
+        ${color().bg} ${color().text}
+        ${sizeClasses()}
+        ${props.glow ? `shadow-lg ${color().glow}` : ""}
+      `}
+    >
+      <span class="font-semibold">{props.label}</span>
+      <Show when={props.variant}>
+        <span class="opacity-60 mx-1">:</span>
+        <span>{props.variant}</span>
+      </Show>
+    </span>
+  );
+};
+
+export default StatusBadge;

--- a/tidepool-native-gui/solid-frontend/src/components/index.ts
+++ b/tidepool-native-gui/solid-frontend/src/components/index.ts
@@ -1,3 +1,10 @@
 export { default as ChatMessage } from "./ChatMessage";
 export { default as InputArea } from "./InputArea";
 export { default as ChoiceGroup } from "./ChoiceGroup";
+
+// Generic UI primitives
+export { default as HintCard } from "./HintCard";
+export { default as HintCardGroup } from "./HintCardGroup";
+export { default as StatusBadge } from "./StatusBadge";
+export { default as SegmentedBar } from "./SegmentedBar";
+export { default as ProgressClock } from "./ProgressClock";

--- a/tidepool-native-gui/solid-frontend/src/lib/socket.ts
+++ b/tidepool-native-gui/solid-frontend/src/lib/socket.ts
@@ -16,6 +16,13 @@ const DEFAULT_UI_STATE: UIState = {
   choices: null,
   graphNode: "init",
   thinking: false,
+  // DM fields - default to null/empty
+  dmStats: null,
+  dmClocks: [],
+  dmDicePool: null,
+  dmMood: null,
+  dmCharCreation: null,
+  dmHistory: [],
 };
 
 export function createSocket(url: string) {

--- a/tidepool-native-gui/wire-types/src/Tidepool/Wire/Types.hs
+++ b/tidepool-native-gui/wire-types/src/Tidepool/Wire/Types.hs
@@ -12,12 +12,39 @@ module Tidepool.Wire.Types
   , ChoiceOption(..)
   , ChoiceConfig(..)
 
+    -- * DM-specific types
+  , DMStats(..)
+  , Precarity(..)
+  , Clock(..)
+  , ClockColor(..)
+  , Position(..)
+  , Effect(..)
+  , OutcomeTier(..)
+  , DieOption(..)
+  , DicePool(..)
+  , DMMood(..)
+  , SceneVariant(..)
+  , Urgency(..)
+  , ActionVariant(..)
+  , ActionDomain(..)
+  , AftermathVariant(..)
+  , DowntimeVariant(..)
+  , BargainOption(..)
+  , BargainCost(..)
+  , CharCreationStep(..)
+  , CharacterCreation(..)
+  , Archetype(..)
+  , Pronouns(..)
+  , TarotCard(..)
+  , TarotSpread(..)
+  , HistoryEntry(..)
+
     -- * Client → Server
   , UserAction(..)
   ) where
 
 import Data.Text (Text)
-import Data.Aeson (ToJSON(..), FromJSON(..), object, (.=), withObject, withText, (.:), (.:?))
+import Data.Aeson (ToJSON(..), FromJSON(..), object, (.=), withObject, withText, (.:), (.:?), (.!=))
 import qualified Data.Aeson.Types as Aeson
 import GHC.Generics (Generic)
 
@@ -34,6 +61,13 @@ data UIState = UIState
   , usChoices :: Maybe ChoiceConfig
   , usGraphNode :: Text
   , usThinking :: Bool
+  -- DM-specific fields
+  , usDMStats :: Maybe DMStats
+  , usDMClocks :: [Clock]
+  , usDMDicePool :: Maybe DicePool
+  , usDMMood :: Maybe DMMood
+  , usDMCharCreation :: Maybe CharacterCreation
+  , usDMHistory :: [HistoryEntry]
   }
   deriving (Show, Eq, Generic)
 
@@ -45,6 +79,12 @@ instance ToJSON UIState where
     , "choices" .= usChoices s
     , "graphNode" .= usGraphNode s
     , "thinking" .= usThinking s
+    , "dmStats" .= usDMStats s
+    , "dmClocks" .= usDMClocks s
+    , "dmDicePool" .= usDMDicePool s
+    , "dmMood" .= usDMMood s
+    , "dmCharCreation" .= usDMCharCreation s
+    , "dmHistory" .= usDMHistory s
     ]
 
 instance FromJSON UIState where
@@ -56,6 +96,12 @@ instance FromJSON UIState where
       <*> v .:? "choices"
       <*> v .: "graphNode"
       <*> v .: "thinking"
+      <*> v .:? "dmStats"
+      <*> (v .:? "dmClocks" .!= [])
+      <*> v .:? "dmDicePool"
+      <*> v .:? "dmMood"
+      <*> v .:? "dmCharCreation"
+      <*> (v .:? "dmHistory" .!= [])
 
 -- | Chat message in conversation history.
 data ChatMessage = ChatMessage
@@ -167,6 +213,606 @@ instance FromJSON ChoiceConfig where
       <$> v .: "prompt"
       <*> v .: "options"
       <*> v .: "multiSelect"
+
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- DM-Specific Types (Blades-inspired, v1 port)
+-- ════════════════════════════════════════════════════════════════════════════
+
+-- | Precarity level - drives narrative voice intensity.
+-- Calculated as: stress + heat + (wanted * 2) + hunted bonus - recovering penalty
+data Precarity
+  = OperatingFromStrength  -- ^ score < 5: expansive, plant threats
+  | RoomToManeuver         -- ^ 5-9: balanced tension
+  | WallsClosingIn         -- ^ 10-14: urgent, compressed
+  | HangingByThread        -- ^ >= 15: desperate, every word counts
+  deriving (Show, Eq, Generic)
+
+instance ToJSON Precarity where
+  toJSON OperatingFromStrength = "operatingFromStrength"
+  toJSON RoomToManeuver = "roomToManeuver"
+  toJSON WallsClosingIn = "wallsClosingIn"
+  toJSON HangingByThread = "hangingByThread"
+
+instance FromJSON Precarity where
+  parseJSON = withText "Precarity" $ \case
+    "operatingFromStrength" -> pure OperatingFromStrength
+    "roomToManeuver" -> pure RoomToManeuver
+    "wallsClosingIn" -> pure WallsClosingIn
+    "hangingByThread" -> pure HangingByThread
+    t -> fail $ "Unknown precarity: " ++ show t
+
+-- | Character stats for sidebar display.
+data DMStats = DMStats
+  { dmsStress :: Int         -- ^ 0-9, trauma at 9
+  , dmsHeat :: Int           -- ^ 0-9
+  , dmsCoin :: Int
+  , dmsWantedLevel :: Int    -- ^ 0-4
+  , dmsTrauma :: [Text]      -- ^ Freeform trauma names (LLM-determined)
+  , dmsPrecarity :: Precarity
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToJSON DMStats where
+  toJSON s = object
+    [ "stress" .= dmsStress s
+    , "heat" .= dmsHeat s
+    , "coin" .= dmsCoin s
+    , "wantedLevel" .= dmsWantedLevel s
+    , "trauma" .= dmsTrauma s
+    , "precarity" .= dmsPrecarity s
+    ]
+
+instance FromJSON DMStats where
+  parseJSON = withObject "DMStats" $ \v ->
+    DMStats
+      <$> v .: "stress"
+      <*> v .: "heat"
+      <*> v .: "coin"
+      <*> v .: "wantedLevel"
+      <*> v .: "trauma"
+      <*> v .: "precarity"
+
+-- | Clock color/type.
+data ClockColor = ClockThreat | ClockOpportunity | ClockNeutral
+  deriving (Show, Eq, Generic)
+
+instance ToJSON ClockColor where
+  toJSON ClockThreat = "threat"
+  toJSON ClockOpportunity = "opportunity"
+  toJSON ClockNeutral = "neutral"
+
+instance FromJSON ClockColor where
+  parseJSON = withText "ClockColor" $ \case
+    "threat" -> pure ClockThreat
+    "opportunity" -> pure ClockOpportunity
+    "neutral" -> pure ClockNeutral
+    t -> fail $ "Unknown clock color: " ++ show t
+
+-- | Progress clock for tracking threats and opportunities.
+data Clock = Clock
+  { clkId :: Text
+  , clkName :: Text
+  , clkSegments :: Int
+  , clkFilled :: Int
+  , clkVisible :: Bool       -- ^ False = hidden GM clock (revealed when triggered)
+  , clkColor :: ClockColor
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToJSON Clock where
+  toJSON c = object
+    [ "id" .= clkId c
+    , "name" .= clkName c
+    , "segments" .= clkSegments c
+    , "filled" .= clkFilled c
+    , "visible" .= clkVisible c
+    , "color" .= clkColor c
+    ]
+
+instance FromJSON Clock where
+  parseJSON = withObject "Clock" $ \v ->
+    Clock
+      <$> v .: "id"
+      <*> v .: "name"
+      <*> v .: "segments"
+      <*> v .: "filled"
+      <*> v .: "visible"
+      <*> v .: "color"
+
+-- | Action position (risk level).
+data Position = Controlled | Risky | Desperate
+  deriving (Show, Eq, Generic)
+
+instance ToJSON Position where
+  toJSON Controlled = "controlled"
+  toJSON Risky = "risky"
+  toJSON Desperate = "desperate"
+
+instance FromJSON Position where
+  parseJSON = withText "Position" $ \case
+    "controlled" -> pure Controlled
+    "risky" -> pure Risky
+    "desperate" -> pure Desperate
+    t -> fail $ "Unknown position: " ++ show t
+
+-- | Action effect level.
+data Effect = Limited | Standard | Great
+  deriving (Show, Eq, Generic)
+
+instance ToJSON Effect where
+  toJSON Limited = "limited"
+  toJSON Standard = "standard"
+  toJSON Great = "great"
+
+instance FromJSON Effect where
+  parseJSON = withText "Effect" $ \case
+    "limited" -> pure Limited
+    "standard" -> pure Standard
+    "great" -> pure Great
+    t -> fail $ "Unknown effect: " ++ show t
+
+-- | Outcome tier - calculated from die value and position.
+data OutcomeTier
+  = TierCritical   -- ^ 6 at any position
+  | TierSuccess    -- ^ 4-5
+  | TierPartial    -- ^ 2-3 (or 1-3 at Controlled)
+  | TierBad        -- ^ 1 at Risky
+  | TierDisaster   -- ^ 1 at Desperate
+  deriving (Show, Eq, Generic)
+
+instance ToJSON OutcomeTier where
+  toJSON TierCritical = "critical"
+  toJSON TierSuccess = "success"
+  toJSON TierPartial = "partial"
+  toJSON TierBad = "bad"
+  toJSON TierDisaster = "disaster"
+
+instance FromJSON OutcomeTier where
+  parseJSON = withText "OutcomeTier" $ \case
+    "critical" -> pure TierCritical
+    "success" -> pure TierSuccess
+    "partial" -> pure TierPartial
+    "bad" -> pure TierBad
+    "disaster" -> pure TierDisaster
+    t -> fail $ "Unknown outcome tier: " ++ show t
+
+-- | Single die option with LLM-generated preview.
+-- All hints are generated at once when entering Action mood (precommitment).
+data DieOption = DieOption
+  { doValue :: Int           -- ^ 1-6
+  , doTier :: OutcomeTier    -- ^ Calculated from position
+  , doHint :: Text           -- ^ LLM-generated preview of this outcome
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToJSON DieOption where
+  toJSON d = object
+    [ "value" .= doValue d
+    , "tier" .= doTier d
+    , "hint" .= doHint d
+    ]
+
+instance FromJSON DieOption where
+  parseJSON = withObject "DieOption" $ \v ->
+    DieOption
+      <$> v .: "value"
+      <*> v .: "tier"
+      <*> v .: "hint"
+
+-- | Dice pool state. Pool depletes across session until bargain mode.
+data DicePool = DicePool
+  { dpDice :: [DieOption]        -- ^ Remaining dice (starts at 5, depletes)
+  , dpPosition :: Position
+  , dpEffect :: Effect
+  , dpContext :: Text            -- ^ What they're attempting
+  , dpPushAvailable :: Bool      -- ^ Can push yourself for +1d (costs 2 stress)
+  , dpDevilBargain :: Maybe Text -- ^ Offered bargain (accept for +1d)
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToJSON DicePool where
+  toJSON p = object
+    [ "dice" .= dpDice p
+    , "position" .= dpPosition p
+    , "effect" .= dpEffect p
+    , "context" .= dpContext p
+    , "pushAvailable" .= dpPushAvailable p
+    , "devilBargain" .= dpDevilBargain p
+    ]
+
+instance FromJSON DicePool where
+  parseJSON = withObject "DicePool" $ \v ->
+    DicePool
+      <$> v .: "dice"
+      <*> v .: "position"
+      <*> v .: "effect"
+      <*> v .: "context"
+      <*> v .: "pushAvailable"
+      <*> v .:? "devilBargain"
+
+-- | Scene urgency level.
+data Urgency = UrgencyLow | UrgencyMedium | UrgencyHigh | UrgencyCritical
+  deriving (Show, Eq, Generic)
+
+instance ToJSON Urgency where
+  toJSON UrgencyLow = "low"
+  toJSON UrgencyMedium = "medium"
+  toJSON UrgencyHigh = "high"
+  toJSON UrgencyCritical = "critical"
+
+instance FromJSON Urgency where
+  parseJSON = withText "Urgency" $ \case
+    "low" -> pure UrgencyLow
+    "medium" -> pure UrgencyMedium
+    "high" -> pure UrgencyHigh
+    "critical" -> pure UrgencyCritical
+    t -> fail $ "Unknown urgency: " ++ show t
+
+-- | Scene variant - what kind of scene this is.
+data SceneVariant
+  = SvEncounter Urgency      -- ^ Someone/something demands attention
+  | SvOpportunity Text       -- ^ Something offered (with a catch)
+  | SvDiscovery Text         -- ^ Found something with implications
+  deriving (Show, Eq, Generic)
+
+instance ToJSON SceneVariant where
+  toJSON (SvEncounter u) = object ["variant" .= ("encounter" :: Text), "urgency" .= u]
+  toJSON (SvOpportunity t) = object ["variant" .= ("opportunity" :: Text), "catch" .= t]
+  toJSON (SvDiscovery t) = object ["variant" .= ("discovery" :: Text), "implications" .= t]
+
+instance FromJSON SceneVariant where
+  parseJSON = withObject "SceneVariant" $ \v -> do
+    var <- v .: "variant" :: Aeson.Parser Text
+    case var of
+      "encounter" -> SvEncounter <$> v .: "urgency"
+      "opportunity" -> SvOpportunity <$> v .: "catch"
+      "discovery" -> SvDiscovery <$> v .: "implications"
+      _ -> fail $ "Unknown scene variant: " ++ show var
+
+-- | Action domain overlay.
+data ActionDomain = DomInfiltration | DomSocial | DomViolence | DomPursuit | DomArcane
+  deriving (Show, Eq, Generic)
+
+instance ToJSON ActionDomain where
+  toJSON DomInfiltration = "infiltration"
+  toJSON DomSocial = "social"
+  toJSON DomViolence = "violence"
+  toJSON DomPursuit = "pursuit"
+  toJSON DomArcane = "arcane"
+
+instance FromJSON ActionDomain where
+  parseJSON = withText "ActionDomain" $ \case
+    "infiltration" -> pure DomInfiltration
+    "social" -> pure DomSocial
+    "violence" -> pure DomViolence
+    "pursuit" -> pure DomPursuit
+    "arcane" -> pure DomArcane
+    t -> fail $ "Unknown action domain: " ++ show t
+
+-- | Action variant - risk level with context.
+data ActionVariant
+  = AvControlled Text Text   -- ^ Advantage, risk on failure
+  | AvRisky Text Text        -- ^ Standard danger, standard stakes
+  | AvDesperate Text Text    -- ^ Serious danger, severe consequences
+  deriving (Show, Eq, Generic)
+
+instance ToJSON ActionVariant where
+  toJSON (AvControlled threat opp) = object
+    ["variant" .= ("controlled" :: Text), "threat" .= threat, "opportunity" .= opp]
+  toJSON (AvRisky threat opp) = object
+    ["variant" .= ("risky" :: Text), "threat" .= threat, "opportunity" .= opp]
+  toJSON (AvDesperate threat opp) = object
+    ["variant" .= ("desperate" :: Text), "threat" .= threat, "opportunity" .= opp]
+
+instance FromJSON ActionVariant where
+  parseJSON = withObject "ActionVariant" $ \v -> do
+    var <- v .: "variant" :: Aeson.Parser Text
+    case var of
+      "controlled" -> AvControlled <$> v .: "threat" <*> v .: "opportunity"
+      "risky" -> AvRisky <$> v .: "threat" <*> v .: "opportunity"
+      "desperate" -> AvDesperate <$> v .: "threat" <*> v .: "opportunity"
+      _ -> fail $ "Unknown action variant: " ++ show var
+
+-- | Aftermath variant - how the action resolved.
+data AftermathVariant
+  = AmClean                  -- ^ Just achieved goal
+  | AmCostly Text            -- ^ Achieved goal but at cost
+  | AmSetback Text           -- ^ Things went wrong (with escape route)
+  | AmDisaster               -- ^ Catastrophic failure
+  deriving (Show, Eq, Generic)
+
+instance ToJSON AftermathVariant where
+  toJSON AmClean = object ["variant" .= ("clean" :: Text)]
+  toJSON (AmCostly cost) = object ["variant" .= ("costly" :: Text), "cost" .= cost]
+  toJSON (AmSetback escape) = object ["variant" .= ("setback" :: Text), "escape" .= escape]
+  toJSON AmDisaster = object ["variant" .= ("disaster" :: Text)]
+
+instance FromJSON AftermathVariant where
+  parseJSON = withObject "AftermathVariant" $ \v -> do
+    var <- v .: "variant" :: Aeson.Parser Text
+    case var of
+      "clean" -> pure AmClean
+      "costly" -> AmCostly <$> v .: "cost"
+      "setback" -> AmSetback <$> v .: "escape"
+      "disaster" -> pure AmDisaster
+      _ -> fail $ "Unknown aftermath variant: " ++ show var
+
+-- | Downtime variant - what kind of downtime activity.
+data DowntimeVariant
+  = DtRecovery [Text]        -- ^ Available activities
+  | DtProject Text Int       -- ^ Long-term work, progress ticks
+  | DtEntanglement Text      -- ^ Heat catches up
+  deriving (Show, Eq, Generic)
+
+instance ToJSON DowntimeVariant where
+  toJSON (DtRecovery acts) = object ["variant" .= ("recovery" :: Text), "activities" .= acts]
+  toJSON (DtProject name prog) = object
+    ["variant" .= ("project" :: Text), "name" .= name, "progress" .= prog]
+  toJSON (DtEntanglement desc) = object ["variant" .= ("entanglement" :: Text), "description" .= desc]
+
+instance FromJSON DowntimeVariant where
+  parseJSON = withObject "DowntimeVariant" $ \v -> do
+    var <- v .: "variant" :: Aeson.Parser Text
+    case var of
+      "recovery" -> DtRecovery <$> v .: "activities"
+      "project" -> DtProject <$> v .: "name" <*> v .: "progress"
+      "entanglement" -> DtEntanglement <$> v .: "description"
+      _ -> fail $ "Unknown downtime variant: " ++ show var
+
+-- | Bargain cost types.
+data BargainCost
+  = CostStress Int
+  | CostHeat Int
+  | CostWanted
+  | CostClockTick Text Int   -- ^ Clock name, segments to tick
+  | CostFactionDebt Text     -- ^ Faction name
+  | CostTrauma
+  | CostItem Text            -- ^ Item lost
+  deriving (Show, Eq, Generic)
+
+instance ToJSON BargainCost where
+  toJSON (CostStress n) = object ["type" .= ("stress" :: Text), "amount" .= n]
+  toJSON (CostHeat n) = object ["type" .= ("heat" :: Text), "amount" .= n]
+  toJSON CostWanted = object ["type" .= ("wanted" :: Text)]
+  toJSON (CostClockTick name segs) = object
+    ["type" .= ("clockTick" :: Text), "clock" .= name, "segments" .= segs]
+  toJSON (CostFactionDebt faction) = object ["type" .= ("factionDebt" :: Text), "faction" .= faction]
+  toJSON CostTrauma = object ["type" .= ("trauma" :: Text)]
+  toJSON (CostItem item) = object ["type" .= ("item" :: Text), "item" .= item]
+
+instance FromJSON BargainCost where
+  parseJSON = withObject "BargainCost" $ \v -> do
+    ty <- v .: "type" :: Aeson.Parser Text
+    case ty of
+      "stress" -> CostStress <$> v .: "amount"
+      "heat" -> CostHeat <$> v .: "amount"
+      "wanted" -> pure CostWanted
+      "clockTick" -> CostClockTick <$> v .: "clock" <*> v .: "segments"
+      "factionDebt" -> CostFactionDebt <$> v .: "faction"
+      "trauma" -> pure CostTrauma
+      "item" -> CostItem <$> v .: "item"
+      _ -> fail $ "Unknown bargain cost type: " ++ show ty
+
+-- | Bargain option - LLM-generated contextual deal.
+data BargainOption = BargainOption
+  { boLabel :: Text
+  , boCost :: BargainCost
+  , boDescription :: Text    -- ^ LLM explains what this deal means
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToJSON BargainOption where
+  toJSON b = object
+    [ "label" .= boLabel b
+    , "cost" .= boCost b
+    , "description" .= boDescription b
+    ]
+
+instance FromJSON BargainOption where
+  parseJSON = withObject "BargainOption" $ \v ->
+    BargainOption
+      <$> v .: "label"
+      <*> v .: "cost"
+      <*> v .: "description"
+
+-- | Current game phase/mood with rich variants.
+-- LLM controls transitions via tools (Engage, Resolve, etc.) - player cannot force.
+data DMMood
+  = MoodScene SceneVariant
+  | MoodAction ActionVariant (Maybe ActionDomain)
+  | MoodAftermath AftermathVariant
+  | MoodDowntime DowntimeVariant
+  | MoodTrauma                   -- ^ Full turn, LLM determines trauma type
+  | MoodBargain [BargainOption]  -- ^ Out of dice, contextual deals offered
+  deriving (Show, Eq, Generic)
+
+instance ToJSON DMMood where
+  toJSON (MoodScene sv) = object ["mood" .= ("scene" :: Text), "scene" .= sv]
+  toJSON (MoodAction av dom) = object
+    ["mood" .= ("action" :: Text), "action" .= av, "domain" .= dom]
+  toJSON (MoodAftermath av) = object ["mood" .= ("aftermath" :: Text), "aftermath" .= av]
+  toJSON (MoodDowntime dv) = object ["mood" .= ("downtime" :: Text), "downtime" .= dv]
+  toJSON MoodTrauma = object ["mood" .= ("trauma" :: Text)]
+  toJSON (MoodBargain opts) = object ["mood" .= ("bargain" :: Text), "options" .= opts]
+
+instance FromJSON DMMood where
+  parseJSON = withObject "DMMood" $ \v -> do
+    m <- v .: "mood" :: Aeson.Parser Text
+    case m of
+      "scene" -> MoodScene <$> v .: "scene"
+      "action" -> MoodAction <$> v .: "action" <*> v .:? "domain"
+      "aftermath" -> MoodAftermath <$> v .: "aftermath"
+      "downtime" -> MoodDowntime <$> v .: "downtime"
+      "trauma" -> pure MoodTrauma
+      "bargain" -> MoodBargain <$> v .: "options"
+      _ -> fail $ "Unknown mood: " ++ show m
+
+-- | Character archetype.
+data Archetype = Cutter | Hound | Leech | Lurk | Slide | Spider | Whisper
+  deriving (Show, Eq, Generic)
+
+instance ToJSON Archetype where
+  toJSON Cutter = "cutter"
+  toJSON Hound = "hound"
+  toJSON Leech = "leech"
+  toJSON Lurk = "lurk"
+  toJSON Slide = "slide"
+  toJSON Spider = "spider"
+  toJSON Whisper = "whisper"
+
+instance FromJSON Archetype where
+  parseJSON = withText "Archetype" $ \case
+    "cutter" -> pure Cutter
+    "hound" -> pure Hound
+    "leech" -> pure Leech
+    "lurk" -> pure Lurk
+    "slide" -> pure Slide
+    "spider" -> pure Spider
+    "whisper" -> pure Whisper
+    t -> fail $ "Unknown archetype: " ++ show t
+
+-- | Character pronouns.
+data Pronouns = HeHim | SheHer | TheyThem | CustomPronouns Text
+  deriving (Show, Eq, Generic)
+
+instance ToJSON Pronouns where
+  toJSON HeHim = object ["type" .= ("heHim" :: Text)]
+  toJSON SheHer = object ["type" .= ("sheHer" :: Text)]
+  toJSON TheyThem = object ["type" .= ("theyThem" :: Text)]
+  toJSON (CustomPronouns p) = object ["type" .= ("custom" :: Text), "pronouns" .= p]
+
+instance FromJSON Pronouns where
+  parseJSON = withObject "Pronouns" $ \v -> do
+    ty <- v .: "type" :: Aeson.Parser Text
+    case ty of
+      "heHim" -> pure HeHim
+      "sheHer" -> pure SheHer
+      "theyThem" -> pure TheyThem
+      "custom" -> CustomPronouns <$> v .: "pronouns"
+      _ -> fail $ "Unknown pronouns type: " ++ show ty
+
+-- | Tarot card for character creation spread.
+data TarotCard = TarotCard
+  { tcName :: Text           -- ^ Card name (e.g., "The Tower", "Three of Swords")
+  , tcMeaning :: Text        -- ^ Doskvol-flavored meaning
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToJSON TarotCard where
+  toJSON c = object ["name" .= tcName c, "meaning" .= tcMeaning c]
+
+instance FromJSON TarotCard where
+  parseJSON = withObject "TarotCard" $ \v ->
+    TarotCard <$> v .: "name" <*> v .: "meaning"
+
+-- | Three-card tarot spread for character creation.
+data TarotSpread = TarotSpread
+  { tsPast :: TarotCard      -- ^ What haunts them
+  , tsPresent :: TarotCard   -- ^ What drives them now
+  , tsFuture :: TarotCard    -- ^ What they're moving toward
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToJSON TarotSpread where
+  toJSON s = object
+    [ "past" .= tsPast s
+    , "present" .= tsPresent s
+    , "future" .= tsFuture s
+    ]
+
+instance FromJSON TarotSpread where
+  parseJSON = withObject "TarotSpread" $ \v ->
+    TarotSpread
+      <$> v .: "past"
+      <*> v .: "present"
+      <*> v .: "future"
+
+-- | Character creation step (Tarot-based, v1 style).
+data CharCreationStep
+  = CCEnterName
+  | CCChoosePronouns
+  | CCChooseArchetype
+  | CCEnterBackground       -- ^ Freeform "who are you in Doskvol?"
+  | CCDrawTarot             -- ^ 3-card spread
+  | CCConfirm               -- ^ Review and confirm
+  deriving (Show, Eq, Generic)
+
+instance ToJSON CharCreationStep where
+  toJSON CCEnterName = object ["step" .= ("enterName" :: Text)]
+  toJSON CCChoosePronouns = object ["step" .= ("choosePronouns" :: Text)]
+  toJSON CCChooseArchetype = object ["step" .= ("chooseArchetype" :: Text)]
+  toJSON CCEnterBackground = object ["step" .= ("enterBackground" :: Text)]
+  toJSON CCDrawTarot = object ["step" .= ("drawTarot" :: Text)]
+  toJSON CCConfirm = object ["step" .= ("confirm" :: Text)]
+
+instance FromJSON CharCreationStep where
+  parseJSON = withObject "CharCreationStep" $ \v -> do
+    step <- v .: "step" :: Aeson.Parser Text
+    case step of
+      "enterName" -> pure CCEnterName
+      "choosePronouns" -> pure CCChoosePronouns
+      "chooseArchetype" -> pure CCChooseArchetype
+      "enterBackground" -> pure CCEnterBackground
+      "drawTarot" -> pure CCDrawTarot
+      "confirm" -> pure CCConfirm
+      _ -> fail $ "Unknown step: " ++ show step
+
+-- | Character creation state (Tarot-based, v1 style).
+data CharacterCreation = CharacterCreation
+  { ccStep :: CharCreationStep
+  , ccName :: Maybe Text
+  , ccPronouns :: Maybe Pronouns
+  , ccArchetype :: Maybe Archetype
+  , ccBackground :: Maybe Text
+  , ccTarotSpread :: Maybe TarotSpread
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToJSON CharacterCreation where
+  toJSON c = object
+    [ "step" .= ccStep c
+    , "name" .= ccName c
+    , "pronouns" .= ccPronouns c
+    , "archetype" .= ccArchetype c
+    , "background" .= ccBackground c
+    , "tarotSpread" .= ccTarotSpread c
+    ]
+
+instance FromJSON CharacterCreation where
+  parseJSON = withObject "CharacterCreation" $ \v ->
+    CharacterCreation
+      <$> v .: "step"
+      <*> v .:? "name"
+      <*> v .:? "pronouns"
+      <*> v .:? "archetype"
+      <*> v .:? "background"
+      <*> v .:? "tarotSpread"
+
+-- | History entry for session log.
+data HistoryEntry = HistoryEntry
+  { heTimestamp :: Text
+  , heType :: Text           -- ^ "narration", "action", "roll", "clock"
+  , heSummary :: Text
+  , heDetails :: Maybe Text
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToJSON HistoryEntry where
+  toJSON e = object
+    [ "timestamp" .= heTimestamp e
+    , "type" .= heType e
+    , "summary" .= heSummary e
+    , "details" .= heDetails e
+    ]
+
+instance FromJSON HistoryEntry where
+  parseJSON = withObject "HistoryEntry" $ \v ->
+    HistoryEntry
+      <$> v .: "timestamp"
+      <*> v .: "type"
+      <*> v .: "summary"
+      <*> v .:? "details"
 
 
 -- ════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

- Add reusable Solid.js UI primitives for game interfaces
- Add DM game types in wire-types (Haskell) and TypeScript

## Components Added

| Component | Purpose |
|-----------|---------|
| `HintCard` | Selectable card with value, label, hint text |
| `HintCardGroup` | Group of cards with 1-9 keyboard shortcuts |
| `SegmentedBar` | N-segment filled bar (stress, heat, HP, etc.) |
| `ProgressClock` | SVG pie clock with urgency glow |
| `StatusBadge` | Color-coded badge/chip |

## Wire Types Added

DM game types mirroring Blades-inspired mechanics:
- `DMStats`, `Clock`, `DicePool`, `DMMood`
- Position, Effect, OutcomeTier variants
- Scene/Action/Aftermath/Downtime/Trauma/Bargain moods
- Character creation types

## Design

Components are **domain-agnostic primitives** - they accept primitive props (`number`, `string`, Tailwind classes) not domain types. DM-specific views compose these:

```tsx
// Example composition in a DM view
<SegmentedBar total={9} filled={stats.stress} color="bg-red-500" label="Stress" />
<HintCardGroup cards={pool.dice.map(d => ({ value: d.value, label: d.tier, hint: d.hint }))} ... />
<ProgressClock segments={8} filled={3} label="Patrol" fillColor="#ef4444" urgent />
```

## Test plan

- [x] TypeScript passes (`npm run typecheck`)
- [ ] Visual review of components in browser
- [ ] Integration with anemone DM agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)