### PR TITLE
feat(types-first): Parallel execution handlers with ForkNode/BarrierNode

### DIFF
--- a/types-first-dev/src/TypesFirstDev/Context/Hybrid.hs
+++ b/types-first-dev/src/TypesFirstDev/Context/Hybrid.hs
@@ -120,8 +120,8 @@ instance ToGVal GingerM TypeHole where
 
 instance ToGVal GingerM EchoChannel where
   toGVal ec = dict
-    [ ("fromImpl", list (toGVal <$> ecFromImpl ec))
-    , ("fromTests", list (toGVal <$> ecFromTests ec))
+    [ ("fromImpl", list (toGVal <$> ec.fromImpl))
+    , ("fromTests", list (toGVal <$> ec.fromTests))
     ]
 
 instance ToGVal GingerM HardeningHint where
@@ -133,9 +133,9 @@ instance ToGVal GingerM HardeningHint where
 
 instance ToGVal GingerM TrivialTestsFeedback where
   toGVal ttf = dict
-    [ ("whyRejected", toGVal (ttfWhyRejected ttf))
-    , ("propertiesWrote", list (toGVal <$> ttfPropertiesWrote ttf))
-    , ("suggestion", toGVal (ttfSuggestion ttf))
+    [ ("whyRejected", toGVal ttf.whyRejected)
+    , ("propertiesWrote", list (toGVal <$> ttf.propertiesWrote))
+    , ("suggestion", toGVal ttf.suggestion)
     ]
 
 instance ToGVal GingerM ScopeLevel where
@@ -158,23 +158,23 @@ instance ToGVal GingerM TypesTemplateCtx where
 
 instance ToGVal GingerM TestsTemplateCtx where
   toGVal ctx = dict
-    [ ("typeName", toGVal (ttcTypeName ctx))
-    , ("constructors", list (toGVal <$> ttcConstructors ctx))
-    , ("functions", list (toGVal <$> ttcFunctions ctx))
-    , ("testPath", toGVal (ttcTestPath ctx))
-    , ("priorFeedback", toGVal (ttcPriorFeedback ctx))
-    , ("echoes", toGVal (ttcEchoes ctx))
-    , ("hardeningHints", list (toGVal <$> ttcHardeningHints ctx))
+    [ ("typeName", toGVal ctx.typeName)
+    , ("constructors", list (toGVal <$> ctx.constructors))
+    , ("functions", list (toGVal <$> ctx.functions))
+    , ("testPath", toGVal ctx.testPath)
+    , ("priorFeedback", toGVal ctx.priorFeedback)
+    , ("echoes", toGVal ctx.echoes)
+    , ("hardeningHints", list (toGVal <$> ctx.hardeningHints))
     ]
 
 instance ToGVal GingerM ImplTemplateCtx where
   toGVal ctx = dict
-    [ ("typeName", toGVal (itcTypeName ctx))
-    , ("constructors", list (toGVal <$> itcConstructors ctx))
-    , ("functions", list (toGVal <$> itcFunctions ctx))
-    , ("implPath", toGVal (itcImplPath ctx))
-    , ("echoes", toGVal (itcEchoes ctx))
-    , ("hardeningHints", list (toGVal <$> itcHardeningHints ctx))
+    [ ("typeName", toGVal ctx.typeName)
+    , ("constructors", list (toGVal <$> ctx.constructors))
+    , ("functions", list (toGVal <$> ctx.functions))
+    , ("implPath", toGVal ctx.implPath)
+    , ("echoes", toGVal ctx.echoes)
+    , ("hardeningHints", list (toGVal <$> ctx.hardeningHints))
     ]
 
 instance ToGVal GingerM MutationTemplateCtx where

--- a/types-first-dev/src/TypesFirstDev/Handlers/Hybrid/Genesis.hs
+++ b/types-first-dev/src/TypesFirstDev/Handlers/Hybrid/Genesis.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 
--- | Genesis handlers for WS1 nodes of the hybrid TDD graph.
+-- | Genesis handlers for the hybrid TDD graph.
 --
--- WS1 owns:
+-- Phase 1: Type Design
 -- * hEntry (entry point)
 -- * hTypes (LLM: design types)
 -- * hSkeleton (Logic: generate skeleton files)
@@ -41,6 +41,11 @@ import Tidepool.Graph.Goto
 import Tidepool.Graph.Memory (getMem, updateMem)
 import Tidepool.Graph.Types (ModelChoice(..))
 
+import TypesFirstDev.Handlers.Hybrid.Effects
+  ( HybridEffects
+  , SessionContext(..)
+  , WorkflowError(..)
+  )
 import TypesFirstDev.Types.Hybrid
 import TypesFirstDev.Templates.Hybrid
   ( hTypesCompiled
@@ -48,10 +53,10 @@ import TypesFirstDev.Templates.Hybrid
   , hTypesFixCompiled
   )
 import TypesFirstDev.Graph.Hybrid (TypesFirstGraphHybrid(..))
-import TypesFirstDev.Handlers.Hybrid.Effects
-  ( HybridEffects
-  , SessionContext(..)
-  , WorkflowError(..)
+import TypesFirstDev.Handlers.Hybrid.Parallel
+  ( hForkHandler
+  , hTestsHandler
+  , hImplHandler
   )
 import TypesFirstDev.Handlers.Hybrid.Merge
   ( hJoinHandler
@@ -288,11 +293,11 @@ hTypesFixHandler = ClaudeCodeLLMHandler @'Haiku @'Nothing
 
 
 -- ════════════════════════════════════════════════════════════════════════════
--- HANDLER RECORD (Partial - WS1 only)
+-- HANDLER RECORD
 -- ════════════════════════════════════════════════════════════════════════════
 
--- | Genesis handlers for WS1 nodes.
--- Other nodes use stubs from Handlers.Hybrid.Stubs.
+-- | Genesis handlers for the hybrid TDD workflow.
+-- Combines handlers from Genesis, Parallel, and Merge modules.
 hybridGenesisHandlers :: TypesFirstGraphHybrid (AsHandler HybridEffects)
 hybridGenesisHandlers = TypesFirstGraphHybrid
   { hEntry          = Proxy @StackSpec
@@ -301,11 +306,11 @@ hybridGenesisHandlers = TypesFirstGraphHybrid
   , hTypeAdversary  = hTypeAdversaryHandler
   , hGate           = hGateHandler
   , hTypesFix       = hTypesFixHandler
-  -- WS2 stubs
-  , hFork           = error "WS2 TODO: hFork"
-  , hTests          = error "WS2 TODO: hTests"
-  , hImpl           = error "WS2 TODO: hImpl"
-  -- WS3 handlers (Merge)
+  -- Phase 3: Parallel Blind Execution
+  , hFork           = hForkHandler
+  , hTests          = hTestsHandler
+  , hImpl           = hImplHandler
+  -- Phase 4-5: Verification + Merge
   , hJoin           = hJoinHandler
   , hVerifyTDD      = hVerifyTDDHandler
   , hTestsReject    = hTestsRejectHandler

--- a/types-first-dev/src/TypesFirstDev/Handlers/Hybrid/Parallel.hs
+++ b/types-first-dev/src/TypesFirstDev/Handlers/Hybrid/Parallel.hs
@@ -1,0 +1,167 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+
+-- | Parallel execution handlers for the hybrid TDD graph.
+--
+-- Phase 3: Parallel Blind Execution
+-- * hFork (ForkNode): Create worktrees, spawn parallel agents
+-- * hTests (LLMNode): Write QuickCheck properties (blind to impl)
+-- * hImpl (LLMNode): Write implementations (blind to tests)
+--
+-- Note: hJoin is in Handlers.Hybrid.Merge
+module TypesFirstDev.Handlers.Hybrid.Parallel
+  ( -- * Handlers
+    hForkHandler
+  , hTestsHandler
+  , hImplHandler
+  ) where
+
+import Control.Monad.Freer (Eff)
+import Control.Monad.Freer.Reader (ask)
+
+import Tidepool.Graph.Goto
+  ( GotoChoice
+  , To
+  , ClaudeCodeLLMHandler(..)
+  , ClaudeCodeResult(..)
+  , gotoArrive
+  )
+import Tidepool.Graph.Types (HList(..), ModelChoice(..), Arrive)
+
+import TypesFirstDev.Types.Hybrid
+import TypesFirstDev.Templates.Hybrid (hTestsCompiled, hImplCompiled)
+import TypesFirstDev.Handlers.Hybrid.Effects (HybridEffects)
+
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- FORK HANDLER (ForkNode)
+-- ════════════════════════════════════════════════════════════════════════════
+
+-- | Handler for hFork node.
+-- Builds template contexts for parallel agents.
+-- Returns HList of payloads for spawn targets.
+--
+-- Note: Worktree creation happens in the orchestration layer,
+-- not in the handler. The handler just prepares the contexts.
+hForkHandler
+  :: GatedState
+  -> Eff HybridEffects (HList '[TestsTemplateCtx, ImplTemplateCtx])
+hForkHandler gated = do
+  spec <- ask @StackSpec
+
+  let skeleton = gated.gsSkeleton
+      typesOutput = skeleton.ssTypesResult.trOutput
+      adversaryOutput = gated.gsTypeAdversary.tarOutput
+
+      -- Build hardening hints from type adversary findings
+      hardeningHints = mkHardeningHints adversaryOutput
+
+      -- Build TestsTemplateCtx
+      testsCtx = TestsTemplateCtx
+        { typeName = typesOutput.typeName
+        , constructors = typesOutput.constructors
+        , functions = typesOutput.functions
+        , testPath = spec.specTestPath
+        , priorFeedback = Nothing  -- First attempt
+        , echoes = Nothing         -- No crosstalk yet
+        , hardeningHints = hardeningHints
+        }
+
+      -- Build ImplTemplateCtx
+      implCtx = ImplTemplateCtx
+        { typeName = typesOutput.typeName
+        , constructors = typesOutput.constructors
+        , functions = typesOutput.functions
+        , implPath = spec.specImplPath
+        , echoes = Nothing         -- No crosstalk yet
+        , hardeningHints = hardeningHints
+        }
+
+  pure (testsCtx ::: implCtx ::: HNil)
+
+-- | Convert type adversary findings to hardening hints.
+mkHardeningHints :: TypeAdversaryOutput -> [HardeningHint]
+mkHardeningHints adversaryOutput =
+  [ HardeningHint
+      { hhContext = hole.description
+      , hhGuidance = hole.suggestedFix
+      , hhSource = "typeAdversary"
+      }
+  | hole <- adversaryOutput.tadHoles
+  , hole.severity `elem` [Critical, Major]  -- Only surface significant holes
+  ]
+
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- TESTS HANDLER (LLMNode with Arrive)
+-- ════════════════════════════════════════════════════════════════════════════
+
+-- | Handler for hTests node.
+-- Spawns ClaudeCode agent to write QuickCheck properties.
+-- Uses Arrive to deposit result at barrier.
+hTestsHandler
+  :: ClaudeCodeLLMHandler
+       'Sonnet                               -- model
+       'Nothing                              -- cwd (set by orchestration)
+       TestsTemplateCtx                      -- input
+       TestsAgentOutput                      -- schema
+       '[To Arrive TestsResult]              -- targets (Arrive, not Goto)
+       HybridEffects                         -- effects
+       TestsTemplateCtx                      -- template context = input (passthrough)
+hTestsHandler = ClaudeCodeLLMHandler @'Sonnet @'Nothing
+  Nothing            -- no system template
+  hTestsCompiled     -- user template
+  buildTestsContext  -- before: passthrough (input IS the context)
+  routeAfterTests    -- after: wrap result and arrive at barrier
+  where
+    -- Input is already the template context, so just pass through
+    buildTestsContext :: TestsTemplateCtx -> Eff HybridEffects TestsTemplateCtx
+    buildTestsContext = pure
+
+    routeAfterTests :: ClaudeCodeResult TestsAgentOutput -> Eff HybridEffects (GotoChoice '[To Arrive TestsResult])
+    routeAfterTests ccResult = do
+      let result = TestsResult
+            { testsOutput = ccResult.ccrParsedOutput
+            , testsWorktree = ""  -- Set by orchestration layer
+            , testsCommitHash = ""  -- Set by orchestration layer
+            , testsSessionId = maybe "unknown" id ccResult.ccrSessionId
+            , testsCost = 0.0  -- TODO: Extract from ClaudeCode metrics
+            , testsFailureProof = []  -- Populated by external verification in hVerifyTDD
+            }
+      pure $ gotoArrive result
+
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- IMPL HANDLER (LLMNode with Arrive)
+-- ════════════════════════════════════════════════════════════════════════════
+
+-- | Handler for hImpl node.
+-- Spawns ClaudeCode agent to write implementations.
+-- Uses Arrive to deposit result at barrier.
+hImplHandler
+  :: ClaudeCodeLLMHandler
+       'Sonnet                               -- model
+       'Nothing                              -- cwd (set by orchestration)
+       ImplTemplateCtx                       -- input
+       ImplAgentOutput                       -- schema
+       '[To Arrive ImplResult]               -- targets (Arrive, not Goto)
+       HybridEffects                         -- effects
+       ImplTemplateCtx                       -- template context = input (passthrough)
+hImplHandler = ClaudeCodeLLMHandler @'Sonnet @'Nothing
+  Nothing           -- no system template
+  hImplCompiled     -- user template
+  buildImplContext  -- before: passthrough
+  routeAfterImpl    -- after: wrap result and arrive at barrier
+  where
+    buildImplContext :: ImplTemplateCtx -> Eff HybridEffects ImplTemplateCtx
+    buildImplContext = pure
+
+    routeAfterImpl :: ClaudeCodeResult ImplAgentOutput -> Eff HybridEffects (GotoChoice '[To Arrive ImplResult])
+    routeAfterImpl ccResult = do
+      let result = ImplResult
+            { implOutput = ccResult.ccrParsedOutput
+            , implWorktree = ""  -- Set by orchestration layer
+            , implCommitHash = ""  -- Set by orchestration layer
+            , implSessionId = maybe "unknown" id ccResult.ccrSessionId
+            , implCost = 0.0  -- TODO: Extract from ClaudeCode metrics
+            }
+      pure $ gotoArrive result

--- a/types-first-dev/src/TypesFirstDev/Handlers/Hybrid/Stubs.hs
+++ b/types-first-dev/src/TypesFirstDev/Handlers/Hybrid/Stubs.hs
@@ -1,25 +1,21 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 
--- | Stub handlers for WS2,3,4 nodes of the hybrid TDD graph.
+-- | Stub handlers for later workstream nodes of the hybrid TDD graph.
 --
--- These are type-correct placeholders that will be implemented in later workstreams:
--- * WS2: hFork, hTests, hImpl
--- * WS3: hJoin, hVerifyTDD, hTestsReject, hMerge, hConflictResolve
--- * WS4: hValidate, hFix, hPostValidate, hMutationAdversary, hWitness
+-- These are type-correct placeholders:
+-- * Verification: hVerifyTDD, hTestsReject, hMerge, hConflictResolve
+-- * Validation: hValidate, hFix, hPostValidate, hMutationAdversary, hWitness
+--
+-- Note: Parallel execution handlers (hFork, hTests, hImpl, hJoin) are
+-- implemented in Handlers.Hybrid.Parallel using ForkNode/BarrierNode.
 module TypesFirstDev.Handlers.Hybrid.Stubs
-  ( -- * WS2 Stubs (Parallel Execution)
-    hForkStub
-  , hTestsStub
-  , hImplStub
-
-    -- * WS3 Stubs (Verification)
-  , hJoinStub
-  , hVerifyTDDStub
+  ( -- * Verification Stubs
+    hVerifyTDDStub
   , hTestsRejectStub
   , hMergeStub
   , hConflictResolveStub
 
-    -- * WS4 Stubs (Validation)
+    -- * Validation Stubs
   , hValidateStub
   , hFixStub
   , hPostValidateStub
@@ -35,78 +31,49 @@ import TypesFirstDev.Types.Hybrid
 
 
 -- ════════════════════════════════════════════════════════════════════════════
--- WS2: PARALLEL EXECUTION
+-- VERIFICATION STUBS
 -- ════════════════════════════════════════════════════════════════════════════
-
--- | Fork handler - creates worktrees and spawns parallel agents.
-hForkStub
-  :: GatedState
-  -> Eff es (GotoChoice '[To "hTests" TestsTemplateCtx, To "hImpl" ImplTemplateCtx])
-hForkStub _ = error "WS2 TODO: hFork - create worktrees, spawn parallel agents"
-
--- | Tests handler - writes QuickCheck properties.
-hTestsStub
-  :: TestsTemplateCtx
-  -> Eff es (GotoChoice '[To "hJoin" TestsResult])
-hTestsStub _ = error "WS2 TODO: hTests - write QuickCheck properties, self-verify fail on skeleton"
-
--- | Impl handler - writes implementation.
-hImplStub
-  :: ImplTemplateCtx
-  -> Eff es (GotoChoice '[To "hJoin" ImplResult])
-hImplStub _ = error "WS2 TODO: hImpl - write implementation, verify build passes"
-
-
--- ════════════════════════════════════════════════════════════════════════════
--- WS3: VERIFICATION
--- ════════════════════════════════════════════════════════════════════════════
-
--- | Join handler - synchronization barrier for parallel agents.
-hJoinStub
-  :: BlindResults
-  -> Eff es (GotoChoice '[To "hVerifyTDD" BlindResults])
-hJoinStub _ = error "WS3 TODO: hJoin - collect parallel results"
 
 -- | Verify TDD handler - external TDD property verification.
 hVerifyTDDStub
   :: BlindResults
   -> Eff es (GotoChoice '[To "hMerge" VerifiedResults, To "hTestsReject" TrivialTestsError])
-hVerifyTDDStub _ = error "WS3 TODO: hVerifyTDD - run tests on skeleton, verify they fail"
+hVerifyTDDStub _ = error "TODO: hVerifyTDD - run tests on skeleton, verify they fail"
 
 -- | Tests reject handler - handle trivial/broken tests.
 hTestsRejectStub
   :: TrivialTestsError
   -> Eff es (GotoChoice '[To "hFork" GatedState])
-hTestsRejectStub _ = error "WS3 TODO: hTestsReject - route back to hFork with feedback"
+hTestsRejectStub _ = error "TODO: hTestsReject - route back to hFork with feedback"
 
 -- | Merge handler - cherry-pick tests and impl into fresh worktree.
 hMergeStub
   :: VerifiedResults
   -> Eff es (GotoChoice '[To "hValidate" MergedState, To "hConflictResolve" ConflictState])
-hMergeStub _ = error "WS3 TODO: hMerge - create merge worktree, cherry-pick commits"
+hMergeStub _ = error "TODO: hMerge - create merge worktree, cherry-pick commits"
 
 -- | Conflict resolve handler - resolve git conflicts via LLM.
 hConflictResolveStub
   :: ConflictState
   -> Eff es (GotoChoice '[To "hValidate" MergedState])
-hConflictResolveStub _ = error "WS3 TODO: hConflictResolve - resolve merge conflicts"
+hConflictResolveStub _ = error "TODO: hConflictResolve - resolve merge conflicts"
 
 
 -- ════════════════════════════════════════════════════════════════════════════
--- WS4: VALIDATION
+-- VALIDATION STUBS
 -- ════════════════════════════════════════════════════════════════════════════
 
 -- | Validate handler - run tests on merged code.
 hValidateStub
   :: MergedState
   -> Eff es (GotoChoice '[To "hPostValidate" ValidatedState, To "hFix" ValidationFailure])
-hValidateStub _ = error "WS4 TODO: hValidate - run cabal test, parse output"
+hValidateStub _ = error "TODO: hValidate - run cabal test, parse output"
 
 -- | Fix handler - fix implementation based on test failures.
 hFixStub
   :: ValidationFailure
   -> Eff es (GotoChoice '[To "hValidate" MergedState])
-hFixStub _ = error "WS4 TODO: hFix - analyze failures, apply fixes, loop"
+hFixStub _ = error "TODO: hFix - analyze failures, apply fixes, loop"
 
 -- | Post-validate handler - route to mutation adversary.
 hPostValidateStub
@@ -124,4 +91,4 @@ hMutationAdversaryStub _ = error "WS4 TODO: hMutationAdversary - introduce bugs,
 hWitnessStub
   :: WitnessReport
   -> Eff es (GotoChoice '[To Exit HybridResult])
-hWitnessStub _ = error "WS4 TODO: hWitness - compile final result"
+hWitnessStub _ = error "TODO: hWitness - compile final result"

--- a/types-first-dev/src/TypesFirstDev/Templates/Hybrid.hs
+++ b/types-first-dev/src/TypesFirstDev/Templates/Hybrid.hs
@@ -10,16 +10,24 @@ module TypesFirstDev.Templates.Hybrid
   , HTypeAdversaryTpl
   , HTypesFixTpl
   , HConflictResolveTpl
+    -- WS4 templates
   , HFixTpl
   , HMutationAdversaryTpl
+    -- Parallel blind execution (WS2)
+  , HTestsTpl
+  , HImplTpl
 
     -- * Compiled Templates
   , hTypesCompiled
   , hTypeAdversaryCompiled
   , hTypesFixCompiled
   , hConflictResolveCompiled
+    -- WS4
   , hFixCompiled
   , hMutationAdversaryCompiled
+    -- Parallel execution (WS2)
+  , hTestsCompiled
+  , hImplCompiled
   ) where
 
 import Text.Parsec.Pos (SourcePos)
@@ -31,8 +39,12 @@ import TypesFirstDev.Context.Hybrid
   , TypeAdversaryTemplateCtx(..)
   , TypesFixTemplateCtx(..)
   , ConflictResolveTemplateCtx(..)
+    -- WS4
   , FixTemplateCtx(..)
   , MutationTemplateCtx(..)
+    -- Parallel execution (WS2)
+  , TestsTemplateCtx(..)
+  , ImplTemplateCtx(..)
   )
 
 
@@ -167,3 +179,47 @@ instance TemplateDef HMutationAdversaryTpl where
   templateCompiled = hMutationAdversaryCompiled
 
   buildContext = error "HMutationAdversaryTpl.buildContext should not be called for ClaudeCode handlers"
+
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- PARALLEL: TESTS TEMPLATE (WS2)
+-- ════════════════════════════════════════════════════════════════════════════
+
+-- | Compile the tests agent template at build time.
+hTestsCompiled :: TypedTemplate TestsTemplateCtx SourcePos
+hTestsCompiled = $(typedTemplateFile ''TestsTemplateCtx "templates/hybrid/tests.jinja")
+
+-- | Template type marker for the tests agent node.
+data HTestsTpl
+
+instance TemplateDef HTestsTpl where
+  type TemplateContext HTestsTpl = TestsTemplateCtx
+  type TemplateConstraint HTestsTpl es = ()
+
+  templateName = "hybrid-tests"
+  templateDescription = "Write QuickCheck properties (blind to impl)"
+  templateCompiled = hTestsCompiled
+
+  buildContext = error "HTestsTpl.buildContext should not be called for ClaudeCode handlers"
+
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- PARALLEL: IMPL TEMPLATE (WS2)
+-- ════════════════════════════════════════════════════════════════════════════
+
+-- | Compile the impl agent template at build time.
+hImplCompiled :: TypedTemplate ImplTemplateCtx SourcePos
+hImplCompiled = $(typedTemplateFile ''ImplTemplateCtx "templates/hybrid/impl.jinja")
+
+-- | Template type marker for the impl agent node.
+data HImplTpl
+
+instance TemplateDef HImplTpl where
+  type TemplateContext HImplTpl = ImplTemplateCtx
+  type TemplateConstraint HImplTpl es = ()
+
+  templateName = "hybrid-impl"
+  templateDescription = "Implement functions (blind to tests)"
+  templateCompiled = hImplCompiled
+
+  buildContext = error "HImplTpl.buildContext should not be called for ClaudeCode handlers"

--- a/types-first-dev/src/TypesFirstDev/Types/Hybrid.hs
+++ b/types-first-dev/src/TypesFirstDev/Types/Hybrid.hs
@@ -479,9 +479,10 @@ data FailureType
 
 -- | Echo channel - shape without substance.
 -- Agents share what they're DOING (names), not HOW (implementations).
+-- NOTE: Field names match template variables for TH validation.
 data EchoChannel = EchoChannel
-  { ecFromImpl  :: [Text]  -- Function names impl is working on
-  , ecFromTests :: [Text]  -- Property names tests is asserting
+  { fromImpl  :: [Text]  -- Function names impl is working on
+  , fromTests :: [Text]  -- Property names tests is asserting
   }
   deriving stock (Show, Eq, Generic)
   deriving anyclass (FromJSON, ToJSON)
@@ -688,10 +689,11 @@ data TrivialTestsError = TrivialTestsError
   deriving anyclass (FromJSON, ToJSON)
 
 -- | Feedback for tests agent when previous tests were trivial.
+-- NOTE: Field names match template variables for TH validation.
 data TrivialTestsFeedback = TrivialTestsFeedback
-  { ttfWhyRejected     :: Text
-  , ttfPropertiesWrote :: [Text]
-  , ttfSuggestion      :: Text
+  { whyRejected     :: Text
+  , propertiesWrote :: [Text]
+  , suggestion      :: Text
   }
   deriving stock (Show, Eq, Generic)
   deriving anyclass (FromJSON, ToJSON)
@@ -753,26 +755,28 @@ data TypesTemplateCtx = TypesTemplateCtx
   deriving anyclass (FromJSON, ToJSON)
 
 -- | Context for TestsTpl - what the tests agent sees.
+-- NOTE: Field names match template variables for TH validation.
 data TestsTemplateCtx = TestsTemplateCtx
-  { ttcTypeName       :: Text
-  , ttcConstructors   :: [Text]
-  , ttcFunctions      :: [FunctionSpec]
-  , ttcTestPath       :: FilePath
-  , ttcPriorFeedback  :: Maybe TrivialTestsFeedback
-  , ttcEchoes         :: Maybe EchoChannel
-  , ttcHardeningHints :: [HardeningHint]
+  { typeName       :: Text
+  , constructors   :: [Text]
+  , functions      :: [FunctionSpec]
+  , testPath       :: FilePath
+  , priorFeedback  :: Maybe TrivialTestsFeedback
+  , echoes         :: Maybe EchoChannel
+  , hardeningHints :: [HardeningHint]
   }
   deriving stock (Show, Eq, Generic)
   deriving anyclass (FromJSON, ToJSON)
 
 -- | Context for ImplTpl - what the impl agent sees.
+-- NOTE: Field names match template variables for TH validation.
 data ImplTemplateCtx = ImplTemplateCtx
-  { itcTypeName       :: Text
-  , itcConstructors   :: [Text]
-  , itcFunctions      :: [FunctionSpec]
-  , itcImplPath       :: FilePath
-  , itcEchoes         :: Maybe EchoChannel
-  , itcHardeningHints :: [HardeningHint]
+  { typeName       :: Text
+  , constructors   :: [Text]
+  , functions      :: [FunctionSpec]
+  , implPath       :: FilePath
+  , echoes         :: Maybe EchoChannel
+  , hardeningHints :: [HardeningHint]
   }
   deriving stock (Show, Eq, Generic)
   deriving anyclass (FromJSON, ToJSON)

--- a/types-first-dev/templates/hybrid/impl.jinja
+++ b/types-first-dev/templates/hybrid/impl.jinja
@@ -1,0 +1,103 @@
+# Task: Implement Functions for {{ typeName }}
+
+## Your Role
+
+You are the IMPL agent. Your job is to implement the functions for the
+`{{ typeName }}` data type. You are **blind to the tests** - you cannot see
+what properties will be tested, only the function specifications.
+
+## Type to Implement
+
+**Type**: `{{ typeName }}`
+**Constructors**: {{ constructors | join(", ") }}
+
+## Functions to Implement
+
+{% for fn in functions %}
+### {{ fn.name }}
+
+**Signature**: `{{ fn.signature }}`
+**Brief**: {{ fn.brief }}
+**Behavior**: {{ fn.behavior }}
+
+**Concrete Examples** (your implementation must handle these):
+{% for ex in fn.examples %}
+- {{ ex.description }}: `{{ ex.input }}` → `{{ ex.expected }}`{% if ex.edgeCase %} (edge case){% endif %}
+{% endfor %}
+
+**Dependencies**: {% if fn.dependsOn %}{{ fn.dependsOn | join(", ") }}{% else %}None{% endif %}
+**Priority**: {{ fn.priority }}
+
+{% endfor %}
+
+## Your Deliverables
+
+1. **Write to disk** (via ClaudeCode):
+   - Edit `{{ implPath }}` to replace `undefined` with real implementations
+   - Follow the type signatures exactly
+   - Run `cabal build` to verify compilation passes
+
+2. **Return structured output** describing what you wrote:
+   - Which functions you implemented
+   - Your approach for each
+   - Design decisions
+
+## Output Schema
+
+Return JSON matching `ImplAgentOutput`:
+- `implFunctions`: List of functions implemented (see FunctionImplemented below)
+- `implDataRepr`: How you represented the data (e.g., "Recursive ADT with spine")
+- `implDesignNotes`: Key design decisions and tradeoffs
+- `implBuildPassed`: Boolean - true ONLY if `cabal build` succeeded
+- `implCommitMsg`: Git commit message
+- `implBlocker`: If blocked, explain (otherwise null)
+
+For each function in `implFunctions`:
+- `fiName`: Function name
+- `fiApproach`: How you implemented it (e.g., "Recursive pattern matching")
+- `fiComplexity`: Time complexity if known (e.g., "O(1)") - null if unsure
+- `fiHandlesEdges`: List of edge cases explicitly handled
+
+## CRITICAL: Build Verification
+
+**Build MUST pass before you return.**
+
+You must:
+1. Run `cabal build` after implementing
+2. Fix any compilation errors
+3. Set `implBuildPassed: true` ONLY after successful build
+
+If the build fails, fix the errors before returning. Do not return with
+`implBuildPassed: false` unless you are truly blocked and cannot proceed.
+
+{% if hardeningHints %}
+## Hardening Hints (from Type Adversary)
+
+The type adversary found these concerns - consider implementing defensively:
+
+{% for hint in hardeningHints %}
+- **{{ hint.source }}**: {{ hint.context }}
+  - Guidance: {{ hint.guidance }}
+{% endfor %}
+{% endif %}
+
+{% if echoes %}
+## Echo Channel (shape, not content)
+
+The tests agent is writing properties for: {{ echoes.fromTests | join(", ") }}
+
+You cannot see their tests, but knowing what properties they're asserting
+may help you ensure your implementation handles those aspects correctly.
+{% endif %}
+
+## Implementation Guidelines
+
+1. **Follow the behavior description exactly** - it specifies the contract
+2. **Handle all edge cases** - especially those marked in examples
+3. **Respect dependencies** - implement functions in priority order if they depend on each other
+4. **Keep it simple** - prefer clarity over cleverness
+
+## Your Task
+
+Implement the functions for `{{ typeName }}`. Replace `undefined` stubs with
+working implementations and verify the build passes.

--- a/types-first-dev/templates/hybrid/tests.jinja
+++ b/types-first-dev/templates/hybrid/tests.jinja
@@ -1,0 +1,125 @@
+# Task: Write QuickCheck Properties for {{ typeName }}
+
+## Your Role
+
+You are the TESTS agent. Your job is to write QuickCheck property-based tests
+for the `{{ typeName }}` data type. You are **blind to the implementation** -
+you cannot see how the functions are implemented, only their specifications.
+
+## Type Under Test
+
+**Type**: `{{ typeName }}`
+**Constructors**: {{ constructors | join(", ") }}
+
+## Functions to Test
+
+{% for fn in functions %}
+### {{ fn.name }}
+
+**Signature**: `{{ fn.signature }}`
+**Brief**: {{ fn.brief }}
+**Behavior**: {{ fn.behavior }}
+
+**Concrete Examples** (ground your properties in these):
+{% for ex in fn.examples %}
+- {{ ex.description }}: `{{ ex.input }}` → `{{ ex.expected }}`{% if ex.edgeCase %} (edge case){% endif %}
+{% endfor %}
+
+**Property Sketches** (implement these as QuickCheck properties):
+{% for prop in fn.properties %}
+- **{{ prop.name }}** ({{ prop.type }}): {{ prop.description }}
+  - Invariant: `{{ prop.invariant }}`
+{% endfor %}
+
+{% endfor %}
+
+## Your Deliverables
+
+1. **Write to disk** (via ClaudeCode):
+   - Edit `{{ testPath }}` to add QuickCheck properties
+   - Add `Arbitrary` instances if needed
+   - Run `cabal build` to verify compilation
+   - Run `cabal test` to verify tests **FAIL on undefined stubs**
+
+2. **Return structured output** describing what you wrote:
+   - Which properties you wrote
+   - Coverage report
+   - Self-verification result
+
+## Output Schema
+
+Return JSON matching `TestsAgentOutput`:
+- `testsProperties`: List of properties written (see PropertyWritten below)
+- `testsCoverage`: Coverage report
+- `testsSelfVerified`: Boolean - true ONLY if tests fail on skeleton
+- `testsCommitMsg`: Git commit message
+- `testsStrategy`: Prose describing your approach
+- `testsBlocker`: If blocked, explain (otherwise null)
+
+For each property in `testsProperties`:
+- `pwName`: Property name (e.g., "prop_pushPopInverse")
+- `pwTargetFunctions`: Functions tested by this property
+- `pwPropertyType`: One of Inverse, Idempotent, etc.
+- `pwDescription`: What the property verifies
+- `pwCoversExamples`: Indices of examples this property covers
+- `pwCoversSketch`: Name of PropertySketch this implements (or null)
+
+For `testsCoverage`:
+- `crFunctionsCovered`: Functions with at least one property
+- `crFunctionsUncovered`: Functions with no properties
+- `crExamplesCovered`: Number of examples covered
+- `crExamplesTotal`: Total examples in spec
+- `crSketchesCovered`: PropertySketch names implemented
+- `crSketchesUncovered`: PropertySketch names NOT implemented
+
+## CRITICAL: Self-Verification
+
+**Tests MUST FAIL on the skeleton stubs.**
+
+The skeleton has `undefined` stubs. If your tests pass on undefined stubs,
+they are trivial or broken. You MUST:
+
+1. Run `cabal test` after writing properties
+2. Verify tests FAIL (hit undefined or produce counterexamples)
+3. Set `testsSelfVerified: true` ONLY after confirming failure
+
+If tests pass on undefined stubs, your work will be rejected and you'll need
+to write meaningful properties that actually exercise the code.
+
+{% if priorFeedback %}
+## Prior Rejection Feedback
+
+Your previous tests were rejected. Here's why:
+
+**Reason**: {{ priorFeedback.whyRejected }}
+**Properties you wrote**: {{ priorFeedback.propertiesWrote | join(", ") }}
+**Suggestion**: {{ priorFeedback.suggestion }}
+
+Write NEW, MEANINGFUL properties that actually test the functions.
+{% endif %}
+
+{% if hardeningHints %}
+## Hardening Hints (from Type Adversary)
+
+The type adversary found these concerns - consider writing properties that
+exercise these edge cases:
+
+{% for hint in hardeningHints %}
+- **{{ hint.source }}**: {{ hint.context }}
+  - Guidance: {{ hint.guidance }}
+{% endfor %}
+{% endif %}
+
+{% if echoes %}
+## Echo Channel (shape, not content)
+
+The impl agent is working on these functions: {{ echoes.fromImpl | join(", ") }}
+
+You cannot see their implementation, but knowing what they're focused on
+may help you prioritize which properties to write first.
+{% endif %}
+
+## Your Task
+
+Write QuickCheck properties for `{{ typeName }}`. Implement the property sketches
+provided, add edge case tests, and verify they fail on the skeleton stubs.

--- a/types-first-dev/types-first-dev.cabal
+++ b/types-first-dev/types-first-dev.cabal
@@ -28,6 +28,7 @@ library
         TypesFirstDev.Handlers.Hybrid.Stubs
         TypesFirstDev.Handlers.Hybrid.Genesis
         TypesFirstDev.Handlers.Hybrid.Merge
+        TypesFirstDev.Handlers.Hybrid.Parallel
         TypesFirstDev.Handlers.Hybrid.Validation
         TypesFirstDev.Handlers.Hybrid.Adversary
         TypesFirstDev.Handlers.Hybrid.Witness


### PR DESCRIPTION
## Summary

- Add parallel blind execution phase for hybrid TDD workflow using ForkNode/BarrierNode graph primitives
- Create handlers for hFork, hTests, hImpl with correct type signatures
- Add Jinja templates for tests and impl agents with value-neutral rubrics

## Changes

### Graph Definition
- `hFork`: ForkNode with `Spawn '[To "hTests" TestsTemplateCtx, To "hImpl" ImplTemplateCtx]`
- `hTests`/`hImpl`: LLMNode with `Arrive` for barrier synchronization  
- `hJoin`: BarrierNode with `Awaits '[TestsResult, ImplResult]` (handler in Merge.hs)

### New Files
- `Handlers/Hybrid/Parallel.hs`: Fork, Tests, Impl handlers
- `templates/hybrid/tests.jinja`: QuickCheck property writing prompt
- `templates/hybrid/impl.jinja`: Function implementation prompt

### Integration with WS1
Rebased on `ws1/genesis-types-skeleton` which provides:
- `Handlers/Hybrid/Effects.hs`: Shared effect stack (breaks import cycle)
- `Handlers/Hybrid/Merge.hs`: hJoin, hVerifyTDD, hMerge, hConflictResolve handlers

### Type Cleanup
Template context types use short field names for TH validation:
- `TestsTemplateCtx`: `typeName`, `constructors`, `functions`, etc.
- `ImplTemplateCtx`: same pattern
- `EchoChannel`, `TrivialTestsFeedback`: likewise updated

This matches the existing `TypesTemplateCtx` pattern where field names match template variables.

## Test plan

- [x] `cabal build types-first-dev` passes
- [ ] Orchestration layer integration (being implemented in parallel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)