### PR TITLE
Fix WASM build: move native-only effects to conditional section

### DIFF
--- a/tidepool-core/tidepool-core.cabal
+++ b/tidepool-core/tidepool-core.cabal
@@ -17,8 +17,6 @@ library
         Tidepool.Platform
         Tidepool.Effect
         Tidepool.Effect.ClaudeCode
-        Tidepool.Effect.LSP
-        Tidepool.Effect.GHCi
         Tidepool.Effect.DevLog
         Tidepool.Effect.Metadata
         Tidepool.Effect.Types
@@ -36,22 +34,27 @@ library
         Tidepool.Graph.Reify
         Tidepool.Graph.Export
         Tidepool.Graph.Memory
+        -- Types needed by WASM (no native dependencies)
+        Tidepool.Anthropic.Types
+        Tidepool.Tool.Wire
+        Tidepool.StructuredOutput
+        Tidepool.StructuredOutput.Class
     -- Development/tooling modules (excluded from WASM builds)
     if !os(wasi)
       exposed-modules:
+        -- Native-only effects (require subprocesses)
+        Tidepool.Effect.LSP
+        Tidepool.Effect.GHCi
+        -- Native-only tooling
         Tidepool.Schema
-        Tidepool.StructuredOutput
-        Tidepool.StructuredOutput.Class
         Tidepool.StructuredOutput.Error
         Tidepool.StructuredOutput.Generic
         Tidepool.StructuredOutput.Instances
         Tidepool.StructuredOutput.Prefix
-        Tidepool.Tool.Wire
         Tidepool.Tool.Convert
         Tidepool.Graph.CLI
         Tidepool.Graph.Tool
         Tidepool.Graph.Template
-        Tidepool.Anthropic.Types
         Tidepool.Effects.Habitica
         Tidepool.Effects.GitHub
         Tidepool.Effects.Observability


### PR DESCRIPTION
## Summary
- Moved `Tidepool.Effect.LSP` and `Tidepool.Effect.GHCi` to `if !os(wasi)` conditional section
- These effects require subprocesses/native dependencies (GHCi REPL, LSP servers)
- Kept `StructuredOutput`, `Anthropic.Types`, `Tool.Wire` in main section (type-only, no native deps)

## Context
Enables `tidepool-core` to build for wasm32-wasi target. Required for automat-reactor WASM compilation for Cloudflare Workers deployment.

## Test Plan
- [x] Native build passes: `cabal build`
- [x] WASM build passes: `wasm32-wasi-cabal build` (in nix shell)
- [x] Successfully deployed to CF Workers
- [x] Worker loads WASM and initializes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)