### PR TITLE
fix(hooks): correct hook binary name to mantle-agent

### DIFF
--- a/rust/mantle-shared/src/lib.rs
+++ b/rust/mantle-shared/src/lib.rs
@@ -52,7 +52,7 @@ pub mod util;
 pub use error::{MantleError, Result};
 pub use events::{ExitReason, InterruptSignal, RunResult, StreamEvent, ToolCall};
 pub use fifo::{ResultFifo, SignalFifo};
-pub use hooks::{find_mantle_binary, HookConfig};
+pub use hooks::HookConfig;
 pub use logging::{init_logging, init_logging_with_default};
 pub use protocol::{ControlMessage, ControlResponse, HookInput, HookOutput};
 pub use socket::ControlSocket;

--- a/rust/mantle-shared/src/protocol.rs
+++ b/rust/mantle-shared/src/protocol.rs
@@ -6,7 +6,7 @@
 //! ## Message Flow
 //!
 //! ```text
-//! Claude Code hooks       mantle hook <event>      Control Socket
+//! Claude Code hooks       mantle-agent hook <event>      Control Socket
 //!      (stdin JSON)  -->   (parse & forward)   -->   (Haskell server)
 //!                    <--   (response JSON)     <--
 //! ```


### PR DESCRIPTION
Fixes tidepool-0o4 by updating the binary name in hook configuration generation and discovery from 'mantle' to 'mantle-agent'.