### PR TITLE
[tidepool-upd] Wire TUI interpreter into control-server

### DIFF
--- a/haskell/control-server/src/Tidepool/Control/Handler.hs
+++ b/haskell/control-server/src/Tidepool/Control/Handler.hs
@@ -11,12 +11,13 @@ import Tidepool.Control.Export (exportMCPTools)
 import Tidepool.Control.Handler.Hook (handleHook)
 import Tidepool.Control.Handler.MCP (handleMcpTool)
 import Tidepool.LSP.Interpreter (LSPSession)
+import Tidepool.TUI.Interpreter (TUIHandle)
 
 -- | Route a control message to the appropriate handler.
-handleMessage :: Logger -> LSPSession -> ControlMessage -> IO ControlResponse
-handleMessage logger lspSession = \case
+handleMessage :: Logger -> LSPSession -> Maybe TUIHandle -> ControlMessage -> IO ControlResponse
+handleMessage logger lspSession maybeTuiHandle = \case
   HookEvent input -> handleHook input
-  McpToolCall reqId name args -> handleMcpTool logger lspSession reqId name args
+  McpToolCall reqId name args -> handleMcpTool logger lspSession maybeTuiHandle reqId name args
   ToolsListRequest -> handleToolsList logger
 
 -- | Handle tool discovery request.

--- a/haskell/control-server/tidepool-control-server.cabal
+++ b/haskell/control-server/tidepool-control-server.cabal
@@ -62,6 +62,7 @@ library
         containers >= 0.6 && < 1,
         freer-simple,
         tidepool-core,
+        tidepool-tui-interpreter,
         tidepool-lsp-interpreter,
         tidepool-training-generator,
         tidepool-teaching,


### PR DESCRIPTION
Closes tidepool-upd. Wires the TUI interpreter into the control-server, allowing MCP tools to display UIs via the sidebar.