### PR TITLE
[tidepool-2gh] Zellij layout: add --continue for session persistence

### DIFF
--- a/.zellij/tidepool.kdl
+++ b/.zellij/tidepool.kdl
@@ -20,7 +20,7 @@ layout {
             // LEFT: Claude Code (auto-launch with debug mode)
             pane name="Claude Code" size="50%" focus=true {
                 command "claude"
-                args "-d"
+                args "-d" "--continue"
             }
 
             pane split_direction="horizontal" {


### PR DESCRIPTION
## Summary
- Adds `--continue` flag to Zellij layout for session persistence
- Enables start-augmented.sh workflow to resume sessions

## Test Plan
- [x] Verified exo_status MCP tool works on bead branch (dogfooding!)

Closes tidepool-2gh

🤖 Generated with [Claude Code](https://claude.com/claude-code)