### PR TITLE
[tidepool-lxk] Clean up dead code warnings from TUI layout changes

### DIFF
--- a/rust/mantle-agent/src/mcp.rs
+++ b/rust/mantle-agent/src/mcp.rs
@@ -31,7 +31,7 @@
 //! - `MANTLE_CONTROL_HOST`: Control server host (required)
 //! - `MANTLE_CONTROL_PORT`: Control server port (required)
 
-use mantle_shared::protocol::{ControlMessage, ControlResponse, McpError, ToolDefinition as ProtocolToolDef};
+use mantle_shared::protocol::{ControlMessage, ControlResponse, McpError};
 use mantle_shared::socket::control_server_addr;
 use mantle_shared::ControlSocket;
 use serde::{Deserialize, Serialize};
@@ -46,6 +46,7 @@ use tracing::{debug, error, info};
 /// JSON-RPC 2.0 request.
 #[derive(Debug, Deserialize)]
 struct JsonRpcRequest {
+    #[allow(dead_code)]
     jsonrpc: String,
     id: Value,
     method: String,
@@ -102,10 +103,6 @@ impl JsonRpcResponse {
 
     fn invalid_params(id: Value, message: String) -> Self {
         Self::error(id, -32602, message)
-    }
-
-    fn internal_error(id: Value, message: String) -> Self {
-        Self::error(id, -32603, message)
     }
 }
 
@@ -474,19 +471,6 @@ impl McpServer {
                 Err("Unexpected ToolsListResponse for MCP tool call".to_string())
             }
         }
-    }
-
-    /// Create a success response for a tool call.
-    fn tool_success_response(&self, id: Value, tool_name: &str) -> JsonRpcResponse {
-        let result = ToolCallResult {
-            content: vec![ToolResultContent {
-                content_type: "text".to_string(),
-                text: format!("Decision recorded: {}", tool_name.replace("decision::", "")),
-            }],
-            is_error: None,
-        };
-
-        JsonRpcResponse::success(id, serde_json::to_value(result).unwrap())
     }
 }
 

--- a/rust/mantle-agent/tests/mcp_integration.rs
+++ b/rust/mantle-agent/tests/mcp_integration.rs
@@ -71,6 +71,7 @@ impl JsonRpcRequest {
 /// JSON-RPC 2.0 response received from MCP server.
 #[derive(Debug, Deserialize)]
 struct JsonRpcResponse {
+    #[allow(dead_code)]
     jsonrpc: String,
     id: Value,
     #[serde(default)]
@@ -84,6 +85,7 @@ struct JsonRpcError {
     code: i32,
     message: String,
     #[serde(default)]
+    #[allow(dead_code)]
     data: Option<Value>,
 }
 

--- a/rust/mantle-hub/src/db.rs
+++ b/rust/mantle-hub/src/db.rs
@@ -409,28 +409,6 @@ pub async fn list_nodes_for_session(pool: &SqlitePool, session_id: &str) -> Resu
     Ok(rows.into_iter().map(|r| r.into_node_info()).collect())
 }
 
-/// Get all nodes for an execution by execution_id in metadata.
-pub async fn get_nodes_by_execution(
-    pool: &SqlitePool,
-    execution_id: &str,
-) -> Result<Vec<NodeInfo>> {
-    let rows = sqlx::query_as::<_, NodeRow>(
-        r#"
-        SELECT n.id, n.session_id, n.parent_node_id, n.branch, n.worktree, n.prompt, n.model, n.state, n.metadata, n.created_at, n.updated_at,
-               r.exit_code, r.is_error, r.result_text, r.structured_output, r.total_cost_usd, r.num_turns, r.cc_session_id, r.duration_secs, r.model_usage
-        FROM nodes n
-        LEFT JOIN results r ON n.id = r.node_id
-        WHERE json_extract(n.metadata, '$.execution_id') = ?
-        ORDER BY n.created_at ASC
-        "#,
-    )
-    .bind(execution_id)
-    .fetch_all(pool)
-    .await?;
-
-    Ok(rows.into_iter().map(|r| r.into_node_info()).collect())
-}
-
 /// Update node state.
 pub async fn update_node_state(pool: &SqlitePool, id: &str, state: NodeState) -> Result<()> {
     let now = chrono::Utc::now().to_rfc3339();

--- a/rust/mantle-hub/tests/helpers/mod.rs
+++ b/rust/mantle-hub/tests/helpers/mod.rs
@@ -2,6 +2,7 @@
 
 mod test_hub;
 
+#[allow(unused_imports)]
 pub use test_hub::{unique_id, TestHub};
 
 use mantle_shared::hub::types::{NodeResult, SessionCreateResponse, SessionRegister};
@@ -9,6 +10,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 /// Create a test NodeResult with minimal required fields.
+#[allow(dead_code)]
 pub fn make_test_node_result(node_id: &str) -> NodeResult {
     NodeResult {
         node_id: node_id.to_string(),
@@ -34,16 +36,6 @@ pub fn make_test_register() -> SessionRegister {
     }
 }
 
-/// Create a test SessionRegister with custom branch.
-pub fn make_test_register_with_branch(branch: &str) -> SessionRegister {
-    SessionRegister {
-        branch: branch.into(),
-        worktree: PathBuf::from("/tmp"),
-        prompt: "Test prompt".into(),
-        model: "sonnet".into(),
-    }
-}
-
 /// Register a session via HTTP and return the SessionCreateResponse.
 pub async fn create_session(
     client: &reqwest::Client,
@@ -60,6 +52,7 @@ pub async fn create_session(
 }
 
 /// Create a child node via HTTP.
+#[allow(dead_code)]
 pub async fn create_child_node(
     client: &reqwest::Client,
     base_url: &str,
@@ -83,6 +76,7 @@ pub async fn create_child_node(
 }
 
 /// Submit a result via the Unix socket.
+#[allow(dead_code)]
 pub async fn submit_via_socket(
     socket_path: &std::path::Path,
     result: &NodeResult,

--- a/rust/mantle-hub/tests/helpers/test_hub.rs
+++ b/rust/mantle-hub/tests/helpers/test_hub.rs
@@ -83,6 +83,7 @@ impl TestHub {
     }
 
     /// Get the socket path for this hub.
+    #[allow(dead_code)]
     pub fn socket_path(&self) -> &Path {
         &self.socket_path
     }

--- a/rust/tui-sidebar/src/protocol.rs
+++ b/rust/tui-sidebar/src/protocol.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 /// Messages sent from Haskell tui-interpreter to Rust tui-sidebar.
 /// Not used in Phase 1 (only UISpec flows via ShowUI effect),
 /// but prepared for future PushUI/ReplaceUI/UpdateUI/PopUI support.
+#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum TUIMessage {

--- a/rust/tui-sidebar/src/render.rs
+++ b/rust/tui-sidebar/src/render.rs
@@ -247,30 +247,3 @@ fn render_placeholder(frame: &mut Frame, msg: &str, area: Rect) {
 
     frame.render_widget(paragraph, area);
 }
-
-/// Collect all focusable elements from layout.
-///
-/// Phase 1: Returns element IDs in render order.
-/// Used by input handler to cycle focus.
-pub fn collect_focusable_ids(layout: &Layout) -> Vec<String> {
-    match layout {
-        Layout::Vertical { elements } => collect_element_ids(elements),
-        Layout::Horizontal { elements } => collect_element_ids(elements),
-        Layout::Split { left, right, .. } => {
-            let mut ids = collect_focusable_ids(left);
-            ids.extend(collect_focusable_ids(right));
-            ids
-        }
-    }
-}
-
-fn collect_element_ids(elements: &[Element]) -> Vec<String> {
-    elements
-        .iter()
-        .filter_map(|e| match e {
-            Element::Button { id, .. } => Some(id.clone()),
-            Element::Input { id, .. } => Some(id.clone()),
-            _ => None,  // Text, Progress not focusable
-        })
-        .collect()
-}

--- a/rust/tui-sidebar/src/ui_stack.rs
+++ b/rust/tui-sidebar/src/ui_stack.rs
@@ -16,6 +16,7 @@ struct StackEntry {
 }
 
 /// Runtime state for elements (updated via UpdateUI).
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 enum ElementState {
     Text(String),
@@ -84,7 +85,7 @@ impl UIStack {
     ///
     /// Returns None if element has no runtime state (use spec defaults).
     #[allow(dead_code)]
-    pub fn get_element_state(&self, element_id: &str) -> Option<&ElementState> {
+    fn get_element_state(&self, element_id: &str) -> Option<&ElementState> {
         self.stack.last()?.element_state.get(element_id)
     }
 }


### PR DESCRIPTION
Closes tidepool-lxk

## Summary
Clean up dead code warnings that appeared after the TUI layout changes (tidepool-ohx). All changes preserve functionality while eliminating compiler warnings.

## Changes

### TUI Sidebar
- **ui_stack.rs**: Mark  enum with  (Phase 2+ feature)
- **render.rs**: Remove truly dead functions (, ) - replaced by index-based focus
- **protocol.rs**: Mark  with  (Phase 2+ feature)

### MCP
- **mcp.rs**: 
  - Remove unused import alias 
  - Remove unused helper method 
  - Remove unused method 
  - Mark JSON-RPC protocol field  with  (required for deserialization)
- **mcp_integration.rs**: Mark JSON-RPC protocol fields with  (required for deserialization)

### Hub (Legacy)
- **db.rs**: Remove unused function 
- **tests/helpers/mod.rs**:
  - Remove duplicate helper  (never used)
  - Mark test helpers with  to suppress false positives from cross-module usage
- **tests/helpers/test_hub.rs**: Mark  with  (used in other test files)

## Testing
- ✅  passes with no warnings
- ✅ All functionality preserved (only removed truly unused code or marked future features)

## Review Notes
-  used for:
  1. **Phase 2+ features** (TUIMessage, ElementState) - intentionally kept for future implementation
  2. **JSON-RPC protocol fields** (jsonrpc, data) - required for deserialization but not accessed
  3. **Test helpers** - suppress false positives from cross-module usage in integration tests