### PR TITLE
Fix missing pmPriTools definition in Export.hs

### DIFF
--- a/haskell/control-server/src/Tidepool/Control/Export.hs
+++ b/haskell/control-server/src/Tidepool/Control/Export.hs
@@ -955,6 +955,7 @@ exportMCPTools logger = do
   let saTools = reifyMCPTools (Proxy @SpawnAgentsGraph)
   let fpTools = reifyMCPTools (Proxy @FilePRGraph)
   let paeTools = reifyMCPTools (Proxy @PmApproveExpansionGraph)
+  let pmPriTools = reifyMCPTools (Proxy @PmPrioritizeGraph)
   let pmRevTools = reifyMCPTools (Proxy @PmReviewDagGraph)
   let pmStatTools = reifyMCPTools (Proxy @PmStatusGraph)
   let pmProTools = reifyMCPTools (Proxy @PMProposeGraph)


### PR DESCRIPTION
## Summary
- Fix compilation error in `haskell/control-server/src/Tidepool/Control/Export.hs`
- Add missing `pmPriTools` definition using `reifyMCPTools (Proxy @PmPrioritizeGraph)`
- Variable was referenced in `allTools` concatenation but never defined

## Test plan
- [x] `cabal build all` completes successfully
- [x] No compilation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)