### PR TITLE
[tidepool-ai5] Update .mcp.json to use Hangar paths

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,10 +1,12 @@
 {
   "mcpServers": {
     "tidepool": {
-      "command": "mantle-agent",
-      "args": ["mcp"],
+      "command": "$HANGAR_ROOT/runtime/bin/mantle-agent",
+      "args": [
+        "mcp"
+      ],
       "env": {
-        "TIDEPOOL_CONTROL_SOCKET": ".tidepool/sockets/control.sock",
+        "TIDEPOOL_CONTROL_SOCKET": "$HANGAR_ROOT/runtime/state/sockets/control.sock",
         "RUST_LOG": "info"
       }
     }


### PR DESCRIPTION
Closes tidepool-ai5. Updates .mcp.json to use  based paths for mantle-agent and control socket, aligning with the Hangar directory schema.