### PR TITLE
[tidepool-4hj] Fix TUI bidirectional socket deadlock by removing PopUI

### DIFF
--- a/rust/tui-sidebar/CLAUDE.md
+++ b/rust/tui-sidebar/CLAUDE.md
@@ -217,7 +217,7 @@ The `tidepool-control-server` package provides the Unix socket server:
 ## Known Limitations (Phase 1)
 
 1. **No input editing** - Input fields display value but don't support typing (Phase 3)
-2. **Immediate UI close** - UI pops after first interaction (no multi-step dialogs yet)
+2. **Auto-pop after interaction** - UI automatically pops after sending Interaction; multi-step flows use repeated PushUI
 3. **No dynamic updates** - Can't update progress bars mid-render (Phase 2)
 4. **Fixed element sizing** - All elements get equal height (Phase 2: smart sizing)
 5. **No Table/Select/List** - These widgets not implemented (Phase 2)

--- a/rust/tui-sidebar/src/protocol.rs
+++ b/rust/tui-sidebar/src/protocol.rs
@@ -5,8 +5,10 @@ use serde::{Deserialize, Serialize};
 // ══════════════════════════════════════════════════════════════
 
 /// Messages sent from Haskell tui-interpreter to Rust tui-sidebar.
-/// Not used in Phase 1 (only UISpec flows via ShowUI effect),
-/// but prepared for future PushUI/ReplaceUI/UpdateUI/PopUI support.
+///
+/// Note: There is no PopUI message. The Rust TUI sidebar pops its UI stack
+/// automatically after sending an Interaction. For multi-step UIs, Haskell
+/// just sends another PushUI - the previous UI was already popped.
 #[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
@@ -14,7 +16,6 @@ pub enum TUIMessage {
     PushUI { spec: UISpec },
     ReplaceUI { spec: UISpec },
     UpdateUI { update: UIUpdate },
-    PopUI,
 }
 
 // ══════════════════════════════════════════════════════════════

--- a/rust/tui-sidebar/src/server.rs
+++ b/rust/tui-sidebar/src/server.rs
@@ -78,10 +78,6 @@ pub fn spawn_io_tasks(
                             debug!("Received UpdateUI (not implemented)");
                             // Phase 2: handle dynamic updates
                         }
-                        Ok(TUIMessage::PopUI) => {
-                            debug!("Received PopUI (not implemented)");
-                            // Phase 2: handle UI stack pop
-                        }
                         Err(e) => {
                             warn!(error = %e, json = %trimmed, "Failed to parse TUIMessage");
                             // Continue reading, don't stop on malformed JSON


### PR DESCRIPTION
## Summary
- Remove PopUI message entirely from the TUI protocol (both Haskell and Rust)
- Rust TUI sidebar already auto-pops its UI stack after sending an Interaction
- Eliminates race condition where Haskell sent PopUI while Rust was still flushing Interaction write
- Multi-step UIs simply send another PushUI - no explicit close needed

## Test plan
- [ ] Verify `cabal build tidepool-tui-interpreter` succeeds
- [ ] Verify `cargo build -p tui-sidebar` succeeds
- [ ] Manual test: Run TUI tools via MCP and confirm no timeout/deadlock

Closes tidepool-4hj

🤖 Generated with [Claude Code](https://claude.ai/claude-code)