### PR TITLE
[tidepool-9uv] Add go-to-tab-name focus on subagent error

### DIFF
--- a/haskell/dsl/core/src/Tidepool/Effects/Zellij.hs
+++ b/haskell/dsl/core/src/Tidepool/Effects/Zellij.hs
@@ -38,6 +38,7 @@ module Tidepool.Effects.Zellij
     -- * Smart Constructors
   , checkZellijEnv
   , newTab
+  , goToTab
 
     -- * Configuration Types
   , TabConfig(..)
@@ -129,6 +130,12 @@ data Zellij r where
     :: TabConfig
     -> Zellij (Either ZellijError TabId)
 
+  -- | Switch focus to a tab by name.
+  -- Returns success or error if tab doesn't exist or command failed.
+  GoToTab
+    :: TabId
+    -> Zellij (Either ZellijError ())
+
 
 -- ════════════════════════════════════════════════════════════════════════════
 -- SMART CONSTRUCTORS
@@ -171,3 +178,20 @@ newTab
   => TabConfig
   -> Eff effs (Either ZellijError TabId)
 newTab = send . NewTab
+
+-- | Switch focus to a tab by name.
+--
+-- The tab must already exist in the current Zellij session.
+-- Requires running inside Zellij (check with 'checkZellijEnv' first).
+--
+-- @
+-- result <- goToTab (TabId "5dj")
+-- case result of
+--   Right () -> -- focus switched successfully
+--   Left err -> handleError err
+-- @
+goToTab
+  :: Member Zellij effs
+  => TabId
+  -> Eff effs (Either ZellijError ())
+goToTab = send . GoToTab


### PR DESCRIPTION
Closes tidepool-9uv

## Description
## Context
Expert consultation confirmed Zellij supports `zellij action go-to-tab-name <name>`.

## Problem
When a subagent errors, TL must manually find and switch to that tab.

## Implementation
When subagent reports error (via hook or process exit):
```bash
zellij action go-to-tab-name "$BEAD_ID"
```

## Integration Points
- Stop hook handler could trigger this
- Process-compose on_failure could call it
- Or polling loop in TL session

## Acceptance Criteria
- [ ] On subagent error, focus switches to that tab automatically
- [ ] Works with bead ID as tab name
- [ ] TL can override/disable if preferred

## Dependencies

  → tidepool-6zq: Enhance spawn_agents to launch Zellij tabs

