### PR TITLE
Implement training-generator CLI for FunctionGemma edge scoring

### DIFF
--- a/haskell/tools/training-generator/CLAUDE.md
+++ b/haskell/tools/training-generator/CLAUDE.md
@@ -1,12 +1,12 @@
 # Training Generator - FunctionGemma Fine-Tuning Data
 
-Generates JSONL training data for fine-tuning FunctionGemma 270M as a semantic edge scorer. Used by semantic-scout to replace heuristics with learned models.
+Generates JSONL training data for fine-tuning FunctionGemma 270M as a semantic edge scorer. Used by control-server to replace heuristics with learned models.
 
 ## When to Read This
 
 Read this if you're:
 - Generating datasets for FunctionGemma fine-tuning
-- Working on semantic-scout training data generation
+- Working on control-server training data generation
 - Understanding the heuristics → ML migration path
 
 ## What It Does
@@ -40,7 +40,7 @@ Schema is "baked" into model weights via fine-tuning - no schema turn needed.
                                        │ Model
                                        ▼
 ┌─────────────────────────────────────────────────────────────────────┐
-│ semantic-scout (via control-server)                                 │
+│ control-server (Scout Module)                                       │
 │   • HTTP to Ollama (port 11434) with OpenAI-style tools array       │
 │   • Ollama auto-translates → FunctionGemma token format             │
 │   • Response in message.tool_calls[0].function.arguments            │
@@ -146,7 +146,7 @@ This bootstraps training data - the fine-tuned model learns to generalize.
 
 ## Related Documentation
 
-- [agents/semantic-scout/CLAUDE.md](../../agents/semantic-scout/CLAUDE.md) - Uses these types
+- [control-server/CLAUDE.md](../../control-server/CLAUDE.md) - Uses these types
 - [effects/lsp-interpreter/CLAUDE.md](../../effects/lsp-interpreter/CLAUDE.md) - LSP for hover info
 - [tools/CLAUDE.md](../CLAUDE.md) - Tools overview
 - [Root CLAUDE.md](../../../CLAUDE.md) - Project overview

--- a/haskell/tools/training-generator/app/Main.hs
+++ b/haskell/tools/training-generator/app/Main.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main (main) where
+
+import Control.Monad (replicateM_)
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Options.Applicative
+import Test.QuickCheck (generate)
+
+import Tidepool.Training.Arbitrary (generateExample)
+import Tidepool.Training.Format (formatEdgeTrainingExample)
+
+data Options = Options
+  { count :: Int
+  }
+
+optionsParser :: Parser Options
+optionsParser = Options
+  <$> argument auto
+      ( metavar "COUNT"
+     <> help "Number of training examples to generate" )
+
+main :: IO ()
+main = do
+  opts <- execParser optsInfo
+  replicateM_ (count opts) $ do
+    example <- generate generateExample
+    BSL.putStrLn $ formatEdgeTrainingExample example
+  where
+    optsInfo = info (optionsParser <**> helper)
+      ( fullDesc
+     <> progDesc "Generate JSONL training data for FunctionGemma 270M edge scoring"
+     <> header "training-generator - semantic edge training data generator" )

--- a/haskell/tools/training-generator/src/Tidepool/Training/Arbitrary.hs
+++ b/haskell/tools/training-generator/src/Tidepool/Training/Arbitrary.hs
@@ -1,0 +1,118 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Tidepool.Training.Arbitrary
+  ( heuristicScoreEdge
+  , generateExample
+  ) where
+
+import qualified Data.Text as T
+import Test.QuickCheck
+import Tidepool.Training.Types
+
+-- | Generate a synthetic training example.
+generateExample :: Gen EdgeTrainingExample
+generateExample = do
+  input <- arbitrary
+  let output = heuristicScoreEdge input
+  pure $ EdgeTrainingExample input output
+
+instance Arbitrary EdgeType where
+  arbitrary = elements allEdgeTypes
+
+instance Arbitrary ScoreEdgeInput where
+  arbitrary = do
+    query <- elements
+      [ "What breaks if I add a variant?"
+      , "Where is this type defined?"
+      , "Show me usage of this function"
+      , "How does this type family work?"
+      , "What uses this constraint?"
+      , "Is this exported?"
+      , "Does this pattern match all cases?"
+      ]
+    sourceFile <- elements ["Types.hs", "Handler.hs", "Main.hs", "Effect.hs", "Internal.hs"]
+    sourceLine <- choose (1, 500)
+    sourceHover <- elements
+      [ "data LLMKind = GPT4 | Claude3 | Gemma"
+      , "type family Map (f :: a -> b) (xs :: [a]) :: [b]"
+      , "case x of { A -> ... ; B -> ... }"
+      , "class Monad m => Effect m where"
+      , "newtype Context = Context Text"
+      ]
+    targetFile <- elements ["Types.hs", "Handler.hs", "Main.hs", "Effect.hs", "Internal.hs"]
+    targetLine <- choose (1, 500)
+    targetHover <- elements
+      [ "data LLMKind = ..."
+      , "instance Monad Effect where"
+      , "map :: (a -> b) -> [a] -> [b]"
+      , "type instance Map f (x:xs) = f x : Map f xs"
+      ]
+    edgeType <- arbitrary
+    pure $ ScoreEdgeInput query sourceFile sourceLine sourceHover targetFile targetLine targetHover edgeType
+
+-- | Heuristic scoring of an edge to bootstrap training data.
+--
+-- This logic creates initial ground truth for training the FunctionGemma 270M model.
+-- The model will learn to generalize these rules and handle edge cases that simple
+-- heuristics miss.
+heuristicScoreEdge :: ScoreEdgeInput -> ScoreEdgeOutput
+heuristicScoreEdge ScoreEdgeInput{..} =
+  let
+    -- Relevance Constants
+    relevanceHigh = 5  -- ^ Perfect match (e.g. "breaks" query -> Reference edge)
+    relevanceMed  = 3  -- ^ Default/Contextual relevance
+
+    -- Risk Constants
+    riskExtreme   = 5  -- ^ Type-level metaprogramming (fragile)
+    riskHigh      = 4  -- ^ Branching logic/Pattern matching (semantic change risk)
+    riskMed       = 3  -- ^ Data definitions (struct layout)
+    riskLow       = 2  -- ^ Pure functions/Standard definitions
+
+    -- Relevance heuristics: Score based on query intent matching edge type
+    relQuery = case () of
+      -- "What breaks?" -> References show impact
+      _ | "break" `T.isInfixOf` T.toLower seiQuery && seiEdgeType == Reference -> relevanceHigh
+      -- "Where is defined?" -> Definition is the answer
+      _ | "defined" `T.isInfixOf` T.toLower seiQuery && seiEdgeType == Definition -> relevanceHigh
+      -- "Show usage" -> Usage edges are direct answers
+      _ | "usage" `T.isInfixOf` T.toLower seiQuery && seiEdgeType == Usage -> relevanceHigh
+      -- Type family queries need type family context
+      _ | "type family" `T.isInfixOf` T.toLower seiQuery && "type family" `T.isInfixOf` T.toLower seiSourceHover -> relevanceHigh
+      -- Constraint queries need TypeConstraint edges
+      _ | "constraint" `T.isInfixOf` T.toLower seiQuery && seiEdgeType == TypeConstraint -> relevanceHigh
+      -- Default: Assuming some relevance since LSP returned it
+      _ -> relevanceMed
+
+    -- Risk heuristics: Score based on code construct complexity
+    risk = case () of
+      -- Type families are brittle and affect compilation globally
+      _ | "type family" `T.isInfixOf` T.toLower seiSourceHover -> riskExtreme
+      -- Case expressions imply logic branching which is risky to modify
+      _ | "case" `T.isInfixOf` T.toLower seiSourceHover -> riskHigh
+      -- Data definitions change memory layout/serialisation
+      _ | "data" `T.isInfixOf` T.toLower seiSourceHover -> riskMed
+      -- Default: Standard code is relatively safe
+      _ -> riskLow
+
+    -- Boolean flags extraction
+    isExhaustive = "case" `T.isInfixOf` T.toLower seiSourceHover || "match" `T.isInfixOf` T.toLower seiSourceHover
+    isTypeFamily = "type family" `T.isInfixOf` T.toLower seiSourceHover || "type instance" `T.isInfixOf` T.toLower seiTargetHover
+    isExported = not ("Internal" `T.isInfixOf` seiSourceFile) && not ("_" `T.isPrefixOf` seiSourceFile)
+
+    reasoning = T.unwords
+      [ if relQuery >= 4 then "Highly relevant" else "Moderately relevant"
+      , "to the query."
+      , if risk >= 4 then "High structural risk." else "Low risk."
+      , if isExhaustive then "Found pattern matching." else ""
+      ]
+
+  in ScoreEdgeOutput
+    { seoRelevance    = relQuery
+    , seoRisk         = risk
+    , seoReasoning    = T.strip reasoning
+    , seoIsExhaustive = isExhaustive
+    , seoIsTypeFamily = isTypeFamily
+    , seoIsExported   = isExported
+    }

--- a/haskell/tools/training-generator/src/Tidepool/Training/Types.hs
+++ b/haskell/tools/training-generator/src/Tidepool/Training/Types.hs
@@ -20,6 +20,11 @@ module Tidepool.Training.Types
 
     -- * Training Example
   , TrainingExample(..)
+  , EdgeTrainingExample(..)
+
+    -- * Score Edge (Flat Format for 270M model)
+  , ScoreEdgeInput(..)
+  , ScoreEdgeOutput(..)
 
     -- * Select Symbols Example (for FunctionGemma symbol selection)
   , SelectSymbolsExample(..)
@@ -103,6 +108,40 @@ data TrainingExample = TrainingExample
   { teQuery  :: QueryContext  -- ^ The query being answered
   , teNode   :: NodeContext   -- ^ The code location being rated
   , teRubric :: Rubric        -- ^ Ground truth rating
+  } deriving stock (Eq, Show, Generic)
+    deriving anyclass (FromJSON, ToJSON)
+
+
+-- | Input context for scoring an edge (flattened for 270M model).
+data ScoreEdgeInput = ScoreEdgeInput
+  { seiQuery       :: Text      -- ^ Natural language query
+  , seiSourceFile  :: Text      -- ^ Source location file
+  , seiSourceLine  :: Int       -- ^ Source location line
+  , seiSourceHover :: Text      -- ^ Hover info at source
+  , seiTargetFile  :: Text      -- ^ Target location file
+  , seiTargetLine  :: Int       -- ^ Target location line
+  , seiTargetHover :: Text      -- ^ Hover info at target
+  , seiEdgeType    :: EdgeType  -- ^ Relationship type
+  } deriving stock (Eq, Show, Generic)
+    deriving anyclass (FromJSON, ToJSON)
+
+
+-- | Output rubric for an edge (flattened for 270M model).
+data ScoreEdgeOutput = ScoreEdgeOutput
+  { seoRelevance    :: Int   -- ^ 1-5: How relevant to query
+  , seoRisk         :: Int   -- ^ 1-5: How risky to modify
+  , seoReasoning    :: Text  -- ^ Natural language justification
+  , seoIsExhaustive :: Bool  -- ^ Pattern match exhaustiveness
+  , seoIsTypeFamily :: Bool  -- ^ Type-level computation
+  , seoIsExported   :: Bool  -- ^ Public API surface
+  } deriving stock (Eq, Show, Generic)
+    deriving anyclass (FromJSON, ToJSON)
+
+
+-- | Complete training example for edge scoring.
+data EdgeTrainingExample = EdgeTrainingExample
+  { eteInput  :: ScoreEdgeInput
+  , eteOutput :: ScoreEdgeOutput
   } deriving stock (Eq, Show, Generic)
     deriving anyclass (FromJSON, ToJSON)
 

--- a/haskell/tools/training-generator/test/Main.hs
+++ b/haskell/tools/training-generator/test/Main.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main (main) where
+
+import qualified Data.Text as T
+import Test.Hspec
+import Test.QuickCheck
+import Tidepool.Training.Arbitrary (heuristicScoreEdge)
+import Tidepool.Training.Types (ScoreEdgeOutput(..))
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = do
+  describe "heuristicScoreEdge" $ do
+    it "produces relevance scores within valid range (1-5)" $ property $
+      \input ->
+        let output = heuristicScoreEdge input
+        in seoRelevance output `shouldSatisfy` (\x -> x >= 1 && x <= 5)
+    
+    it "produces risk scores within valid range (1-5)" $ property $
+      \input ->
+        let output = heuristicScoreEdge input
+        in seoRisk output `shouldSatisfy` (\x -> x >= 1 && x <= 5)
+
+    it "always includes reasoning" $ property $
+      \input ->
+        let output = heuristicScoreEdge input
+        in not (T.null (seoReasoning output))

--- a/haskell/tools/training-generator/tidepool-training-generator.cabal
+++ b/haskell/tools/training-generator/tidepool-training-generator.cabal
@@ -24,11 +24,13 @@ library
   exposed-modules:
     Tidepool.Training.Types
     Tidepool.Training.Format
+    Tidepool.Training.Arbitrary
   build-depends:
     base >= 4.17 && < 5,
     aeson >= 2.1 && < 3,
     bytestring >= 0.11 && < 1,
-    text >= 2.0 && < 3
+    text >= 2.0 && < 3,
+    QuickCheck >= 2.14 && < 3
   hs-source-dirs:   src
   default-language: GHC2021
   default-extensions:
@@ -36,3 +38,29 @@ library
     DeriveGeneric
     DerivingStrategies
     OverloadedStrings
+
+executable training-generator
+  import:           warnings
+  main-is:          Main.hs
+  build-depends:
+    base >= 4.17 && < 5,
+    tidepool-training-generator,
+    QuickCheck >= 2.14 && < 3,
+    bytestring >= 0.11 && < 1,
+    text >= 2.0 && < 3,
+    optparse-applicative >= 0.17 && < 1
+  hs-source-dirs:   app
+  default-language: GHC2021
+
+test-suite training-generator-test
+  import:           warnings
+  default-language: GHC2021
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   test
+  main-is:          Main.hs
+  build-depends:
+    base >= 4.17 && < 5,
+    tidepool-training-generator,
+    QuickCheck >= 2.14 && < 3,
+    hspec >= 2.0 && < 3,
+    text >= 2.0 && < 3


### PR DESCRIPTION
This PR completes the implementation of the `training-generator` tool as specified in the task `tidepool-iiz`.

### Changes:
- **Types**: Added `ScoreEdgeInput`, `ScoreEdgeOutput`, and `EdgeTrainingExample` to `Tidepool.Training.Types`.
- **Generation**: Created `Tidepool.Training.Arbitrary` with QuickCheck generators and a heuristic scoring function to bootstrap training data.
- **Formatting**: Implemented `formatEdgeTrainingExample` in `Tidepool.Training.Format` using the 2-turn JSONL conversation format required by FunctionGemma 270M.
- **CLI**: Implemented the command-line entry point in `app/Main.hs` using `optparse-applicative`.
- **Cabal**: Updated `tidepool-training-generator.cabal` with new modules, executable, and dependencies (`QuickCheck`, `optparse-applicative`).

### Testing:
Verified by building and running the tool:
```bash
cabal run training-generator -- 5
```
The output correctly follows the specified JSONL format.