### PR TITLE
feat(spawn-agents): Add MCP config and role-based context for subagents

### DIFF
--- a/rust/mantle-agent/src/main.rs
+++ b/rust/mantle-agent/src/main.rs
@@ -48,6 +48,15 @@ enum Commands {
         role: Role,
     },
 
+    /// Start a stdio-based MCP server.
+    ///
+    /// Forwards JSON-RPC requests from stdin to the control server via Unix socket.
+    Mcp {
+        /// The role of the agent (dev, tl, pm). Determines available tools.
+        #[arg(long, default_value = "dev")]
+        role: Role,
+    },
+
     /// Check control server health via Ping/Pong on socket.
     Health,
 }
@@ -64,6 +73,7 @@ fn main() {
 
     let result = match cli.command {
         Commands::Hook { event, runtime, role } => handle_hook(event, runtime, role),
+        Commands::Mcp { role } => mantle_shared::handle_mcp(role),
         Commands::Health => health::run_health_check(),
     };
 

--- a/rust/mantle-shared/src/commands/mcp.rs
+++ b/rust/mantle-shared/src/commands/mcp.rs
@@ -1,0 +1,228 @@
+//! MCP command implementation.
+//!
+//! Provides a stdio-based MCP server that forwards requests to the Haskell
+//! control server via Unix socket. This allows Gemini CLI and other stdio-only
+//! MCP clients to access Tidepool tools.
+
+use crate::error::{MantleError, Result};
+use crate::protocol::{ControlMessage, ControlResponse, Role};
+use crate::socket::{control_socket_path, ControlSocket};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::io::{BufRead, Write};
+use tracing::{debug, error, info, trace};
+
+#[derive(Debug, Deserialize)]
+struct JsonRpcRequest {
+    jsonrpc: String,
+    id: Value,
+    method: String,
+    params: Option<Value>,
+}
+
+#[derive(Debug, Serialize)]
+struct JsonRpcResponse {
+    jsonrpc: String,
+    id: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<Value>,
+}
+
+/// Handle MCP requests from stdio.
+pub fn handle_mcp(role: Role) -> Result<()> {
+    info!(role = %role, "Starting MCP server (stdio)");
+
+    // Get control server socket path
+    let path = control_socket_path()?;
+    let mut socket = ControlSocket::connect(&path)?;
+
+    let stdin = std::io::stdin();
+    let mut stdout = std::io::stdout();
+
+    for line in stdin.lock().lines() {
+        let line = line.map_err(MantleError::Io)?;
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        trace!(line = %line, "Received MCP request");
+
+        let request: JsonRpcRequest = match serde_json::from_str(&line) {
+            Ok(req) => req,
+            Err(e) => {
+                error!(error = %e, line = %line, "Failed to parse JSON-RPC request");
+                let response = JsonRpcResponse {
+                    jsonrpc: "2.0".to_string(),
+                    id: Value::Null,
+                    result: None,
+                    error: Some(json!({
+                        "code": -32700,
+                        "message": format!("Parse error: {}", e)
+                    })),
+                };
+                send_response(&mut stdout, &response)?;
+                continue;
+            }
+        };
+
+        let response = match request.method.as_str() {
+            "initialize" => {
+                JsonRpcResponse {
+                    jsonrpc: "2.0".to_string(),
+                    id: request.id,
+                    result: Some(json!({
+                        "protocolVersion": "2024-11-05",
+                        "capabilities": {
+                            "tools": {}
+                        },
+                        "serverInfo": {
+                            "name": "tidepool-mcp",
+                            "version": "0.1.0"
+                        }
+                    })),
+                    error: None,
+                }
+            }
+            "tools/list" => {
+                let msg = ControlMessage::ToolsListRequest { role: Some(role) };
+                match socket.send(&msg) {
+                    Ok(ControlResponse::ToolsListResponse { tools }) => {
+                        let mcp_tools: Vec<Value> = tools.into_iter().map(|t| json!({ 
+                            "name": t.name,
+                            "description": t.description,
+                            "inputSchema": t.input_schema
+                        })).collect();
+                        
+                        JsonRpcResponse {
+                            jsonrpc: "2.0".to_string(),
+                            id: request.id,
+                            result: Some(json!({
+                                "tools": mcp_tools
+                            })),
+                            error: None,
+                        }
+                    }
+                    Ok(_) => {
+                        error!("Unexpected response type from control server for tools/list");
+                        JsonRpcResponse {
+                            jsonrpc: "2.0".to_string(),
+                            id: request.id,
+                            result: None,
+                            error: Some(json!({
+                                "code": -32603,
+                                "message": "Internal server error: unexpected response type"
+                            })),
+                        }
+                    }
+                    Err(e) => {
+                        error!(error = %e, "Failed to communicate with control server");
+                        JsonRpcResponse {
+                            jsonrpc: "2.0".to_string(),
+                            id: request.id,
+                            result: None,
+                            error: Some(json!({
+                                "code": -32603,
+                                "message": format!("Control server error: {}", e)
+                            })),
+                        }
+                    }
+                }
+            }
+            "tools/call" => {
+                let params = request.params.unwrap_or(Value::Null);
+                let tool_name = params["name"].as_str().unwrap_or("").to_string();
+                let tool_args = params["arguments"].clone();
+
+                let msg = ControlMessage::McpToolCall {
+                    id: request.id.to_string(),
+                    tool_name,
+                    arguments: tool_args,
+                    role: Some(role),
+                };
+
+                match socket.send(&msg) {
+                    Ok(ControlResponse::McpToolResponse { result, error, .. }) => {
+                        if let Some(err) = error {
+                            JsonRpcResponse {
+                                jsonrpc: "2.0".to_string(),
+                                id: request.id,
+                                result: None,
+                                error: Some(json!({
+                                    "code": err.code,
+                                    "message": err.message
+                                })),
+                            }
+                        } else {
+                            JsonRpcResponse {
+                                jsonrpc: "2.0".to_string(),
+                                id: request.id,
+                                result: Some(json!({
+                                    "content": [
+                                        {
+                                            "type": "text",
+                                            "text": serde_json::to_string_pretty(&result.unwrap_or(Value::Null)).unwrap_or_default()
+                                        }
+                                    ]
+                                })),
+                                error: None,
+                            }
+                        }
+                    }
+                    Ok(_) => {
+                        error!("Unexpected response type from control server for tools/call");
+                        JsonRpcResponse {
+                            jsonrpc: "2.0".to_string(),
+                            id: request.id,
+                            result: None,
+                            error: Some(json!({
+                                "code": -32603,
+                                "message": "Internal server error: unexpected response type"
+                            })),
+                        }
+                    }
+                    Err(e) => {
+                        error!(error = %e, "Failed to communicate with control server");
+                        JsonRpcResponse {
+                            jsonrpc: "2.0".to_string(),
+                            id: request.id,
+                            result: None,
+                            error: Some(json!({
+                                "code": -32603,
+                                "message": format!("Control server error: {}", e)
+                            })),
+                        }
+                    }
+                }
+            }
+            "notifications/initialized" => {
+                continue; // Ignore
+            }
+            _ => {
+                debug!(method = %request.method, "Unknown MCP method");
+                JsonRpcResponse {
+                    jsonrpc: "2.0".to_string(),
+                    id: request.id,
+                    result: None,
+                    error: Some(json!({
+                        "code": -32601,
+                        "message": format!("Method not found: {}", request.method)
+                    })),
+                }
+            }
+        };
+
+        send_response(&mut stdout, &response)?;
+    }
+
+    Ok(())
+}
+
+fn send_response<W: Write>(writer: &mut W, response: &JsonRpcResponse) -> Result<()> {
+    let json = serde_json::to_string(response).map_err(MantleError::JsonSerialize)?;
+    writer.write_all(json.as_bytes()).map_err(MantleError::Io)?;
+    writer.write_all(b"\n").map_err(MantleError::Io)?;
+    writer.flush().map_err(MantleError::Io)?;
+    Ok(())
+}

--- a/rust/mantle-shared/src/commands/mod.rs
+++ b/rust/mantle-shared/src/commands/mod.rs
@@ -9,7 +9,9 @@
 //! - [`hook`]: Handle Claude Code hook events via control socket
 
 pub mod hook;
+pub mod mcp;
 pub mod signal;
 
 pub use hook::{default_allow_response, handle_hook, HookEventType};
+pub use mcp::handle_mcp;
 pub use signal::send_signal;

--- a/rust/mantle-shared/src/lib.rs
+++ b/rust/mantle-shared/src/lib.rs
@@ -66,5 +66,5 @@ pub use hub::{
 };
 
 // Re-export command types
-pub use commands::{handle_hook, send_signal, HookEventType};
+pub use commands::{handle_hook, handle_mcp, send_signal, HookEventType};
 pub use util::{build_prompt, find_mantle_agent_binary, shell_quote};

--- a/rust/mantle-shared/src/protocol.rs
+++ b/rust/mantle-shared/src/protocol.rs
@@ -23,8 +23,9 @@ use serde_json::Value;
 // ============================================================================
 
 /// The runtime environment for the agent.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, ValueEnum)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, ValueEnum, strum::Display)]
 #[serde(rename_all = "lowercase")]
+#[strum(serialize_all = "lowercase")]
 pub enum Runtime {
     /// Anthropic's Claude Code CLI.
     Claude,
@@ -39,8 +40,9 @@ impl Default for Runtime {
 }
 
 /// The role of the agent (determines hook behavior and context).
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, ValueEnum, Default)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, ValueEnum, Default, strum::Display)]
 #[serde(rename_all = "lowercase")]
+#[strum(serialize_all = "lowercase")]
 pub enum Role {
     /// Developer/subagent role - focused on implementing tasks.
     #[default]
@@ -300,10 +302,17 @@ pub enum ControlMessage {
         tool_name: String,
         /// Tool arguments.
         arguments: Value,
+        /// Optional role for routing (not serialized).
+        #[serde(skip)]
+        role: Option<Role>,
     },
 
     /// Request list of available MCP tools from control server.
-    ToolsListRequest,
+    ToolsListRequest {
+        /// Optional role for routing (not serialized).
+        #[serde(skip)]
+        role: Option<Role>,
+    },
 
     /// Health check ping.
     Ping,

--- a/rust/mantle-shared/src/socket.rs
+++ b/rust/mantle-shared/src/socket.rs
@@ -68,22 +68,30 @@ impl ControlSocket {
             ControlMessage::HookEvent { input, runtime, role } => {
                 // API expects [HookInput, Runtime, Role]
                 let body = serde_json::json!([input, runtime, role]);
-                ("POST", "/hook", Some(body))
+                ("POST", "/hook".to_string(), Some(body))
             },
-            ControlMessage::McpToolCall { id, tool_name, arguments } => {
+            ControlMessage::McpToolCall { id, tool_name, arguments, role } => {
                 // API expects {"id": ..., "tool_name": ..., "arguments": ...}
+                let endpoint = match role {
+                    Some(r) => format!("/role/{}/mcp/call", r),
+                    None => "/mcp/call".to_string(),
+                };
                 let body = serde_json::json!({
                     "id": id,
                     "tool_name": tool_name,
                     "arguments": arguments
                 });
-                ("POST", "/mcp/call", Some(body))
+                ("POST", endpoint, Some(body))
             },
-            ControlMessage::ToolsListRequest => {
-                ("GET", "/mcp/tools", None)
+            ControlMessage::ToolsListRequest { role } => {
+                let endpoint = match role {
+                    Some(r) => format!("/role/{}/mcp/tools", r),
+                    None => "/mcp/tools".to_string(),
+                };
+                ("GET", endpoint, None)
             },
             ControlMessage::Ping => {
-                ("GET", "/ping", None)
+                ("GET", "/ping".to_string(), None)
             }
         };
 


### PR DESCRIPTION
## Summary

- Generate `.mcp.json` for Claude Code with role-prefixed endpoint (`http+unix://<socket>/role/dev/mcp`)
- Update Gemini config to pass `--role` flag to `mantle-agent mcp`
- Add `TIDEPOOL_ROLE=dev` to spawned agent environment
- Simplify `bead.md` to task description only (workflow instructions moved to SessionStart template)
- Implement `mantle-agent mcp` subcommand as stdio JSON-RPC server for Gemini CLI
- Add `Role` enum (Dev, Tl, Pm) to protocol types
- Route MCP calls to role-prefixed endpoints in socket client

## Test plan

- [ ] Spawn a subagent with `spawn_agents` tool
- [ ] Verify `.mcp.json` is created with `/role/dev/mcp` URL in worktree
- [ ] Verify Claude Code MCP tools connect via role endpoint
- [ ] Verify Gemini config includes `--role dev` argument
- [ ] Verify `bead.md` contains only task info (no workflow instructions)
- [ ] Verify `TIDEPOOL_ROLE=dev` in subagent environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)