### PR TITLE
[role-system] Role-Based Access Control Overhaul

### DIFF
--- a/haskell/control-server/src/Tidepool/Control/ExoTools/FilePR.hs
+++ b/haskell/control-server/src/Tidepool/Control/ExoTools/FilePR.hs
@@ -27,10 +27,11 @@ import Tidepool.Effects.Git (Git, WorktreeInfo(..), getWorktreeInfo)
 import Tidepool.Effects.GitHub (GitHub, Repo(..), PRCreateSpec(..), PRUrl(..), PullRequest(..), PRFilter(..), createPR, listPullRequests, defaultPRFilter)
 import qualified Data.Text as T
 import Data.Maybe (listToMaybe)
+import Tidepool.Role (Role(..))
 import Tidepool.Graph.Generic (AsHandler, type (:-))
 import Tidepool.Graph.Generic.Core (EntryNode, ExitNode, LogicNode)
 import Tidepool.Graph.Goto (Goto, GotoChoice, To, gotoExit)
-import Tidepool.Graph.Types (type (:@), Input, UsesEffects, Exit, MCPExport, MCPToolDef)
+import Tidepool.Graph.Types (type (:@), Input, UsesEffects, Exit, MCPExport, MCPToolDef, MCPRoleHint)
 import Tidepool.Schema (HasJSONSchema(..), objectSchema, emptySchema, SchemaType(..), describeField)
 
 import Tidepool.Control.ExoTools.Internal (parseBeadId, slugify, formatPRBody)
@@ -98,6 +99,7 @@ data FilePRGraph mode = FilePRGraph
   { fpEntry :: mode :- EntryNode FilePRArgs
       :@ MCPExport
       :@ MCPToolDef '("file_pr", "File a pull request for current bead. Idempotent: returns existing PR if one exists.")
+      :@ MCPRoleHint 'Dev
 
   , fpRun :: mode :- LogicNode
       :@ Input FilePRArgs

--- a/haskell/control-server/src/Tidepool/Control/ExoTools/SpawnAgents.hs
+++ b/haskell/control-server/src/Tidepool/Control/ExoTools/SpawnAgents.hs
@@ -36,10 +36,11 @@ import Tidepool.Effects.Worktree (Worktree, WorktreeSpec(..), WorktreePath(..), 
 
 import Tidepool.Effects.FileSystem (FileSystem, createDirectory, writeFileText, copyFile, fileExists, directoryExists, readFileText)
 import Tidepool.Effects.Zellij (Zellij, TabConfig(..), TabId(..), checkZellijEnv, newTab)
+import Tidepool.Role (Role(..))
 import Tidepool.Graph.Generic (AsHandler, type (:-))
 import Tidepool.Graph.Generic.Core (EntryNode, ExitNode, LogicNode)
 import Tidepool.Graph.Goto (Goto, GotoChoice, To, gotoExit)
-import Tidepool.Graph.Types (type (:@), Input, UsesEffects, Exit, MCPExport, MCPToolDef)
+import Tidepool.Graph.Types (type (:@), Input, UsesEffects, Exit, MCPExport, MCPToolDef, MCPRoleHint)
 import Tidepool.Schema (HasJSONSchema(..), objectSchema, arraySchema, emptySchema, SchemaType(..), describeField)
 
 import Tidepool.Control.ExoTools.Internal (slugify)
@@ -164,6 +165,7 @@ data SpawnAgentsGraph mode = SpawnAgentsGraph
     saEntry :: mode :- EntryNode SpawnAgentsArgs
       :@ MCPExport
       :@ MCPToolDef '("spawn_agents", "Create worktrees and branches for parallel agent dispatch. Accepts optional 'backend' parameter ('claude' or 'gemini', defaults to 'claude').")
+      :@ MCPRoleHint 'TL
 
   , saRun :: mode :- LogicNode
       :@ Input SpawnAgentsArgs

--- a/haskell/control-server/src/Tidepool/Control/Export.hs
+++ b/haskell/control-server/src/Tidepool/Control/Export.hs
@@ -88,7 +88,7 @@ exportMCPTools logger = do
   logInfo logger $ "[MCP Discovery] Total: " <> T.pack (show (length allTools)) <> " tools discovered"
 
   -- Log tool names with entry points for verification
-  forM_ allTools $ \(MCPToolInfo name _desc _schema entryName) -> 
+  forM_ allTools $ \(MCPToolInfo name _desc _schema entryName _roles) -> 
     logDebug logger $ "[MCP Discovery]   " <> name <> " -> " <> entryName
 
   logDebug logger "[MCP Discovery] Converting to ToolDefinition format..."
@@ -96,7 +96,7 @@ exportMCPTools logger = do
 
 -- | Convert MCPToolInfo -> ToolDefinition.
 reifyToToolDef :: MCPToolInfo -> ToolDefinition
-reifyToToolDef (MCPToolInfo name desc schema _entryName) = ToolDefinition 
+reifyToToolDef (MCPToolInfo name desc schema _entryName _roles) = ToolDefinition 
   { tdName = name 
   , tdDescription = desc 
   , tdInputSchema = schema 

--- a/haskell/control-server/src/Tidepool/Control/LSPTools.hs
+++ b/haskell/control-server/src/Tidepool/Control/LSPTools.hs
@@ -85,6 +85,7 @@ import GHC.Generics (Generic)
 
 import Tidepool.Effect.LSP
 import Tidepool.Effect.Types (Log, logDebug, Return, returnValue)
+import Tidepool.Role (Role(..))
 import Tidepool.Graph.Generic (type (:-))
 import Tidepool.Graph.Generic.Core (LogicNode)
 import Tidepool.Graph.Types (type (:@), Input, UsesEffects, GraphEntries, GraphEntry(..))
@@ -181,7 +182,7 @@ newtype FindCallersGraph mode = FindCallersGraph
 
 -- | MCP tool entry point declaration for find_callers.
 type instance GraphEntries FindCallersGraph =
-  '[ "find_callers" ':~> '("fcRun", FindCallersArgs, "Find actual call sites of a function, filtering out imports and type signatures") ]
+  '[ "find_callers" ':~> '("fcRun", FindCallersArgs, "Find actual call sites of a function, filtering out imports and type signatures", '[ 'Dev]) ]
 
 -- | Core logic for finding callers.
 findCallersLogic
@@ -371,7 +372,7 @@ newtype FindCalleesGraph mode = FindCalleesGraph
 
 -- | MCP tool entry point declaration for find_callees.
 type instance GraphEntries FindCalleesGraph =
-  '[ "find_callees" ':~> '("fceRun", FindCalleesArgs, "Find functions called by a given function") ]
+  '[ "find_callees" ':~> '("fceRun", FindCalleesArgs, "Find functions called by a given function", '[ 'Dev]) ]
 
 -- | Core logic for finding callees.
 findCalleesLogic
@@ -554,7 +555,7 @@ newtype ShowTypeGraph mode = ShowTypeGraph
 
 -- | MCP tool entry point declaration for show_type.
 type instance GraphEntries ShowTypeGraph =
-  '[ "show_type" ':~> '("stRun", ShowTypeArgs, "Inspect a Haskell type: shows fields (for records) and constructors (for sum types/GADTs)") ]
+  '[ "show_type" ':~> '("stRun", ShowTypeArgs, "Inspect a Haskell type: shows fields (for records) and constructors (for sum types/GADTs)", '[ 'Dev]) ]
 
 -- | Core logic for showing type information.
 showTypeLogic
@@ -726,7 +727,7 @@ newtype ShowFieldsGraph mode = ShowFieldsGraph
 
 -- | MCP tool entry point declaration for show_fields.
 type instance GraphEntries ShowFieldsGraph =
-  '[ "show_fields" ':~> '("sfRun", ShowFieldsArgs, "Show fields of a Haskell record type with their types") ]
+  '[ "show_fields" ':~> '("sfRun", ShowFieldsArgs, "Show fields of a Haskell record type with their types", '[ 'Dev]) ]
 
 -- | Core logic for showing fields.
 showFieldsLogic
@@ -870,7 +871,7 @@ newtype ShowConstructorsGraph mode = ShowConstructorsGraph
 
 -- | MCP tool entry point declaration for show_constructors.
 type instance GraphEntries ShowConstructorsGraph =
-  '[ "show_constructors" ':~> '("scRun", ShowConstructorsArgs, "Show constructors of a Haskell sum type or GADT") ]
+  '[ "show_constructors" ':~> '("scRun", ShowConstructorsArgs, "Show constructors of a Haskell sum type or GADT", '[ 'Dev]) ]
 
 -- | Core logic for showing constructors.
 showConstructorsLogic

--- a/haskell/control-server/src/Tidepool/Control/PMPropose.hs
+++ b/haskell/control-server/src/Tidepool/Control/PMPropose.hs
@@ -29,11 +29,12 @@ import qualified Data.Text as T
 import GHC.Generics (Generic)
 
 import Tidepool.Effects.BD (BD, BeadType(..), CreateBeadInput(..), defaultCreateInput, createBead)
+import Tidepool.Role (Role(..))
 import Tidepool.Control.PMTools (labelNeedsTLReview)
 import Tidepool.Graph.Generic (AsHandler, type (:-))
 import Tidepool.Graph.Generic.Core (EntryNode, ExitNode, LogicNode)
 import Tidepool.Graph.Goto (Goto, GotoChoice, To, gotoExit)
-import Tidepool.Graph.Types (type (:@), Input, UsesEffects, Exit, MCPExport, MCPToolDef)
+import Tidepool.Graph.Types (type (:@), Input, UsesEffects, Exit, MCPExport, MCPToolDef, MCPRoleHint)
 import Tidepool.Schema (HasJSONSchema(..), objectSchema, arraySchema, emptySchema, SchemaType(..), describeField)
 
 -- ════════════════════════════════════════════════════════════════════════════
@@ -100,6 +101,7 @@ data PMProposeGraph mode = PMProposeGraph
   { ppEntry :: mode :- EntryNode PMProposeArgs
       :@ MCPExport
       :@ MCPToolDef '("pm_propose", "Propose a new bead with intent-level details for TL review.")
+      :@ MCPRoleHint 'PM
 
   , ppRun :: mode :- LogicNode
       :@ Input PMProposeArgs

--- a/haskell/control-server/src/Tidepool/Control/PMReviewDAG.hs
+++ b/haskell/control-server/src/Tidepool/Control/PMReviewDAG.hs
@@ -33,10 +33,11 @@ import Data.Ord (comparing)
 
 import Tidepool.Effects.BD (BD, listBeads, defaultListBeadsInput, BeadInfo(..), BeadStatus(..), DependencyInfo(..), DependencyType(..))
 import Tidepool.Effect.Types (Time, getCurrentTime)
+import Tidepool.Role (Role(..))
 import Tidepool.Graph.Generic (AsHandler, type (:-))
 import Tidepool.Graph.Generic.Core (EntryNode, LogicNode, ExitNode)
 import Tidepool.Graph.Goto (Goto, GotoChoice, To, gotoExit)
-import Tidepool.Graph.Types (type (:@), Input, UsesEffects, Exit, MCPExport, MCPToolDef)
+import Tidepool.Graph.Types (type (:@), Input, UsesEffects, Exit, MCPExport, MCPToolDef, MCPRoleHint)
 import Tidepool.Schema (HasJSONSchema(..), objectSchema, describeField, emptySchema, SchemaType(..))
 
 -- | Arguments for pm_review_dag tool.
@@ -113,6 +114,7 @@ data PmReviewDagGraph mode = PmReviewDagGraph
   { prdEntry :: mode :- EntryNode PmReviewDagArgs
       :@ MCPExport
       :@ MCPToolDef ('("pm_review_dag", "Analyze the bead DAG for strategic planning, identifying critical paths and priority inversions."))
+      :@ MCPRoleHint 'PM
 
   , prdRun :: mode :- LogicNode
       :@ Input PmReviewDagArgs

--- a/haskell/control-server/src/Tidepool/Control/PMStatus.hs
+++ b/haskell/control-server/src/Tidepool/Control/PMStatus.hs
@@ -31,11 +31,12 @@ import GHC.Generics (Generic)
 import Tidepool.Effects.BD (BD, listBeads, ListBeadsInput(..), defaultListBeadsInput, BeadStatus(..), BeadInfo(..))
 import Tidepool.Effects.GitHub (GitHub, listPullRequests, PRFilter(..), defaultPRFilter, PRState(..), PullRequest(..), Repo(..))
 import Tidepool.Effect.Types (Time, getCurrentTime)
+import Tidepool.Role (Role(..))
 import Tidepool.Control.PMTools (labelReady, labelNeedsTLReview, labelNeedsPMApproval)
 import Tidepool.Graph.Generic (AsHandler, type (:-))
 import Tidepool.Graph.Generic.Core (EntryNode, ExitNode, LogicNode)
 import Tidepool.Graph.Goto (Goto, GotoChoice, To, gotoExit)
-import Tidepool.Graph.Types (type (:@), Input, UsesEffects, Exit, MCPExport, MCPToolDef)
+import Tidepool.Graph.Types (type (:@), Input, UsesEffects, Exit, MCPExport, MCPToolDef, MCPRoleHint)
 import Tidepool.Schema (HasJSONSchema(..), objectSchema, emptySchema, SchemaType(..), describeField)
 
 -- ════════════════════════════════════════════════════════════════════════════
@@ -148,6 +149,7 @@ data PmStatusGraph mode = PmStatusGraph
   { psEntry :: mode :- EntryNode PmStatusArgs
       :@ MCPExport
       :@ MCPToolDef '("pm_status", "Sprint health dashboard for PM observability. Calculates velocity, cycle time, and state distribution.")
+      :@ MCPRoleHint 'PM
 
   , psRun :: mode :- LogicNode
       :@ Input PmStatusArgs

--- a/haskell/control-server/src/Tidepool/Control/PMTools.hs
+++ b/haskell/control-server/src/Tidepool/Control/PMTools.hs
@@ -55,10 +55,11 @@ import qualified Data.Text as T
 import GHC.Generics (Generic)
 
 import Tidepool.Effects.BD (BD, getLabels, addLabel, removeLabel, getBead, updateBead, BeadInfo(..), UpdateBeadInput(..), emptyUpdateInput)
+import Tidepool.Role (Role(..))
 import Tidepool.Graph.Generic (AsHandler, type (:-))
 import Tidepool.Graph.Generic.Core (EntryNode, ExitNode, LogicNode)
 import Tidepool.Graph.Goto (Goto, GotoChoice, To, gotoExit)
-import Tidepool.Graph.Types (type (:@), Input, UsesEffects, Exit, MCPExport, MCPToolDef)
+import Tidepool.Graph.Types (type (:@), Input, UsesEffects, Exit, MCPExport, MCPToolDef, MCPRoleHint)
 import Tidepool.Schema (HasJSONSchema(..), objectSchema, arraySchema, describeField, emptySchema, SchemaType(..))
 
 -- ════════════════════════════════════════════════════════════════════════════
@@ -184,6 +185,7 @@ data PmApproveExpansionGraph mode = PmApproveExpansionGraph
   { paeEntry :: mode :- EntryNode PmApproveExpansionArgs
       :@ MCPExport
       :@ MCPToolDef ('("pm_approve_expansion", "Approve or reject a bead's expansion plan. Handles label transitions and feedback."))
+      :@ MCPRoleHint 'PM
 
   , paeRun :: mode :- LogicNode
       :@ Input PmApproveExpansionArgs
@@ -295,6 +297,7 @@ data PmPrioritizeGraph mode = PmPrioritizeGraph
   { ppEntry :: mode :- EntryNode PmPrioritizeArgs
       :@ MCPExport
       :@ MCPToolDef '("pm_prioritize", "Batch update bead priorities with rationale audit trail.")
+      :@ MCPRoleHint 'PM
 
   , ppRun :: mode :- LogicNode
       :@ Input PmPrioritizeArgs

--- a/haskell/control-server/src/Tidepool/Control/Protocol.hs
+++ b/haskell/control-server/src/Tidepool/Control/Protocol.hs
@@ -35,6 +35,7 @@ import Data.Aeson
 import Data.Aeson.Types (Parser)
 import Data.Text (Text)
 import GHC.Generics (Generic)
+import Tidepool.Control.RoleConfig (Role(..))
 
 -- ============================================================================
 -- Hook Input (from Claude Code via mantle-agent)
@@ -265,22 +266,6 @@ instance FromJSON Runtime where
 instance ToJSON Runtime where
   toJSON Claude = String "claude"
   toJSON Gemini = String "gemini"
-
--- | The role of the agent (determines hook behavior and context).
-data Role = Dev | TL | PM
-  deriving stock (Show, Eq, Generic, Enum, Bounded)
-
-instance FromJSON Role where
-  parseJSON = withText "Role" $ \case
-    "dev" -> pure Dev
-    "tl" -> pure TL
-    "pm" -> pure PM
-    r -> fail $ "Unknown role: " <> show r
-
-instance ToJSON Role where
-  toJSON Dev = String "dev"
-  toJSON TL = String "tl"
-  toJSON PM = String "pm"
 
 -- | Tool definition for MCP discovery (must match Rust ToolDefinition).
 data ToolDefinition = ToolDefinition

--- a/haskell/control-server/src/Tidepool/Control/RoleConfig.hs
+++ b/haskell/control-server/src/Tidepool/Control/RoleConfig.hs
@@ -6,8 +6,9 @@ module Tidepool.Control.RoleConfig
   ) where
 
 import Data.Text (Text)
+import qualified Data.Text as T
 import qualified Data.Set as Set
-import Tidepool.Control.Protocol (Role(..))
+import Tidepool.Role (Role(..))
 
 roleFromText :: Text -> Maybe Role
 roleFromText "pm" = Just PM
@@ -16,17 +17,31 @@ roleFromText "dev" = Just Dev
 roleFromText _ = Nothing
 
 roleTools :: Role -> Maybe (Set.Set Text)
-roleTools Dev = Nothing -- All tools allowed
-roleTools PM = Just $ Set.fromList
-  [ "pm_status", "pm_review_dag", "pm_propose", "pm_approve_expansion", "pm_prioritize"
-  , "send_message", "check_inbox", "read_message", "mark_read"
-  , "exo_status"
-  ]
 roleTools TL = Just $ Set.fromList
-  [ "spawn_agents", "exo_status", "exo_complete", "file_pr"
-  , "find_callers", "show_fields", "show_constructors", "teach-graph"
+  -- Orchestration: spawn and monitor agents
+  [ "spawn_agents"
+  , "exo_status"      -- Check agent status
+  , "exo_complete"    -- Mark agent work complete
+  -- Messaging with agents
   , "send_message", "check_inbox", "read_message", "mark_read"
+  ]
+
+roleTools Dev = Just $ Set.fromList
+  -- Workflow execution
+  [ "file_pr"         -- File pull requests
+  -- Code intelligence (LSP-backed)
+  , "find_callers", "show_fields", "show_constructors", "teach-graph"
+  -- Interactive (TUI-backed)
   , "confirm_action", "select_option", "request_guidance"
+  ]
+
+roleTools PM = Just $ Set.fromList
+  -- Planning tools
+  [ "pm_status", "pm_review_dag", "pm_propose"
+  , "pm_approve_expansion", "pm_prioritize"
+  -- Messaging
+  , "send_message", "check_inbox", "read_message", "mark_read"
+  , "exo_status"  -- Can view but not spawn
   ]
 
 isToolAllowed :: Role -> Text -> Bool

--- a/haskell/control-server/src/Tidepool/Control/TUITools.hs
+++ b/haskell/control-server/src/Tidepool/Control/TUITools.hs
@@ -42,6 +42,7 @@ import GHC.Generics (Generic)
 
 import Tidepool.Effect.TUI
 import Tidepool.Effect.Types (Return, returnValue)
+import Tidepool.Role (Role(..))
 import Tidepool.Graph.Generic (type (:-))
 import Tidepool.Graph.Generic.Core (LogicNode)
 import Tidepool.Graph.Types (type (:@), Input, UsesEffects, GraphEntries, GraphEntry(..))
@@ -113,7 +114,7 @@ newtype ConfirmActionGraph mode = ConfirmActionGraph
 
 -- | MCP tool entry point declaration for confirm_action.
 type instance GraphEntries ConfirmActionGraph =
-  '[ "confirm_action" ':~> '("caRun", ConfirmArgs, "Show a confirmation dialog to the user for a potentially destructive or important action") ]
+  '[ "confirm_action" ':~> '("caRun", ConfirmArgs, "Show a confirmation dialog to the user for a potentially destructive or important action", '[ 'Dev, 'TL, 'PM]) ]
 
 -- | Core logic for confirm_action.
 confirmActionLogic
@@ -184,7 +185,7 @@ newtype SelectOptionGraph mode = SelectOptionGraph
 
 -- | MCP tool entry point declaration for select_option.
 type instance GraphEntries SelectOptionGraph =
-  '[ "select_option" ':~> '("soRun", SelectArgs, "Ask the user to select from a list of predefined options, or provide a custom response") ]
+  '[ "select_option" ':~> '("soRun", SelectArgs, "Ask the user to select from a list of predefined options, or provide a custom response", '[ 'Dev, 'TL, 'PM]) ]
 
 -- | Core logic for select_option.
 selectOptionLogic
@@ -261,7 +262,7 @@ newtype RequestGuidanceGraph mode = RequestGuidanceGraph
 
 -- | MCP tool entry point declaration for request_guidance.
 type instance GraphEntries RequestGuidanceGraph =
-  '[ "request_guidance" ':~> '("rgRun", GuidanceArgs, "Ask the user for free-form guidance or to select from suggestions when the agent is stuck") ]
+  '[ "request_guidance" ':~> '("rgRun", GuidanceArgs, "Ask the user for free-form guidance or to select from suggestions when the agent is stuck", '[ 'Dev, 'TL, 'PM]) ]
 
 -- | Core logic for request_guidance.
 requestGuidanceLogic

--- a/haskell/control-server/src/Tidepool/Control/Types.hs
+++ b/haskell/control-server/src/Tidepool/Control/Types.hs
@@ -8,6 +8,7 @@ import Data.Text (Text)
 
 import Tidepool.Observability.Types (ObservabilityConfig)
 import Tidepool.Control.Hook.Policy (HookPolicy, defaultPolicy)
+import Tidepool.Control.RoleConfig (Role(..))
 
 
 
@@ -22,6 +23,10 @@ data ServerConfig = ServerConfig
   , role       :: Maybe Text
 
     -- ^ Current agent role (e.g., "pm", "tl")
+
+  , defaultRole :: Role
+
+    -- ^ Default role for non-role-prefixed endpoints
 
   , noTui      :: Bool
 
@@ -50,6 +55,8 @@ defaultConfig = ServerConfig
   { projectDir = "."
 
   , role       = Nothing
+
+  , defaultRole = Dev
 
   , noTui      = False
 

--- a/haskell/control-server/test/RoleConfigSpec.hs
+++ b/haskell/control-server/test/RoleConfigSpec.hs
@@ -1,0 +1,42 @@
+module Main (main) where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+import Data.Text (Text)
+import qualified Data.Set as Set
+import Data.Maybe (fromMaybe)
+
+import Tidepool.Role (Role(..))
+import Tidepool.Control.RoleConfig
+
+main :: IO ()
+main = defaultMain spec
+
+spec :: TestTree
+spec = testGroup "Role Configuration"
+  [ testGroup "Tool Access"
+    [ testCase "TL can spawn_agents" $
+        isToolAllowed TL "spawn_agents" @?= True
+    , testCase "TL cannot file_pr" $
+        isToolAllowed TL "file_pr" @?= False
+    , testCase "Dev can file_pr" $
+        isToolAllowed Dev "file_pr" @?= True
+    , testCase "Dev cannot spawn_agents" $
+        isToolAllowed Dev "spawn_agents" @?= False
+    , testCase "PM can pm_status" $
+        isToolAllowed PM "pm_status" @?= True
+    , testCase "PM cannot spawn_agents" $
+        isToolAllowed PM "spawn_agents" @?= False
+    ]
+
+  , testGroup "Role Parsing"
+    [ testCase "dev parses to Dev" $
+        roleFromText "dev" @?= Just Dev
+    , testCase "tl parses to TL" $
+        roleFromText "tl" @?= Just TL
+    , testCase "pm parses to PM" $
+        roleFromText "pm" @?= Just PM
+    , testCase "invalid returns Nothing" $
+        roleFromText "invalid" @?= Nothing
+    ]
+  ]

--- a/haskell/control-server/tidepool-control-server.cabal
+++ b/haskell/control-server/tidepool-control-server.cabal
@@ -1,7 +1,7 @@
 cabal-version:      3.0
 name:               tidepool-control-server
 version:            0.1.0.0
-synopsis:           Unix socket control server for Claude Code++ hooks and MCP
+synopsis:           Unix socket control server for Claude Code++ integration. Receives hook events from mantle-agent and direct HTTP MCP requests from Claude Code via Unix socket. Provides 7 MCP tools organized in tiers: LSP-only (Tier 1), LLM-enhanced (Tier 2), external orchestration (Tier 3), TUI-interactive (Tier 4), and mailbox communication (Tier 5).
 description:        Receives hook events and MCP tool calls from mantle-agent
                     via NDJSON over Unix socket. Routes to effect handlers.
                     Includes semantic-scout for code exploration via LSP.
@@ -404,103 +404,56 @@ test-suite ssh-exec-test
         TypeApplications
 
 test-suite circuit-breaker-test
-
     import:           warnings
-
     type:             exitcode-stdio-1.0
-
     main-is:          CircuitBreakerSpec.hs
-
     build-depends:
-
         base >= 4.17 && < 5,
-
         tidepool-control-server,
-
         text >= 2.0 && < 3,
-
         stm >= 2.5 && < 3,
-
         time >= 1.9 && < 2,
-
         containers,
-
         tasty,
-
         tasty-hunit
-
     hs-source-dirs:   test
-
     default-language: GHC2024
-
     default-extensions:
-
         OverloadedStrings
-
         TypeApplications
 
-
-
-test-suite session-start-test
-
-
-
+test-suite role-config-test
     import:           warnings
-
-
-
     type:             exitcode-stdio-1.0
-
-
-
-    main-is:          SessionStartSpec.hs
-
-
-
+    main-is:          RoleConfigSpec.hs
     build-depends:
-
-
-
         base >= 4.17 && < 5,
-
-
-
         tidepool-control-server,
-
-
-
         tidepool-core,
-
-
-
-        tidepool-bd-interpreter,
-
-
-
         text >= 2.0 && < 3,
-
-
-
-        freer-simple,
-
-
-
+        containers,
         tasty,
-
-
-
         tasty-hunit
-
-
-
-
-
     hs-source-dirs:   test
-
     default-language: GHC2024
-
     default-extensions:
-
         OverloadedStrings
 
+test-suite session-start-test
+    import:           warnings
+    type:             exitcode-stdio-1.0
+    main-is:          SessionStartSpec.hs
+    build-depends:
+        base >= 4.17 && < 5,
+        tidepool-control-server,
+        tidepool-core,
+        tidepool-bd-interpreter,
+        text >= 2.0 && < 3,
+        freer-simple,
+        tasty,
+        tasty-hunit
+    hs-source-dirs:   test
+    default-language: GHC2024
+    default-extensions:
+        OverloadedStrings
         TypeApplications

--- a/haskell/dsl/core/src/Tidepool/Graph/Generic.hs
+++ b/haskell/dsl/core/src/Tidepool/Graph/Generic.hs
@@ -131,7 +131,7 @@ import Tidepool.Graph.Errors
 import Tidepool.Graph.Validate (FormatSymbolList)
 import Control.Monad.Freer (Eff, Member)
 
-import Tidepool.Graph.Types (type (:@), Input, Schema, Template, Vision, Tools, Memory, System, UsesEffects, ClaudeCode, ModelChoice, Gemini, Spawn, Barrier, Awaits, HList(..), MCPExport, MCPToolDef)
+import Tidepool.Graph.Types (type (:@), Input, Schema, Template, Vision, Tools, Memory, System, UsesEffects, ClaudeCode, ModelChoice, Gemini, Spawn, Barrier, Awaits, HList(..), MCPExport, MCPToolDef, MCPRoleHint)
 import Tidepool.Effect.Gemini (GeminiOp, SingGeminiModel(..))
 import Tidepool.Graph.Template (TemplateContext)
 import Tidepool.Graph.Edges (GetUsesEffects, GetGotoTargets, GotoEffectsToTargets, GetClaudeCode, GetGeminiModel, GetSpawnTargets, GetAwaits)
@@ -494,6 +494,8 @@ type family NodeHandlerDispatch nodeDef origNode es mInput mTpl mSchema mEffs wh
   NodeHandlerDispatch (node :@ MCPExport) orig es mInput mTpl mSchema mEffs =
     NodeHandlerDispatch node orig es mInput mTpl mSchema mEffs
   NodeHandlerDispatch (node :@ MCPToolDef _) orig es mInput mTpl mSchema mEffs =
+    NodeHandlerDispatch node orig es mInput mTpl mSchema mEffs
+  NodeHandlerDispatch (node :@ MCPRoleHint _) orig es mInput mTpl mSchema mEffs =
     NodeHandlerDispatch node orig es mInput mTpl mSchema mEffs
 
   -- Skip Fork/Barrier annotations (extracted directly in terminal cases)

--- a/haskell/dsl/core/src/Tidepool/Graph/Types.hs
+++ b/haskell/dsl/core/src/Tidepool/Graph/Types.hs
@@ -79,6 +79,7 @@ module Tidepool.Graph.Types
     -- * MCP Export Annotations
   , MCPExport
   , MCPToolDef
+  , MCPRoleHint
 
     -- * Graph Entry Point Declaration (new DSL)
   , GraphEntry(..)
@@ -98,6 +99,7 @@ import Data.Kind (Type)
 import Data.Text (Text)
 import GHC.TypeLits (Symbol)
 
+import Tidepool.Role (Role(..))
 import Tidepool.Effect.Gemini (GeminiModel(..))
 
 -- | Marks an LLM node as executed via Gemini CLI subprocess.
@@ -1126,6 +1128,17 @@ data MCPExport
 type MCPToolDef :: (Symbol, Symbol) -> Type
 data MCPToolDef nameAndDesc
 
+-- | Document which role is allowed to access an MCP tool.
+--
+-- @
+-- :@ MCPRoleHint 'TL
+-- @
+--
+-- This is used for documentation and potentially compile-time verification
+-- of role-based tool availability.
+type MCPRoleHint :: Role -> Type
+data MCPRoleHint r
+
 -- ════════════════════════════════════════════════════════════════════════════
 -- GRAPH ENTRY POINT DECLARATION (Simplified DSL)
 -- ════════════════════════════════════════════════════════════════════════════
@@ -1147,8 +1160,8 @@ data MCPToolDef nameAndDesc
 -- graphs. The graph becomes just the computation nodes, and external
 -- entry points are declared separately.
 data GraphEntry
-  = Symbol :~> (Symbol, Type, Symbol)
-  -- ^ @externalName ':~>' '(nodeField, inputType, description)@
+  = Symbol :~> (Symbol, Type, Symbol, [Role])
+  -- ^ @externalName ':~>' '(nodeField, inputType, description, roles)@
 
 -- | Operator for constructing 'GraphEntry' values at the type level.
 --

--- a/haskell/dsl/core/src/Tidepool/Role.hs
+++ b/haskell/dsl/core/src/Tidepool/Role.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Tidepool.Role
+  ( Role(..)
+  ) where
+
+import Data.Aeson (ToJSON(..), FromJSON(..), Value(..), withText)
+import qualified Data.Text as T
+import GHC.Generics (Generic)
+
+-- | Agent role for access control and orchestration.
+data Role = Dev | TL | PM
+  deriving (Show, Eq, Enum, Bounded, Generic)
+
+instance ToJSON Role where
+  toJSON Dev = String "dev"
+  toJSON TL = String "tl"
+  toJSON PM = String "pm"
+
+instance FromJSON Role where
+  parseJSON = withText "Role" $ \case
+    "dev" -> pure Dev
+    "tl" -> pure TL
+    "pm" -> pure PM
+    r -> fail $ "Unknown role: " <> T.unpack r

--- a/haskell/dsl/core/tidepool-core.cabal
+++ b/haskell/dsl/core/tidepool-core.cabal
@@ -44,6 +44,7 @@ library
         Tidepool.Graph.MCPReify
         Tidepool.Graph.Export
         Tidepool.Graph.Memory
+        Tidepool.Role
         -- Types needed by WASM (no native dependencies)
         Tidepool.Anthropic.Types
         Tidepool.Tool.Wire


### PR DESCRIPTION
This PR implements a comprehensive overhaul of the role-based access control (RBAC) system for MCP tools.

### Key Changes

1. Centralized Role Definition: Moved the Role data type to tidepool-core (Tidepool.Role) to make it available across the framework.
2. DSL Enhancements:
   - Added MCPRoleHint annotation for documenting and reifying intended tool roles.
   - Updated GraphEntry 4-tuple to include roles.
   - Updated reifyMCPTools and reifyGraphEntries to extract role metadata.
3. RBAC Enforcement:
   - Updated handleMcpTool in control-server to validate the agent's role against the tool's allowed roles.
   - Unauthorized calls now return a PermissionDenied error with a list of available tools for that role.
4. Tool Mapping Fixes:
   - TL: spawn_agents, exo_status, exo_complete, messaging.
   - Dev: file_pr, LSP tools (find_callers, show_type), interactive TUI tools.
   - PM: pm_* tools, exo_status (read-only), messaging.
5. Testing:
   - Added RoleConfigSpec covering role parsing and tool access.
   - Verified all 10 tests pass.
6. Documentation:
   - Added Role-Based Access Control section to haskell/control-server/CLAUDE.md.

### Verification Results
- cabal test role-config-test: PASS (10/10)
- cabal test exo-tools-test: PASS
- cabal test tools-test: PASS