### PR TITLE
feat(observability): Implement OpenTelemetry tracing in control-server

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -79,3 +79,8 @@ package zlib
 --   upstream: https://github.com/inanna-malick/ginger @ 25af8c8
 -- - freer-simple: GHC 9.10/9.12 compatibility (PR #45, not yet merged upstream)
 --   upstream: https://github.com/georgefst/freer-simple @ e1d88c1
+
+source-repository-package
+  type: git
+  location: https://github.com/iand675/hs-opentelemetry
+  subdir: api sdk exporters/otlp

--- a/haskell/control-server/src/Tidepool/Control/Handler.hs
+++ b/haskell/control-server/src/Tidepool/Control/Handler.hs
@@ -5,6 +5,7 @@ module Tidepool.Control.Handler
 
 import qualified Data.Text as T
 
+import OpenTelemetry.Trace (Tracer)
 import Tidepool.Control.Logging (Logger, logInfo)
 import Tidepool.Control.Protocol
 import Tidepool.Control.Types (ServerConfig(..))
@@ -16,9 +17,9 @@ import Tidepool.Control.Handler.MCP (handleMcpTool)
 import Tidepool.Observability.Types (TraceContext)
 
 -- | Route a control message to the appropriate handler.
-handleMessage :: Logger -> ServerConfig -> TraceContext -> TUIState -> CircuitBreakerMap -> ControlMessage -> IO ControlResponse
-handleMessage logger config traceCtx tuiState cbMap = \case
-  HookEvent input r rl -> handleHook config input r rl cbMap
+handleMessage :: Logger -> ServerConfig -> Tracer -> TraceContext -> TUIState -> CircuitBreakerMap -> ControlMessage -> IO ControlResponse
+handleMessage logger config tracer traceCtx tuiState cbMap = \case
+  HookEvent input r rl -> handleHook tracer config input r rl cbMap
   McpToolCall reqId name args ->
     handleMcpTool logger config traceCtx tuiState reqId name args
   ToolsListRequest -> handleToolsList logger

--- a/haskell/control-server/src/Tidepool/Control/Interpreters/Traced.hs
+++ b/haskell/control-server/src/Tidepool/Control/Interpreters/Traced.hs
@@ -1,0 +1,192 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Tidepool.Control.Interpreters.Traced
+  ( traceCabal
+  , traceGit
+  , traceBD
+  , traceLSP
+  ) where
+
+import Control.Monad (when)
+import Control.Monad.Freer (Eff, Member, LastMember, interpose, send, sendM)
+import Data.Maybe (isJust, fromMaybe)
+import Data.Text (Text)
+import qualified Data.Text as T
+import OpenTelemetry.Trace
+import OpenTelemetry.Context (Context)
+import OpenTelemetry.Context.ThreadLocal (getContext)
+
+import Tidepool.Effects.Cabal (Cabal(..), CabalResult(..))
+import Tidepool.Effects.Git (Git(..), WorktreeInfo(..))
+import Tidepool.Effects.BD (BD(..), ListBeadsInput(..), CreateBeadInput(..))
+import Tidepool.Effect.LSP (LSP(..), Position(..), TextDocumentIdentifier(..))
+
+-- | Helper to wrap an action in a span.
+-- Note: We don't propagate context thread-locally here because 'interpose' 
+-- runs the action via 'send' which might switch threads in the interpreter.
+-- This is sufficient for measuring the latency of the effect itself.
+withSpan 
+  :: (LastMember IO effs) 
+  => Tracer 
+  -> Text 
+  -> (Span -> Eff effs a) 
+  -> Eff effs a
+withSpan tracer name action = do
+  -- Get current context (from thread local) to link as parent
+  ctx <- sendM getContext
+  span <- sendM $ createSpan tracer ctx name defaultSpanArguments
+  result <- action span
+  sendM $ endSpan span Nothing
+  pure result
+
+-- | Trace Cabal effects
+traceCabal 
+  :: (Member Cabal effs, LastMember IO effs) 
+  => Tracer 
+  -> Eff effs a 
+  -> Eff effs a
+traceCabal tracer = interpose $ \case
+  CabalBuild path -> withSpan tracer "cabal.build" $ \span -> do
+    sendM $ addAttribute span "cabal.path" (T.pack path)
+    res <- send (CabalBuild path)
+    case res of
+      CabalSuccess -> 
+        sendM $ addAttribute span "cabal.status" ("success" :: Text)
+      CabalBuildFailure code stderr _ _ -> do
+        sendM $ addAttribute span "cabal.status" ("build_failure" :: Text)
+        sendM $ addAttribute span "cabal.exit_code" (fromIntegral code :: Int)
+        sendM $ addAttribute span "error.message" (T.take 1000 stderr)
+      CabalTestFailure _ raw -> do
+        sendM $ addAttribute span "cabal.status" ("test_failure" :: Text)
+        sendM $ addAttribute span "error.message" (T.take 1000 raw)
+      CabalTestSuccess _ -> 
+        sendM $ addAttribute span "cabal.status" ("success" :: Text)
+    pure res
+
+  CabalTest path -> withSpan tracer "cabal.test" $ \span -> do
+    sendM $ addAttribute span "cabal.path" (T.pack path)
+    res <- send (CabalTest path)
+    case res of
+      CabalSuccess -> 
+        sendM $ addAttribute span "cabal.status" ("success" :: Text)
+      CabalTestSuccess _ -> 
+        sendM $ addAttribute span "cabal.status" ("success" :: Text)
+      CabalBuildFailure code stderr _ _ -> do
+        sendM $ addAttribute span "cabal.status" ("build_failure" :: Text)
+        sendM $ addAttribute span "cabal.exit_code" (fromIntegral code :: Int)
+        sendM $ addAttribute span "error.message" (T.take 1000 stderr)
+      CabalTestFailure _ raw -> do
+        sendM $ addAttribute span "cabal.status" ("test_failure" :: Text)
+        sendM $ addAttribute span "error.message" (T.take 1000 raw)
+    pure res
+
+  CabalClean path -> withSpan tracer "cabal.clean" $ \span -> do
+    sendM $ addAttribute span "cabal.path" (T.pack path)
+    res <- send (CabalClean path)
+    pure res
+
+-- | Trace Git effects
+traceGit 
+  :: (Member Git effs, LastMember IO effs) 
+  => Tracer 
+  -> Eff effs a 
+  -> Eff effs a
+traceGit tracer = interpose $ \case
+  GetWorktreeInfo -> withSpan tracer "git.worktree_info" $ \span -> do
+    res <- send GetWorktreeInfo
+    sendM $ addAttribute span "git.found" (isJust res)
+    case res of
+      Just info -> do
+        sendM $ addAttribute span "git.branch" info.wiBranch
+        sendM $ addAttribute span "git.is_worktree" info.wiIsWorktree
+      Nothing -> pure ()
+    pure res
+
+  GetDirtyFiles -> withSpan tracer "git.dirty_files" $ \span -> do
+    res <- send GetDirtyFiles
+    sendM $ addAttribute span "git.dirty_count" (length res)
+    pure res
+
+  GetRecentCommits n -> withSpan tracer "git.recent_commits" $ \span -> do
+    sendM $ addAttribute span "git.limit" (fromIntegral n :: Int)
+    res <- send (GetRecentCommits n)
+    sendM $ addAttribute span "git.count" (length res)
+    pure res
+
+  GetCurrentBranch -> withSpan tracer "git.current_branch" $ \span -> do
+    res <- send GetCurrentBranch
+    sendM $ addAttribute span "git.branch" res
+    pure res
+
+  GetCommitsAhead ref -> withSpan tracer "git.commits_ahead" $ \span -> do
+    sendM $ addAttribute span "git.ref" ref
+    res <- send (GetCommitsAhead ref)
+    sendM $ addAttribute span "git.ahead_count" (fromIntegral res :: Int)
+    pure res
+
+-- | Trace BD effects
+traceBD 
+  :: (Member BD effs, LastMember IO effs) 
+  => Tracer 
+  -> Eff effs a 
+  -> Eff effs a
+traceBD tracer = interpose $ \case
+  GetBead id' -> withSpan tracer "bd.get_bead" $ \span -> do
+    sendM $ addAttribute span "bead.id" id'
+    res <- send (GetBead id')
+    sendM $ addAttribute span "bead.found" (isJust res)
+    pure res
+
+  ListBeads input -> withSpan tracer "bd.list_beads" $ \span -> do
+    case input.lbiStatus of
+      Just s -> sendM $ addAttribute span "bd.status" (T.pack $ show s)
+      Nothing -> pure ()
+    res <- send (ListBeads input)
+    sendM $ addAttribute span "bd.count" (length res)
+    pure res
+
+  -- Pass through others with generic span or explicit handling
+  CreateBead input -> withSpan tracer "bd.create_bead" $ \span -> do
+    sendM $ addAttribute span "bead.title" input.cbiTitle
+    res <- send (CreateBead input)
+    sendM $ addAttribute span "bead.id" res
+    pure res
+  
+  -- Fallback for other constructors to just wrap in a span
+  op -> do
+    -- We can't easily get the constructor name without Show, but we can group them
+    withSpan tracer "bd.op" $ \_ -> send op
+
+-- | Trace LSP effects
+traceLSP 
+  :: (Member LSP effs, LastMember IO effs) 
+  => Tracer 
+  -> Eff effs a 
+  -> Eff effs a
+traceLSP tracer = interpose $ \case
+  Hover doc pos -> withSpan tracer "lsp.hover" $ \span -> do
+    sendM $ addAttribute span "lsp.file" doc.tdiUri
+    sendM $ addAttribute span "lsp.line" (fromIntegral $ pos.posLine :: Int)
+    res <- send (Hover doc pos)
+    sendM $ addAttribute span "lsp.found" (isJust res)
+    pure res
+
+  References doc pos -> withSpan tracer "lsp.references" $ \span -> do
+    sendM $ addAttribute span "lsp.file" doc.tdiUri
+    res <- send (References doc pos)
+    sendM $ addAttribute span "lsp.count" (length res)
+    pure res
+
+  Diagnostics doc -> withSpan tracer "lsp.diagnostics" $ \span -> do
+    sendM $ addAttribute span "lsp.file" doc.tdiUri
+    res <- send (Diagnostics doc)
+    sendM $ addAttribute span "lsp.count" (length res)
+    pure res
+
+  -- Fallback
+  op -> withSpan tracer "lsp.op" $ \_ -> send op

--- a/haskell/control-server/src/Tidepool/Control/Observability.hs
+++ b/haskell/control-server/src/Tidepool/Control/Observability.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE DataKinds #-}
+module Tidepool.Control.Observability
+  ( withTracerProvider
+  , getTracer
+  , TracingConfig(..)
+  ) where
+
+import OpenTelemetry.Trace hiding (inSpan, getTracer)
+import qualified OpenTelemetry.Trace as Trace
+import OpenTelemetry.Exporter.OTLP
+import OpenTelemetry.Resource
+import OpenTelemetry.Processor.Batch (batchProcessor, batchTimeoutConfig)
+import OpenTelemetry.Attributes (emptyAttributes)
+import Data.ByteString.Base64 (encode)
+import qualified Data.Text.Encoding as TE
+import Data.Text (Text)
+import qualified Data.Text as T
+import Data.ByteString (ByteString)
+import qualified Data.ByteString.Char8 as BS8
+import System.Environment (setEnv)
+
+data TracingConfig = TracingConfig
+  { tcEndpoint :: String        -- "localhost:5081" or "openobserve:5081"
+  , tcAuthEmail :: Text
+  , tcAuthPassword :: Text
+  , tcServiceName :: Text       -- "tidepool-control-server"
+  }
+
+-- | Initialize tracing with OTLP export to OpenObserve
+withTracerProvider :: TracingConfig -> (TracerProvider -> IO a) -> IO a
+withTracerProvider cfg action = do
+  let authHeader = makeAuthHeader cfg.tcAuthEmail cfg.tcAuthPassword
+  
+  -- Set environment variables for OTLP exporter
+  setEnv "OTEL_EXPORTER_OTLP_ENDPOINT" ("http://" <> cfg.tcEndpoint)
+  setEnv "OTEL_EXPORTER_OTLP_HEADERS" (BS8.unpack authHeader)
+  setEnv "OTEL_EXPORTER_OTLP_INSECURE" "true"
+  setEnv "OTEL_SERVICE_NAME" (T.unpack cfg.tcServiceName)
+  
+  exporterConfig <- loadExporterEnvironmentVariables
+  exporter <- otlpExporter exporterConfig
+
+  processor <- batchProcessor batchTimeoutConfig exporter
+  
+  let res :: Resource 'Nothing
+      res = mkResource [ "service.name" .= cfg.tcServiceName ]
+      materializedRes = materializeResources res
+
+  provider <- createTracerProvider [processor] $
+    emptyTracerProviderOptions
+      { tracerProviderOptionsResources = materializedRes
+      }
+
+  result <- action provider
+  shutdownTracerProvider provider
+  pure result
+
+makeAuthHeader :: Text -> Text -> ByteString
+makeAuthHeader email password =
+  "Basic " <> encode (TE.encodeUtf8 $ email <> ":" <> password)
+
+getTracer :: TracerProvider -> Text -> Tracer
+getTracer provider name = makeTracer provider lib tracerOptions
+  where
+    lib = InstrumentationLibrary name "" "" emptyAttributes

--- a/haskell/control-server/tidepool-control-server.cabal
+++ b/haskell/control-server/tidepool-control-server.cabal
@@ -38,6 +38,8 @@ library
         Tidepool.Control.Hook.CircuitBreaker
         Tidepool.Control.Handler.Hook
         Tidepool.Control.Handler.MCP
+        Tidepool.Control.Observability
+        Tidepool.Control.Interpreters.Traced
         -- Hook implementations
         Tidepool.Control.Hook.SessionStart
         Tidepool.Control.Hook.SessionStart.Context
@@ -95,6 +97,7 @@ library
         text >= 2.0 && < 3,
         aeson >= 2.1 && < 3,
         bytestring >= 0.11 && < 1,
+        base64-bytestring >= 1.2,
         async,
         directory,
         filepath,
@@ -135,6 +138,10 @@ library
         vector,
         -- Code sampling
         random,
+        -- OpenTelemetry
+        hs-opentelemetry-api >= 0.1,
+        hs-opentelemetry-sdk >= 0.1,
+        hs-opentelemetry-exporter-otlp >= 0.1,
         -- Template rendering (for Graph/Templates.hs)
         mtl,
         ginger,


### PR DESCRIPTION
Implements OpenTelemetry tracing for the Tidepool control server using `hs-opentelemetry`.

Key changes:
- Adds `hs-opentelemetry` dependencies.
- Introduces `Tidepool.Control.Observability` to manage TracerProvider and OTLP export (using `batchProcessor`).
- Adds `Tidepool.Control.Interpreters.Traced` to wrap effects (Cabal, Git, BD, LSP) with spans.
- Integrates tracing into `Main`, `Server`, `Handler`, and `Hook`.
- Injects session context (`session.id`, `jsonl.file`) into hook spans.

This enables full observability of control server operations and sub-agent activities in OpenObserve.