### PR TITLE
feat(effector): create effector scaffold binary

### DIFF
--- a/docker/claude-agent/Dockerfile
+++ b/docker/claude-agent/Dockerfile
@@ -17,8 +17,9 @@ COPY rust/ ./rust/
 # Use cache mounts for cargo to speed up rebuilds
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/build/rust/target \
-    cd rust && cargo build --release -p mantle-agent && \
-    cp target/release/mantle-agent /mantle-agent
+    cd rust && cargo build --release -p mantle-agent -p effector && \
+    cp target/release/mantle-agent /mantle-agent && \
+    cp target/release/effector /effector
 
 # Stage 2: Main Agent Image
 FROM --platform=linux/amd64 ubuntu:22.04
@@ -96,9 +97,10 @@ ENV PATH="/home/agent/.local/bin:/home/agent/.ghcup/bin:/home/agent/.cargo/bin:$
 # Back to root to copy mantle-agent
 USER root
 
-# Copy pre-built mantle-agent binary from Rust builder stage
+# Copy pre-built binaries from Rust builder stage
 COPY --from=rust-builder /mantle-agent /usr/local/bin/mantle-agent
-RUN chmod +x /usr/local/bin/mantle-agent
+COPY --from=rust-builder /effector /usr/local/bin/effector
+RUN chmod +x /usr/local/bin/mantle-agent /usr/local/bin/effector
 
 # Set up entrypoint script
 COPY docker/claude-agent/entrypoint.sh /usr/local/bin/entrypoint.sh

--- a/justfile
+++ b/justfile
@@ -41,6 +41,14 @@ pre-commit:
     cabal test all
     cd rust && cargo test
 
+# Build effector binary
+build-effector:
+    cd rust && cargo build -p effector
+
+# Test effector binary
+test-effector:
+    cd rust && cargo test -p effector
+
 # ─────────────────────────────────────────────────────────────
 # WASM Roundtrip Testing
 # ─────────────────────────────────────────────────────────────
@@ -99,8 +107,8 @@ rebuild-runtime:
     cabal build tidepool-control-server
 
     echo ""
-    echo "── Building Rust (mantle-agent, tui-sidebar, tui-popup, ssh-proxy) ──"
-    cd "$REPO_ROOT/rust" && cargo build --release -p mantle-agent -p tui-sidebar -p tui-popup -p ssh-proxy
+    echo "── Building Rust (mantle-agent, tui-sidebar, tui-popup, ssh-proxy, effector) ──"
+    cd "$REPO_ROOT/rust" && cargo build --release -p mantle-agent -p tui-sidebar -p tui-popup -p ssh-proxy -p effector
 
     echo ""
     echo "── Installing to $RUNTIME_BIN ──"
@@ -110,6 +118,7 @@ rebuild-runtime:
     cp "$REPO_ROOT/rust/target/release/tui-sidebar" "$RUNTIME_BIN/"
     cp "$REPO_ROOT/rust/target/release/tui-popup" "$RUNTIME_BIN/"
     cp "$REPO_ROOT/rust/target/release/ssh-proxy" "$RUNTIME_BIN/"
+    cp "$REPO_ROOT/rust/target/release/effector" "$RUNTIME_BIN/"
 
     echo ""
     echo "── Code signing binaries (macOS) ──"
@@ -118,6 +127,7 @@ rebuild-runtime:
     codesign -s - --force "$RUNTIME_BIN/tui-sidebar" 2>/dev/null || true
     codesign -s - --force "$RUNTIME_BIN/tui-popup" 2>/dev/null || true
     codesign -s - --force "$RUNTIME_BIN/ssh-proxy" 2>/dev/null || true
+    codesign -s - --force "$RUNTIME_BIN/effector" 2>/dev/null || true
 
     echo ""
     echo "✓ Runtime binaries rebuilt from current repo:"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1098,6 +1098,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "effector"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "serde",
+ "serde_json",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,4 +7,5 @@ members = ["hangar-config",
     "tui-sidebar",
     "tui-popup",
     "ssh-proxy",
+    "effector",
 ]

--- a/rust/effector/CLAUDE.md
+++ b/rust/effector/CLAUDE.md
@@ -1,0 +1,29 @@
+# Effector: Stateless IO Executor
+
+Stateless IO executor that runs in agent containers and returns structured JSON. This is the foundation for the Stop Hook workflow engine.
+
+## Design Principles
+
+1. **Structured JSON output, always** - No plain text, always parseable.
+2. **Exit code 0 = effector ran successfully** - Even if build failed (failure is data).
+3. **Exit code non-zero = effector itself broke** - Couldn't find cabal, parse error, etc.
+4. **Stateless** - No state between invocations.
+5. **Env vars for config** - CWD override, GitHub token, etc.
+
+## Commands
+
+### Cabal
+- `effector cabal build [--cwd <path>]`: Run cabal build and return JSON.
+- `effector cabal test [--cwd <path>] [--package <name>]`: Run cabal test and return JSON.
+
+### Git
+- `effector git status [--cwd <path>]`: Get git status as JSON.
+- `effector git diff [--cwd <path>] [--staged]`: Get git diff as JSON.
+
+### GitHub (gh)
+- `effector gh pr-status [--branch <name>]`: Get PR status as JSON.
+- `effector gh pr-create --title <title> --body <body> [--base <branch>]`: Create PR and return JSON.
+
+## Integration
+
+Used by the Haskell control-server via SSH or HTTP effects to execute commands in isolated agent environments.

--- a/rust/effector/Cargo.toml
+++ b/rust/effector/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "effector"
+version = "0.1.0"
+edition = "2021"
+description = "Stateless IO executor for Tidepool agents"
+
+[dependencies]
+clap = { version = "4", features = ["derive", "env"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+anyhow = "1"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[[bin]]
+name = "effector"
+path = "src/main.rs"

--- a/rust/effector/src/cabal.rs
+++ b/rust/effector/src/cabal.rs
@@ -1,0 +1,22 @@
+use anyhow::Result;
+use crate::types::{CabalBuildResult, CabalTestResult};
+
+pub fn build(_cwd: &str) -> Result<()> {
+    let result = CabalBuildResult {
+        success: true,
+        errors: vec![],
+        warnings: vec![],
+    };
+    println!("{}", serde_json::to_string(&result)?);
+    Ok(())
+}
+
+pub fn test(_cwd: &str, _package: Option<String>) -> Result<()> {
+    let result = CabalTestResult {
+        passed: 0,
+        failed: 0,
+        failures: vec![],
+    };
+    println!("{}", serde_json::to_string(&result)?);
+    Ok(())
+}

--- a/rust/effector/src/gh.rs
+++ b/rust/effector/src/gh.rs
@@ -1,0 +1,24 @@
+use anyhow::Result;
+use crate::types::{GhPrStatusResult, GhPrCreateResult};
+
+pub fn pr_status(_branch: Option<String>) -> Result<()> {
+    let result = GhPrStatusResult {
+        exists: false,
+        url: None,
+        number: None,
+        state: None,
+        review_status: None,
+        comments: vec![],
+    };
+    println!("{}", serde_json::to_string(&result)?);
+    Ok(())
+}
+
+pub fn pr_create(_title: String, _body: String, _base: Option<String>) -> Result<()> {
+    let result = GhPrCreateResult {
+        url: "https://github.com/example/repo/pull/1".to_string(),
+        number: 1,
+    };
+    println!("{}", serde_json::to_string(&result)?);
+    Ok(())
+}

--- a/rust/effector/src/git.rs
+++ b/rust/effector/src/git.rs
@@ -1,0 +1,24 @@
+use anyhow::Result;
+use crate::types::{GitStatusResult, GitDiffResult};
+
+pub fn status(_cwd: &str) -> Result<()> {
+    let result = GitStatusResult {
+        branch: "main".to_string(),
+        dirty: vec![],
+        staged: vec![],
+        ahead: 0,
+        behind: 0,
+    };
+    println!("{}", serde_json::to_string(&result)?);
+    Ok(())
+}
+
+pub fn diff(_cwd: &str, _staged: bool) -> Result<()> {
+    let result = GitDiffResult {
+        files: vec![],
+        additions: 0,
+        deletions: 0,
+    };
+    println!("{}", serde_json::to_string(&result)?);
+    Ok(())
+}

--- a/rust/effector/src/main.rs
+++ b/rust/effector/src/main.rs
@@ -1,0 +1,94 @@
+use clap::{Parser, Subcommand};
+use anyhow::Result;
+
+mod types;
+mod cabal;
+mod git;
+mod gh;
+
+#[derive(Parser)]
+#[command(name = "effector")]
+#[command(about = "Stateless IO executor for Tidepool agents")]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    Cabal {
+        #[command(subcommand)]
+        action: CabalAction,
+    },
+    Git {
+        #[command(subcommand)]
+        action: GitAction,
+    },
+    Gh {
+        #[command(subcommand)]
+        action: GhAction,
+    },
+}
+
+#[derive(Subcommand)]
+enum CabalAction {
+    Build {
+        #[arg(long, default_value = ".")]
+        cwd: String,
+    },
+    Test {
+        #[arg(long, default_value = ".")]
+        cwd: String,
+        #[arg(long)]
+        package: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
+enum GitAction {
+    Status {
+        #[arg(long, default_value = ".")]
+        cwd: String,
+    },
+    Diff {
+        #[arg(long, default_value = ".")]
+        cwd: String,
+        #[arg(long)]
+        staged: bool,
+    },
+}
+
+#[derive(Subcommand)]
+enum GhAction {
+    PrStatus {
+        #[arg(long)]
+        branch: Option<String>,
+    },
+    PrCreate {
+        #[arg(long)]
+        title: String,
+        #[arg(long)]
+        body: String,
+        #[arg(long)]
+        base: Option<String>,
+    },
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    match cli.command {
+        Commands::Cabal { action } => match action {
+            CabalAction::Build { cwd } => cabal::build(&cwd),
+            CabalAction::Test { cwd, package } => cabal::test(&cwd, package),
+        },
+        Commands::Git { action } => match action {
+            GitAction::Status { cwd } => git::status(&cwd),
+            GitAction::Diff { cwd, staged } => git::diff(&cwd, staged),
+        },
+        Commands::Gh { action } => match action {
+            GhAction::PrStatus { branch } => gh::pr_status(branch),
+            GhAction::PrCreate { title, body, base } => gh::pr_create(title, body, base),
+        },
+    }
+}

--- a/rust/effector/src/types.rs
+++ b/rust/effector/src/types.rs
@@ -1,0 +1,87 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct CabalBuildResult {
+    pub success: bool,
+    pub errors: Vec<BuildError>,
+    pub warnings: Vec<BuildWarning>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct BuildError {
+    pub file: String,
+    pub line: u32,
+    pub column: u32,
+    pub message: String,
+    pub error_type: String,  // "type-error", "parse-error", "scope-error", etc.
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct BuildWarning {
+    pub file: String,
+    pub line: u32,
+    pub message: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct CabalTestResult {
+    pub passed: u32,
+    pub failed: u32,
+    pub failures: Vec<TestFailure>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct TestFailure {
+    pub suite: String,
+    pub test_name: String,
+    pub message: String,
+    pub location: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct GitStatusResult {
+    pub branch: String,
+    pub dirty: Vec<String>,       // modified/untracked files
+    pub staged: Vec<String>,      // staged files
+    pub ahead: u32,
+    pub behind: u32,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct GitDiffResult {
+    pub files: Vec<DiffFile>,
+    pub additions: u32,
+    pub deletions: u32,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct DiffFile {
+    pub path: String,
+    pub status: String,  // "added", "modified", "deleted"
+    pub additions: u32,
+    pub deletions: u32,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct GhPrStatusResult {
+    pub exists: bool,
+    pub url: Option<String>,
+    pub number: Option<u32>,
+    pub state: Option<String>,      // "open", "closed", "merged"
+    pub review_status: Option<String>, // "pending", "approved", "changes_requested"
+    pub comments: Vec<PrComment>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct PrComment {
+    pub author: String,
+    pub body: String,
+    pub path: Option<String>,       // for review comments
+    pub line: Option<u32>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct GhPrCreateResult {
+    pub url: String,
+    pub number: u32,
+}


### PR DESCRIPTION
- Created `rust/effector` crate with structured JSON output types.
- Implemented stubs for `cabal`, `git`, and `gh` subcommands.
- Added `effector` to workspace in `rust/Cargo.toml`.
- Added `just build-effector` and `test-effector` targets.
- Updated `docker/claude-agent/Dockerfile` to include `effector`.
- Verified JSON output for all subcommands.