### PR TITLE
feat(stop-hook): Add doc freshness check stage

### DIFF
--- a/haskell/control-server/src/Tidepool/Control/Effects/Effector.hs
+++ b/haskell/control-server/src/Tidepool/Control/Effects/Effector.hs
@@ -10,34 +10,106 @@ module Tidepool.Control.Effects.Effector
   , runEffectorIO
   ) where
 
-import Control.Monad.Freer (Eff, Member, LastMember, interpret, sendM)
+import Control.Monad.Freer (Eff, Member, interpret, LastMember, sendM)
+import Data.Aeson (eitherDecodeStrict)
 import Data.Text (Text)
 import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
 import System.Process (readProcessWithExitCode)
 import System.Exit (ExitCode(..))
 
 import Tidepool.Control.Effects.SshExec (SshExec, ExecRequest(..), ExecResult(..), execCommand)
-import Tidepool.Effects.Effector (Effector(..))
+import Tidepool.Effects.Effector (Effector(..), GitStatusResult, GitDiffResult)
 
--- | Interpreter: uses SshExec to run effector commands remotely
-runEffectorViaSsh :: Member SshExec effs => Text -> FilePath -> Eff (Effector ': effs) a -> Eff effs a
-runEffectorViaSsh container workingDir = interpret $ \case
+-- | Interpreter: uses SshExec to run 'effector' commands on a container
+runEffectorViaSsh :: Member SshExec effs => Text -> Eff (Effector ': effs) a -> Eff effs a
+runEffectorViaSsh container = interpret $ \case
   RunEffector cmd args -> do
     result <- execCommand $ ExecRequest
       { erContainer = container
       , erCommand = "effector"
       , erArgs = cmd : args
-      , erWorkingDir = workingDir
+      , erWorkingDir = "."
       , erEnv = []
       , erTimeout = 60
       }
     -- Return combined stdout and stderr for now, similar to how it would be used
     pure $ exStdout result <> exStderr result
 
--- | Interpreter: runs effector commands locally
-runEffectorIO :: LastMember IO effs => FilePath -> Eff (Effector ': effs) a -> Eff effs a
-runEffectorIO workingDir = interpret $ \case
+  EffectorGitStatus cwd -> do
+    result <- execCommand $ ExecRequest
+      { erContainer = container
+      , erCommand = "effector"
+      , erArgs = ["git", "status", "--cwd", T.pack cwd]
+      , erWorkingDir = "."
+      , erEnv = []
+      , erTimeout = 30
+      }
+    case eitherDecodeStrict (T.encodeUtf8 (exStdout result)) of
+      Left err -> error $ "Failed to parse effector git status JSON: " ++ err
+      Right val -> pure val
+
+  EffectorGitDiff cwd staged -> do
+    let args = if staged 
+               then ["git", "diff", "--staged", "--cwd", T.pack cwd]
+               else ["git", "diff", "--cwd", T.pack cwd]
+    result <- execCommand $ ExecRequest
+      { erContainer = container
+      , erCommand = "effector"
+      , erArgs = args
+      , erWorkingDir = "."
+      , erEnv = []
+      , erTimeout = 30
+      }
+    case eitherDecodeStrict (T.encodeUtf8 (exStdout result)) of
+      Left err -> error $ "Failed to parse effector git diff JSON: " ++ err
+      Right val -> pure val
+
+  EffectorGitLsFiles cwd args -> do
+    result <- execCommand $ ExecRequest
+      { erContainer = container
+      , erCommand = "effector"
+      , erArgs = ["git", "ls-files", "--cwd", T.pack cwd] ++ args
+      , erWorkingDir = "."
+      , erEnv = []
+      , erTimeout = 30
+      }
+    case eitherDecodeStrict (T.encodeUtf8 (exStdout result)) of
+      Left err -> error $ "Failed to parse effector git ls-files JSON: " ++ err
+      Right val -> pure val
+
+-- | Interpreter: runs 'effector' binary directly via IO
+runEffectorIO :: LastMember IO effs => Eff (Effector ': effs) a -> Eff effs a
+runEffectorIO = interpret $ \case
   RunEffector cmd args -> do
     (code, stdout, stderr) <- sendM $ readProcessWithExitCode "effector" (T.unpack cmd : map T.unpack args) ""
     -- We ignore exit code for now because Effector results are often parsed from JSON in stdout even on failure
     pure $ T.pack stdout <> T.pack stderr
+
+  EffectorGitStatus cwd -> do
+    (exitCode, stdout, stderr) <- sendM $ readProcessWithExitCode "effector" ["git", "status", "--cwd", cwd] ""
+    case exitCode of
+      ExitSuccess -> case eitherDecodeStrict (T.encodeUtf8 (T.pack stdout)) of
+        Left err -> error $ "Failed to parse effector git status JSON: " ++ err
+        Right val -> pure val
+      ExitFailure _ -> error $ "effector git status failed: " ++ stderr
+
+  EffectorGitDiff cwd staged -> do
+    let args = if staged 
+               then ["git", "diff", "--staged", "--cwd", cwd]
+               else ["git", "diff", "--cwd", cwd]
+    (exitCode, stdout, stderr) <- sendM $ readProcessWithExitCode "effector" args ""
+    case exitCode of
+      ExitSuccess -> case eitherDecodeStrict (T.encodeUtf8 (T.pack stdout)) of
+        Left err -> error $ "Failed to parse effector git diff JSON: " ++ err
+        Right val -> pure val
+      ExitFailure _ -> error $ "effector git diff failed: " ++ stderr
+
+  EffectorGitLsFiles cwd args -> do
+    let cmdArgs = ["git", "ls-files", "--cwd", cwd] ++ map T.unpack args
+    (exitCode, stdout, stderr) <- sendM $ readProcessWithExitCode "effector" cmdArgs ""
+    case exitCode of
+      ExitSuccess -> case eitherDecodeStrict (T.encodeUtf8 (T.pack stdout)) of
+        Left err -> error $ "Failed to parse effector git ls-files JSON: " ++ err
+        Right val -> pure val
+      ExitFailure _ -> error $ "effector git ls-files failed: " ++ stderr

--- a/haskell/control-server/src/Tidepool/Control/Handler/Hook.hs
+++ b/haskell/control-server/src/Tidepool/Control/Handler/Hook.hs
@@ -260,10 +260,10 @@ runStopHookLogic tracer input = do
         Just container ->
           runM
           $ runSshExec (T.pack sshProxyUrl)
-          $ runGitViaSsh (T.pack container) "."
+          $ runEffectorViaSsh (T.pack container)
           $ runCabalViaSsh (T.pack container)
-          $ runEffectorViaSsh (T.pack container) "."
           $ traceCabal tracer
+          $ runGitViaSsh (T.pack container) "."
           $ traceGit tracer
           $ runGraphMeta (GraphMetadata "stop-hook")
           $ runNodeMeta defaultNodeMeta
@@ -271,14 +271,14 @@ runStopHookLogic tracer input = do
           $ runGraph stopHookHandlers agentState
         Nothing ->
           runM
-          $ runGitIO
+          $ runState initialWorkflow
+          $ runEffectorIO
           $ runCabalIO defaultCabalConfig
-          $ runEffectorIO "."
           $ traceCabal tracer
+          $ runGitIO
           $ traceGit tracer
           $ runGraphMeta (GraphMetadata "stop-hook")
           $ runNodeMeta defaultNodeMeta
-          $ runState initialWorkflow
           $ runGraph stopHookHandlers agentState
 
   pure result

--- a/haskell/control-server/src/Tidepool/Control/StopHook/Graph.hs
+++ b/haskell/control-server/src/Tidepool/Control/StopHook/Graph.hs
@@ -76,7 +76,7 @@ data StopHookGraph mode = StopHookGraph
       :@ Input AgentState
       :@ UsesEffects '[ State WorkflowState
                       , Goto "testMaxReached" ()
-                      , Goto "checkPR" AgentState
+                      , Goto "checkDocs" AgentState
                       ]
 
   , testMaxReached :: mode :- LogicNode
@@ -88,6 +88,15 @@ data StopHookGraph mode = StopHookGraph
       :@ Input TemplateName
       :@ UsesEffects '[ State WorkflowState
                       , Goto Exit (TemplateName, StopHookContext)
+                      ]
+
+  -- Docs stage
+  , checkDocs :: mode :- LogicNode
+      :@ Input AgentState
+      :@ UsesEffects '[ Effector
+                      , State WorkflowState
+                      , Goto Exit (TemplateName, StopHookContext)
+                      , Goto "checkPR" AgentState
                       ]
 
   -- PR stage
@@ -115,11 +124,6 @@ data StopHookGraph mode = StopHookGraph
   , prMaxReached :: mode :- LogicNode
       :@ Input ()
       :@ UsesEffects '[Goto "buildContext" TemplateName]
-
-  -- Stub for next stage (kept for compatibility)
-  , stubNextStage :: mode :- LogicNode
-      :@ Input AgentState
-      :@ UsesEffects '[Goto Exit (TemplateName, StopHookContext)]
 
   , exit :: mode :- ExitNode (TemplateName, StopHookContext)
   }

--- a/haskell/control-server/src/Tidepool/Control/StopHook/Templates.hs
+++ b/haskell/control-server/src/Tidepool/Control/StopHook/Templates.hs
@@ -30,6 +30,9 @@ fixTestFailuresTpl = $(typedTemplateFile ''StopHookContext "templates/stop-hook/
 testStuckTpl :: TypedTemplate StopHookContext SourcePos
 testStuckTpl = $(typedTemplateFile ''StopHookContext "templates/stop-hook/test-stuck.jinja")
 
+updateDocsTpl :: TypedTemplate StopHookContext SourcePos
+updateDocsTpl = $(typedTemplateFile ''StopHookContext "templates/stop-hook/update-docs.jinja")
+
 nextStageStubTpl :: TypedTemplate StopHookContext SourcePos
 nextStageStubTpl = $(typedTemplateFile ''StopHookContext "templates/stop-hook/next-stage-stub.jinja")
 
@@ -43,5 +46,6 @@ renderStopHookTemplate name ctx = case name of
   "build-stuck" -> runTypedTemplate ctx buildStuckTpl
   "fix-test-failures" -> runTypedTemplate ctx fixTestFailuresTpl
   "test-stuck" -> runTypedTemplate ctx testStuckTpl
+  "update-docs" -> runTypedTemplate ctx updateDocsTpl
   "next-stage-stub" -> runTypedTemplate ctx nextStageStubTpl
   _ -> "Error: Unknown template '" <> name <> "'"

--- a/haskell/control-server/src/Tidepool/Control/StopHook/Types.hs
+++ b/haskell/control-server/src/Tidepool/Control/StopHook/Types.hs
@@ -165,6 +165,9 @@ data StopHookContext = StopHookContext
   , pr_number :: Maybe Int
   , pr_review_status :: Maybe Text
   , pr_comments :: [PrComment]
+  -- Doc info
+  , stale_docs :: [FilePath]
+  , git_dirty_files :: [FilePath]
   }
   deriving stock (Show, Eq, Generic)
   deriving anyclass (FromJSON, ToJSON)
@@ -193,6 +196,8 @@ instance ToGVal GingerRun StopHookContext where
     , "pr_number" ~> pr_number ctx
     , "pr_review_status" ~> pr_review_status ctx
     , "pr_comments" ~> pr_comments ctx
+    , "stale_docs" ~> stale_docs ctx
+    , "git_dirty_files" ~> git_dirty_files ctx
     ]
 
 instance ToGVal GingerRun TestFailureInfo where

--- a/haskell/control-server/templates/stop-hook/update-docs.jinja
+++ b/haskell/control-server/templates/stop-hook/update-docs.jinja
@@ -1,0 +1,13 @@
+Code has changed but documentation may be stale.
+
+## Modified Files
+{% for file in git_dirty_files %}
+- {{ file }}
+{% endfor %}
+
+## CLAUDE.md Files to Review
+{% for doc in stale_docs %}
+- {{ doc }}
+{% endfor %}
+
+Please review and update relevant CLAUDE.md files to reflect your changes.

--- a/haskell/dsl/core/src/Tidepool/Effects.hs
+++ b/haskell/dsl/core/src/Tidepool/Effects.hs
@@ -20,8 +20,8 @@ module Tidepool.Effects
     -- * Integration Effects
   , module Tidepool.Effects.BD
   , module Tidepool.Effects.Cabal
-  , module Tidepool.Effects.Env
   , module Tidepool.Effects.Effector
+  , module Tidepool.Effects.Env
   , module Tidepool.Effects.Git
   , module Tidepool.Effects.GitHub
   , module Tidepool.Effects.Habitica

--- a/haskell/dsl/core/src/Tidepool/Effects/Effector.hs
+++ b/haskell/dsl/core/src/Tidepool/Effects/Effector.hs
@@ -5,22 +5,33 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 
 module Tidepool.Effects.Effector
   ( -- * Effect
     Effector(..)
   , runEffector
+  , effectorGitStatus
+  , effectorGitDiff
+  , effectorGitLsFiles
 
     -- * Types
   , GhPrStatusResult(..)
   , GhPrCreateResult(..)
   , PrComment(..)
+  , GitStatusResult(..)
+  , GitDiffResult(..)
+  , DiffFile(..)
   ) where
 
 import Control.Monad.Freer (Eff, Member, send)
-import Data.Aeson (FromJSON, ToJSON)
+import Data.Aeson (FromJSON(..), ToJSON(..), object, withObject, (.=), (.:))
 import Data.Text (Text)
 import GHC.Generics (Generic)
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- TYPES: GitHub
+-- ════════════════════════════════════════════════════════════════════════════
 
 -- | Result of @effector gh pr-status@
 data GhPrStatusResult = GhPrStatusResult
@@ -52,13 +63,88 @@ data GhPrCreateResult = GhPrCreateResult
   deriving stock (Show, Eq, Generic)
   deriving anyclass (FromJSON, ToJSON)
 
+-- ════════════════════════════════════════════════════════════════════════════
+-- TYPES: Git
+-- ════════════════════════════════════════════════════════════════════════════
+
+data GitStatusResult = GitStatusResult
+  { gsrBranch :: Text
+  , gsrDirty :: [FilePath]
+  , gsrStaged :: [FilePath]
+  , gsrAhead :: Int
+  , gsrBehind :: Int
+  } deriving (Show, Eq, Generic)
+
+instance FromJSON GitStatusResult where
+  parseJSON = withObject "GitStatusResult" $ \v ->
+    GitStatusResult
+      <$> v .: "branch"
+      <*> v .: "dirty"
+      <*> v .: "staged"
+      <*> v .: "ahead"
+      <*> v .: "behind"
+
+instance ToJSON GitStatusResult
+
+data GitDiffResult = GitDiffResult
+  { gdrFiles :: [DiffFile]
+  , gdrAdditions :: Int
+  , gdrDeletions :: Int
+  } deriving (Show, Eq, Generic)
+
+instance FromJSON GitDiffResult where
+  parseJSON = withObject "GitDiffResult" $ \v ->
+    GitDiffResult
+      <$> v .: "files"
+      <*> v .: "additions"
+      <*> v .: "deletions"
+
+instance ToJSON GitDiffResult
+
+data DiffFile = DiffFile
+  { dfPath :: FilePath
+  , dfStatus :: Text
+  , dfAdditions :: Int
+  , dfDeletions :: Int
+  } deriving (Show, Eq, Generic)
+
+instance FromJSON DiffFile where
+  parseJSON = withObject "DiffFile" $ \v ->
+    DiffFile
+      <$> v .: "path"
+      <*> v .: "status"
+      <*> v .: "additions"
+      <*> v .: "deletions"
+
+instance ToJSON DiffFile
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- EFFECT
+-- ════════════════════════════════════════════════════════════════════════════
+
 -- | Effector effect for running the @effector@ tool.
 --
 -- This tool handles SSH transparently for subagent control.
 data Effector r where
   RunEffector :: Text -> [Text] -> Effector Text
+  EffectorGitStatus :: FilePath -> Effector GitStatusResult
+  EffectorGitDiff :: FilePath -> Bool -> Effector GitDiffResult
+  EffectorGitLsFiles :: FilePath -> [Text] -> Effector [FilePath]
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- SMART CONSTRUCTORS
+-- ════════════════════════════════════════════════════════════════════════════
 
 -- | Run the @effector@ tool with the given command and arguments.
 -- Returns the raw stdout as Text.
-runEffector :: Member Effector effs => Text -> [Text] -> Eff (effs) Text
+runEffector :: Member Effector effs => Text -> [Text] -> Eff effs Text
 runEffector cmd args = send (RunEffector cmd args)
+
+effectorGitStatus :: Member Effector effs => FilePath -> Eff effs GitStatusResult
+effectorGitStatus cwd = send (EffectorGitStatus cwd)
+
+effectorGitDiff :: Member Effector effs => FilePath -> Bool -> Eff effs GitDiffResult
+effectorGitDiff cwd staged = send (EffectorGitDiff cwd staged)
+
+effectorGitLsFiles :: Member Effector effs => FilePath -> [Text] -> Eff effs [FilePath]
+effectorGitLsFiles cwd args = send (EffectorGitLsFiles cwd args)

--- a/rust/effector/src/git.rs
+++ b/rust/effector/src/git.rs
@@ -1,24 +1,153 @@
-use anyhow::Result;
-use crate::types::{GitStatusResult, GitDiffResult};
+use anyhow::{Result, anyhow};
+use crate::types::{GitStatusResult, GitDiffResult, DiffFile};
+use std::process::Command;
+use std::collections::HashMap;
 
-pub fn status(_cwd: &str) -> Result<()> {
+fn run_git(cwd: &str, args: &[&str]) -> Result<String> {
+    let output = Command::new("git")
+        .current_dir(cwd)
+        .args(args)
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(anyhow!("git command failed: {}", stderr));
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+pub fn status(cwd: &str) -> Result<()> {
+    let output_res = run_git(cwd, &["status", "--porcelain=v2", "--branch"]);
+    
+    let mut branch = "none".to_string();
+    let mut ahead = 0;
+    let mut behind = 0;
+    let mut dirty = Vec::new();
+    let mut staged = Vec::new();
+
+    if let Ok(output) = output_res {
+        for line in output.lines() {
+            if line.starts_with("# branch.head ") {
+                branch = line[14..].to_string();
+            } else if line.starts_with("# branch.ab ") {
+                let parts: Vec<&str> = line[12..].split_whitespace().collect();
+                if parts.len() >= 2 {
+                    ahead = parts[0].trim_start_matches('+').parse().unwrap_or(0);
+                    behind = parts[1].trim_start_matches('-').parse().unwrap_or(0);
+                }
+            } else if line.starts_with("1 ") || line.starts_with("2 ") {
+                // 1 <XY> ... <path>
+                // 2 <XY> ... <path> <orig_path>
+                let parts: Vec<&str> = line.split_whitespace().collect();
+                if parts.len() >= 2 {
+                    let xy = parts[1];
+                    let x = xy.chars().next().unwrap_or('.');
+                    let y = xy.chars().nth(1).unwrap_or('.');
+                    let path = parts[parts.len() - 1].to_string();
+
+                    if x != '.' {
+                        staged.push(path.clone());
+                    }
+                    if y != '.' {
+                        dirty.push(path);
+                    }
+                }
+            } else if line.starts_with("? ") {
+                let path = line[2..].to_string();
+                dirty.push(path);
+            } else if line.starts_with("u ") {
+                let parts: Vec<&str> = line.split_whitespace().collect();
+                if parts.len() >= 9 {
+                    let path = parts[8].to_string();
+                    dirty.push(path);
+                }
+            }
+        }
+    }
+
     let result = GitStatusResult {
-        branch: "main".to_string(),
-        dirty: vec![],
-        staged: vec![],
-        ahead: 0,
-        behind: 0,
+        branch,
+        dirty,
+        staged,
+        ahead,
+        behind,
     };
     println!("{}", serde_json::to_string(&result)?);
     Ok(())
 }
 
-pub fn diff(_cwd: &str, _staged: bool) -> Result<()> {
+pub fn diff(cwd: &str, staged: bool) -> Result<()> {
+    let mut args = vec!["diff", "--numstat"];
+    if staged {
+        args.push("--staged");
+    }
+    let numstat_output_res = run_git(cwd, &args);
+
+    let mut status_args = vec!["diff", "--name-status"];
+    if staged {
+        status_args.push("--staged");
+    }
+    let name_status_output_res = run_git(cwd, &status_args);
+
+    let mut files = Vec::new();
+    let mut total_additions = 0;
+    let mut total_deletions = 0;
+
+    if let (Ok(numstat_output), Ok(name_status_output)) = (numstat_output_res, name_status_output_res) {
+        let mut statuses = HashMap::new();
+        for line in name_status_output.lines() {
+            let parts: Vec<&str> = line.split_whitespace().collect();
+            if parts.len() >= 2 {
+                let status_code = parts[0].chars().next().unwrap_or('M');
+                let path = parts[parts.len() - 1];
+                let status_str = match status_code {
+                    'A' => "added",
+                    'D' => "deleted",
+                    _ => "modified",
+                };
+                statuses.insert(path.to_string(), status_str.to_string());
+            }
+        }
+
+        for line in numstat_output.lines() {
+            let parts: Vec<&str> = line.split_whitespace().collect();
+            if parts.len() >= 3 {
+                let additions: u32 = parts[0].parse().unwrap_or(0);
+                let deletions: u32 = parts[1].parse().unwrap_or(0);
+                let path = parts[2].to_string();
+                
+                let status = statuses.get(&path).cloned().unwrap_or_else(|| "modified".to_string());
+
+                total_additions += additions;
+                total_deletions += deletions;
+
+                files.push(DiffFile {
+                    path,
+                    status,
+                    additions,
+                    deletions,
+                });
+            }
+        }
+    }
+
     let result = GitDiffResult {
-        files: vec![],
-        additions: 0,
-        deletions: 0,
+        files,
+        additions: total_additions,
+        deletions: total_deletions,
     };
     println!("{}", serde_json::to_string(&result)?);
+    Ok(())
+}
+
+pub fn ls_files(cwd: &str, args: Vec<String>) -> Result<()> {
+    let mut git_args = vec!["ls-files"];
+    for arg in &args {
+        git_args.push(arg);
+    }
+    let output = run_git(cwd, &git_args)?;
+    let files: Vec<String> = output.lines().map(|s| s.to_string()).collect();
+    println!("{}", serde_json::to_string(&files)?);
     Ok(())
 }

--- a/rust/effector/src/main.rs
+++ b/rust/effector/src/main.rs
@@ -56,6 +56,12 @@ enum GitAction {
         #[arg(long)]
         staged: bool,
     },
+    LsFiles {
+        #[arg(long, default_value = ".")]
+        cwd: String,
+        #[arg(trailing_var_arg = true)]
+        args: Vec<String>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -85,6 +91,7 @@ fn main() -> Result<()> {
         Commands::Git { action } => match action {
             GitAction::Status { cwd } => git::status(&cwd),
             GitAction::Diff { cwd, staged } => git::diff(&cwd, staged),
+            GitAction::LsFiles { cwd, args } => git::ls_files(&cwd, args),
         },
         Commands::Gh { action } => match action {
             GhAction::PrStatus { branch } => gh::pr_status(branch),


### PR DESCRIPTION
Implements a documentation freshness check in the Stop Hook workflow using a new `Effector` capability.

## Changes
- **Rust**: Added `git status`, `git diff`, and `git ls-files` to `effector`.
- **Haskell DSL**: Added `Effector` effect for interacting with the `effector` binary.
- **Control Server**:
    - Implemented SSH and Native interpreters for `Effector`.
    - Added `checkDocs` stage to `StopHookGraph`.
    - Added logic to detect if code files are dirty but `CLAUDE.md` files are not.
    - Added `update-docs.jinja` template to warn the user.

## Testing
- Verified `effector` binary commands.
- Verified `stop-hook-test` passes.
- Built `tidepool-control-server` successfully with integration.