### PR TITLE
feat(stop-hook): Implement test stage with effector cabal test

### DIFF
--- a/haskell/control-server/src/Tidepool/Control/StopHook/Graph.hs
+++ b/haskell/control-server/src/Tidepool/Control/StopHook/Graph.hs
@@ -50,10 +50,36 @@ data StopHookGraph mode = StopHookGraph
       :@ Input AgentState
       :@ UsesEffects '[ State WorkflowState
                       , Goto "buildMaxReached" ()
-                      , Goto "checkPR" AgentState
+                      , Goto "checkTest" AgentState
                       ]
 
   , buildMaxReached :: mode :- LogicNode
+      :@ Input ()
+      :@ UsesEffects '[Goto "buildContext" TemplateName]
+
+  -- Test stage
+  , checkTest :: mode :- LogicNode
+      :@ Input AgentState
+      :@ UsesEffects '[ Effector
+                      , State WorkflowState
+                      , Goto "routeTest" (AgentState, TestResult)
+                      ]
+
+  , routeTest :: mode :- LogicNode
+      :@ Input (AgentState, TestResult)
+      :@ UsesEffects '[ State WorkflowState
+                      , Goto "buildContext" TemplateName
+                      , Goto "testLoopCheck" AgentState
+                      ]
+
+  , testLoopCheck :: mode :- LogicNode
+      :@ Input AgentState
+      :@ UsesEffects '[ State WorkflowState
+                      , Goto "testMaxReached" ()
+                      , Goto "checkPR" AgentState
+                      ]
+
+  , testMaxReached :: mode :- LogicNode
       :@ Input ()
       :@ UsesEffects '[Goto "buildContext" TemplateName]
 

--- a/haskell/control-server/src/Tidepool/Control/StopHook/Templates.hs
+++ b/haskell/control-server/src/Tidepool/Control/StopHook/Templates.hs
@@ -16,16 +16,22 @@ import Tidepool.Control.StopHook.Types (StopHookContext, TemplateName)
 -- This ensures that all templates are valid with respect to the context at compile time.
 
 fixBuildErrorsTpl :: TypedTemplate StopHookContext SourcePos
-fixBuildErrorsTpl = $(typedTemplateFile ''StopHookContext "templates/hook/fix-build-errors.jinja")
+fixBuildErrorsTpl = $(typedTemplateFile ''StopHookContext "templates/stop-hook/fix-build-errors.jinja")
 
 maxLoopsTpl :: TypedTemplate StopHookContext SourcePos
-maxLoopsTpl = $(typedTemplateFile ''StopHookContext "templates/hook/max-loops.jinja")
+maxLoopsTpl = $(typedTemplateFile ''StopHookContext "templates/stop-hook/max-loops.jinja")
 
 buildStuckTpl :: TypedTemplate StopHookContext SourcePos
-buildStuckTpl = $(typedTemplateFile ''StopHookContext "templates/hook/build-stuck.jinja")
+buildStuckTpl = $(typedTemplateFile ''StopHookContext "templates/stop-hook/build-stuck.jinja")
+
+fixTestFailuresTpl :: TypedTemplate StopHookContext SourcePos
+fixTestFailuresTpl = $(typedTemplateFile ''StopHookContext "templates/stop-hook/fix-test-failures.jinja")
+
+testStuckTpl :: TypedTemplate StopHookContext SourcePos
+testStuckTpl = $(typedTemplateFile ''StopHookContext "templates/stop-hook/test-stuck.jinja")
 
 nextStageStubTpl :: TypedTemplate StopHookContext SourcePos
-nextStageStubTpl = $(typedTemplateFile ''StopHookContext "templates/hook/next-stage-stub.jinja")
+nextStageStubTpl = $(typedTemplateFile ''StopHookContext "templates/stop-hook/next-stage-stub.jinja")
 
 -- | Render a template by name using the typed context.
 -- This function acts as the bridge between dynamic graph execution (TemplateName)
@@ -35,5 +41,7 @@ renderStopHookTemplate name ctx = case name of
   "fix-build-errors" -> runTypedTemplate ctx fixBuildErrorsTpl
   "max-loops" -> runTypedTemplate ctx maxLoopsTpl
   "build-stuck" -> runTypedTemplate ctx buildStuckTpl
+  "fix-test-failures" -> runTypedTemplate ctx fixTestFailuresTpl
+  "test-stuck" -> runTypedTemplate ctx testStuckTpl
   "next-stage-stub" -> runTypedTemplate ctx nextStageStubTpl
   _ -> "Error: Unknown template '" <> name <> "'"

--- a/haskell/control-server/templates/stop-hook/build-stuck.jinja
+++ b/haskell/control-server/templates/stop-hook/build-stuck.jinja
@@ -1,0 +1,12 @@
+# Build Stuck: Maximum Retries Reached
+
+The build stage has failed **5 times** in a row.
+
+## Build Summary
+- Total stage retries: {{ stage_retries }}
+- Last error count: {{ error_count }}
+
+## Suggestions
+- You seem to be having trouble fixing these specific build errors.
+- Consider asking for help or using `signal_blocker`.
+- Maybe revert some recent changes and try a simpler implementation.

--- a/haskell/control-server/templates/stop-hook/fix-build-errors.jinja
+++ b/haskell/control-server/templates/stop-hook/fix-build-errors.jinja
@@ -1,0 +1,66 @@
+# Build Errors Detected
+
+Your code has {{ error_count }} error(s) that need to be fixed.
+
+## Error Summary
+
+{% for error in errors %}
+### {{ loop.index }}. {{ error.file }}:{{ error.line }}
+
+**Type:** {{ error.error_type.tag }}
+**Message:** {{ error.message }}
+
+{% if error.error_type.tag == "TypeError" %}
+{% set info = error.error_type.contents %}
+{% if info.tag == "TypeMismatch" %}
+**Expected:** `{{ info.teExpected }}`
+**Actual:** `{{ info.teActual }}`
+
+**Suggestion:** Check that the value you're passing matches the expected type. Common causes:
+- Wrong function argument order
+- Missing type conversion
+- Incorrect record field access
+{% endif %}
+{% endif %}
+
+{% if error.error_type.tag == "ScopeError" %}
+{% set info = error.error_type.contents %}
+{% if info.tag == "VariableNotInScope" %}
+**Missing:** `{{ info.contents }}`
+
+**Suggestion:**
+- Check spelling of the variable/function name
+- Ensure it's imported (add to import list)
+- Check if it's defined in scope (let binding, where clause)
+{% endif %}
+{% endif %}
+
+{% if error.error_type.tag == "ParseError" %}
+**Suggestion:**
+- Check for missing brackets, parentheses, or commas
+- Verify indentation (Haskell is whitespace-sensitive)
+- Look for incomplete expressions
+{% endif %}
+
+{% endfor %}
+
+## Build Retry Count
+
+This is attempt **{{ stage_retries + 1 }}** of 5 for the build stage.
+
+{% if stage_retries >= 3 %}
+**Warning:** You've attempted to fix build errors {{ stage_retries }} times. Consider:
+- Taking a different approach
+- Breaking the change into smaller pieces
+- Using `signal_blocker` if you're stuck
+{% endif %}
+
+## Next Steps
+
+1. Review each error above
+2. Fix the errors in your code
+3. The stop hook will automatically re-check when you stop
+
+{% if stage_retries >= 4 %}
+**Note:** One more failed attempt will escalate to the handler.
+{% endif %}

--- a/haskell/control-server/templates/stop-hook/fix-test-failures.jinja
+++ b/haskell/control-server/templates/stop-hook/fix-test-failures.jinja
@@ -1,0 +1,13 @@
+Tests are failing. Here's the summary:
+
+{{ test_failed_count }} tests failed out of {{ test_passed_count + test_failed_count }} total.
+
+{% for failure in test_failures[:5] %}
+## {{ failure.suite }} / {{ failure.test_name }}
+{% if failure.location %}Location: {{ failure.location }}{% endif %}
+
+{{ failure.message }}
+
+{% endfor %}
+
+Please fix the failing tests and re-run.

--- a/haskell/control-server/templates/stop-hook/max-loops.jinja
+++ b/haskell/control-server/templates/stop-hook/max-loops.jinja
@@ -1,0 +1,14 @@
+# Circuit Breaker: Maximum Stops Reached
+
+The Tidepool circuit breaker has been triggered for this session.
+You have reached the global limit of **15 stops**.
+
+This usually indicates that the agent is stuck in a loop or unable to make progress.
+
+## Global Stats
+- Total Stops: {{ global_stops }}
+
+## Suggestions
+- Review your recent changes carefully.
+- Try a different approach to the problem.
+- If you believe this is an error, you can reset the circuit breaker by restarting the session.

--- a/haskell/control-server/templates/stop-hook/next-stage-stub.jinja
+++ b/haskell/control-server/templates/stop-hook/next-stage-stub.jinja
@@ -1,0 +1,11 @@
+# Build Succeeded
+
+Great job! Your code compiled successfully.
+
+The next stage in the workflow is **Tests**, which is currently under development.
+
+## Summary
+- Global stops: {{ global_stops }}
+- Stage: {{ stage }}
+
+You can continue with your task.

--- a/haskell/control-server/templates/stop-hook/pr-body.jinja
+++ b/haskell/control-server/templates/stop-hook/pr-body.jinja
@@ -1,0 +1,26 @@
+Closes {{ bead_id }}
+
+## Description
+{{ description | default("(No description)") }}
+
+## Testing
+{{ testing }}
+{% if compromises %}
+
+## Compromises
+{{ compromises }}
+{% endif %}
+{% if dependencies %}
+
+## Dependencies
+{% for dep in dependencies %}
+- {{ dep.id }}: {{ dep.title }}
+{% endfor %}
+{% endif %}
+{% if dependents %}
+
+## Dependents
+{% for dep in dependents %}
+- {{ dep.id }}: {{ dep.title }}
+{% endfor %}
+{% endif %}

--- a/haskell/control-server/templates/stop-hook/session-start-dev-no-bead.jinja
+++ b/haskell/control-server/templates/stop-hook/session-start-dev-no-bead.jinja
@@ -1,0 +1,27 @@
+# Development Session
+
+You are a **Dev agent** but no bead context was detected.
+
+This can happen if:
+- You're on main branch (not a bd-* worktree)
+- The bead ID couldn't be parsed from your branch name
+- The bead doesn't exist in the database
+
+## What to do
+
+If you were spawned by a TL to work on a task:
+1. Check your branch name: `git branch --show-current`
+2. The branch should be `bd-xxx/description`
+3. If it's not a bd-* branch, you may be in the wrong worktree
+
+If you're doing exploratory work:
+1. Proceed with your task
+2. Request a new bead from the TL if work becomes multi-session
+
+## Available Tools
+
+You have access to Dev tools:
+- `file_pr` - File pull requests
+- `find_callers`, `show_fields`, `show_constructors` - Code intelligence
+- `teach-graph` - DSL teaching
+- `confirm_action`, `select_option`, `request_guidance` - Interactive tools

--- a/haskell/control-server/templates/stop-hook/session-start-dev.jinja
+++ b/haskell/control-server/templates/stop-hook/session-start-dev.jinja
@@ -1,0 +1,51 @@
+# Task: {{ bead.title }}
+
+**ID:** {{ bead.id }}
+**Branch:** {{ branch }}
+**Status:** {{ bead.status }}
+**Priority:** P{{ bead.priority }}
+
+## Description
+
+{{ bead.description | default("No description provided.") }}
+
+{% if bead.acceptance_criteria %}
+## Acceptance Criteria
+
+{{ bead.acceptance_criteria }}
+{% endif %}
+
+{% if bead.depends_on %}
+## Dependencies
+
+{% for dep in bead.depends_on %}
+- **{{ dep.dep_id }}**: {{ dep.dep_title }} (P{{ dep.dep_priority }})
+{% endfor %}
+{% endif %}
+
+## Workflow
+
+You are a **Dev agent** executing this task. Your workflow:
+
+1. **Implement** the changes described above
+2. **Test** your changes compile: `cabal build`
+3. **Commit** with message: `[{{ bead.id }}] <description>`
+4. **Push** to remote: `git push -u origin {{ branch }}`
+5. **File PR** using the `file_pr` MCP tool (NOT gh CLI)
+
+## Important Notes
+
+- Do NOT use `bd` commands - the orchestrator manages beads
+- Do NOT spawn other agents - you are a leaf worker
+- Focus on implementation quality and test coverage
+- If blocked, use `signal_blocker` tool to escalate
+
+## Session Close
+
+Before finishing, ensure:
+```
+git status          # Check changes
+git add <files>     # Stage changes
+git commit -m "[{{ bead.id }}] ..."
+git push
+```

--- a/haskell/control-server/templates/stop-hook/session-start-tl.jinja
+++ b/haskell/control-server/templates/stop-hook/session-start-tl.jinja
@@ -1,0 +1,78 @@
+# Team Lead Session
+
+You are a **TL (Team Lead)** orchestrating development work.
+
+## Project Status
+
+### Ready to Work ({{ dashboard.ready | length }} issues)
+{% if dashboard.ready %}
+{% for bead in dashboard.ready[:10] %}
+- **{{ bead.id }}** [P{{ bead.priority }}]: {{ bead.title }}
+{% endfor %}
+{% if dashboard.ready | length > 10 %}
+... and {{ dashboard.ready | length - 10 }} more (run `bd ready` for full list)
+{% endif %}
+{% else %}
+No issues ready. Check blocked issues or create new work.
+{% endif %}
+
+### In Progress ({{ dashboard.in_progress | length }} issues)
+{% if dashboard.in_progress %}
+{% for bead in dashboard.in_progress %}
+- **{{ bead.id }}**: {{ bead.title }} (assigned: {{ bead.owner | default("unassigned") }})
+{% endfor %}
+{% else %}
+No work in progress.
+{% endif %}
+
+### Blocked ({{ dashboard.blocked | length }} issues)
+{% if dashboard.blocked %}
+{% for bead in dashboard.blocked %}
+- **{{ bead.id }}**: {{ bead.title }}
+{% endfor %}
+{% endif %}
+
+## Your Workflow
+
+As TL, you:
+1. **Triage** incoming work with `bd ready`, `bd list`
+2. **Spawn** dev agents with `spawn_agents` tool
+3. **Monitor** agent progress with `exo_status`
+4. **Intervene** when agents are stuck
+5. **Complete** work with `exo_complete` after PR merges
+
+## Available Tools
+
+- `spawn_agents` - Create worktrees and launch dev agents
+- `exo_status` - Check status of all spawned agents
+- `exo_complete` - Mark agent work as complete
+- `send_message`, `check_inbox` - Communicate with agents
+
+## Common Commands
+
+```bash
+# View work
+bd ready              # Issues ready to spawn
+bd list --status=open # All open issues
+bd show <id>          # Issue details
+
+# Manage work
+bd create --title="..." --type=task --priority=2
+bd update <id> --status=in_progress
+bd dep add <issue> <depends-on>
+
+# Sync
+bd sync               # Push changes to remote
+```
+
+## Session Close Protocol
+
+Before finishing:
+```
+git status
+git add <files>
+bd sync
+git commit -m "..."
+bd sync
+git push
+```

--- a/haskell/control-server/templates/stop-hook/session-start.jinja
+++ b/haskell/control-server/templates/stop-hook/session-start.jinja
@@ -1,0 +1,19 @@
+{% if bead is defined %}
+# {{ bead.id }}: {{ bead.title }}
+
+{{ bead.description }}
+{% if bead.depends_on %}
+
+## Dependencies
+{% for dep in bead.depends_on %}
+- {{ dep.dep_title }}
+{% endfor %}
+{% endif %}
+
+## Exit
+```
+git add <files> && git commit -m "[{{ bead.id }}] <description>" && git push
+```
+{% else %}
+Branch: {{ branch | default("(unknown)") }}
+{% endif %}

--- a/haskell/control-server/templates/stop-hook/stop.jinja
+++ b/haskell/control-server/templates/stop-hook/stop.jinja
@@ -1,0 +1,73 @@
+{# Only show uncommitted changes warning when blocking (no PR filed yet) #}
+{% if dirty_files and not pr %}
+## Uncommitted Changes
+
+The following files have uncommitted changes:
+{% for f in dirty_files %}
+- `{{ f }}`
+{% endfor %}
+
+Commit these changes before stopping. Use structured commit metadata:
+```
+git add <files>
+git commit -m "[{{ bead_id | default(branch) }}] <type>: <description>"
+git push
+```
+{% endif %}
+
+{% if commits_ahead > 0 and not pr %}
+## Ready for PR
+
+You have {{ commits_ahead }} commit(s) on `{{ branch }}` not yet in a PR.
+
+Use the `file_pr` MCP tool to create a pull request:
+- **testing** (required): How did you verify this works?
+- **compromises** (optional): Any tradeoffs or known limitations?
+
+The tool will infer bead ID and title from your branch.
+{% endif %}
+
+{# TODO: Wire pr_review_status to fetch actual pending_comments count #}
+
+{% if pr %}
+## PR Filed
+{% if dirty_files %}
+✓ PR #{{ pr.number }} filed. You have local uncommitted changes (not blocking since PR exists).
+{% else %}
+✓ PR #{{ pr.number }} is up to date.
+{% endif %}
+{% endif %}
+
+{% if clean and not bead_id %}
+✓ Clean state. Not on a bead branch.
+{% endif %}
+
+{% if clean and bead_id and pr %}
+✓ {{ bead_id }}: All changes committed, PR #{{ pr.number }} filed.
+{% endif %}
+
+{# Pre-commit check results #}
+{% if pre_commit %}
+## Pre-commit Checks
+
+{% if pre_commit.success %}
+✓ Pre-commit checks passed.
+{% else %}
+✗ Pre-commit checks failed:
+
+```
+{{ pre_commit.output }}
+```
+
+Fix the issues above before stopping.
+{% endif %}
+{% endif %}
+
+{# Bead closing status #}
+{% if bead_closed %}
+## Bead Completed
+
+✓ {{ bead_id }} has been closed automatically (PR filed, checks passed).
+{% elif bead_already_closed %}
+ℹ {{ bead_id }} was already closed.
+{% endif %}

--- a/haskell/control-server/templates/stop-hook/test-stuck.jinja
+++ b/haskell/control-server/templates/stop-hook/test-stuck.jinja
@@ -1,0 +1,1 @@
+Test stage is stuck in a loop. Breaking to avoid infinite recursion.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1103,6 +1103,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "regex",
  "serde",
  "serde_json",
  "tracing",

--- a/rust/effector/Cargo.toml
+++ b/rust/effector/Cargo.toml
@@ -11,6 +11,7 @@ serde_json = "1"
 anyhow = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+regex = "1.12.2"
 
 [[bin]]
 name = "effector"

--- a/rust/effector/src/cabal.rs
+++ b/rust/effector/src/cabal.rs
@@ -1,5 +1,8 @@
-use anyhow::Result;
-use crate::types::{CabalBuildResult, CabalTestResult};
+use anyhow::{Result, Context};
+use std::process::Command;
+use std::io::{BufReader, BufRead};
+use regex::Regex;
+use crate::types::{CabalBuildResult, CabalTestResult, TestFailure};
 
 pub fn build(_cwd: &str) -> Result<()> {
     let result = CabalBuildResult {
@@ -11,12 +14,80 @@ pub fn build(_cwd: &str) -> Result<()> {
     Ok(())
 }
 
-pub fn test(_cwd: &str, _package: Option<String>) -> Result<()> {
-    let result = CabalTestResult {
+pub fn test(cwd: &str, _package: Option<String>) -> Result<()> {
+    let mut child = Command::new("cabal")
+        .arg("test")
+        .arg("--test-show-details=streaming")
+        .arg("--color=never")
+        .current_dir(cwd)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .context("Failed to spawn cabal test")?;
+
+    let stdout = child.stdout.take().context("Failed to capture stdout")?;
+    let reader = BufReader::new(stdout);
+
+    let mut result = CabalTestResult {
         passed: 0,
         failed: 0,
         failures: vec![],
     };
+
+    // Regex for HSpec/Tasty summaries
+    let summary_re = Regex::new(r"(\d+) tests? passed, (\d+) tests? failed").unwrap();
+    // Regex for test suite result
+    let suite_result_re = Regex::new(r"Test suite (\S+): (\w+)").unwrap();
+    // Regex for failure header (HSpec)
+    let failure_header_re = Regex::new(r"^\s*\d+\)\s+(.+)").unwrap();
+
+    let mut current_suite = String::from("unknown");
+    let mut in_failure_block = false;
+    let mut current_failure: Option<TestFailure> = None;
+
+    for line in reader.lines() {
+        let line = line?;
+        
+        if let Some(caps) = suite_result_re.captures(&line) {
+            current_suite = caps[1].to_string();
+        }
+
+        if let Some(caps) = summary_re.captures(&line) {
+            result.passed += caps[1].parse::<u32>().unwrap_or(0);
+            result.failed += caps[2].parse::<u32>().unwrap_or(0);
+        }
+
+        // Simplistic failure parsing
+        if let Some(caps) = failure_header_re.captures(&line) {
+            if let Some(fail) = current_failure.take() {
+                result.failures.push(fail);
+            }
+            in_failure_block = true;
+            current_failure = Some(TestFailure {
+                suite: current_suite.clone(),
+                test_name: caps[1].trim().to_string(),
+                message: String::new(),
+                location: None,
+            });
+        } else if in_failure_block {
+            if line.trim().is_empty() {
+                // Potential end of failure block if we see multiple empty lines or a summary, 
+                // but let's keep it simple for now.
+            } else if let Some(ref mut fail) = current_failure {
+                if !fail.message.is_empty() {
+                    fail.message.push('\n');
+                }
+                fail.message.push_str(&line);
+            }
+        }
+    }
+
+    if let Some(fail) = current_failure {
+        result.failures.push(fail);
+    }
+
+    let _ = child.wait();
+
     println!("{}", serde_json::to_string(&result)?);
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Implements `effector cabal test` command with real HSpec/Tasty output parsing
- Adds test stage to StopHookGraph (checkTest → routeTest → testLoopCheck)
- Integrates test circuit breaker (3 retries before test-stuck)
- Extends StopHookContext with test failure fields and ToGVal instances

## Technical Details
- **Rust**: Real `cabal test --test-show-details=streaming` execution with regex parsing
- **Haskell**: Generic Effector design (`RunEffector :: Text -> [Text] -> Effector Value`)
- **Templates**: fix-test-failures.jinja, test-stuck.jinja, session-start variants

## Merge Order
This PR uses the same generic Effector design as #337 (pr-stage). Should be merged before #338 (docs-stage) which uses typed operations.

## Test plan
- [ ] Build passes: `cabal build tidepool-control-server`
- [ ] Rust builds: `cargo build -p effector`
- [ ] Manual test: `effector cabal test` in a Haskell project with tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)