### PR TITLE
Centralize MCP config: subagents use shared control-server via TCP

### DIFF
--- a/docker/control-server/Dockerfile
+++ b/docker/control-server/Dockerfile
@@ -18,8 +18,27 @@ COPY rust/docker-ctl ./docker-ctl
 COPY rust/mantle-shared ./mantle-shared
 COPY rust/hangar-config ./hangar-config
 
-# Create minimal workspace Cargo.toml (only crates needed for tui-spawner and docker-ctl)
-RUN echo '[workspace]\nresolver = "2"\nmembers = ["tui-spawner", "tui-sidebar", "tui-popup", "docker-ctl", "mantle-shared", "hangar-config"]' > Cargo.toml
+# Create minimal workspace Cargo.toml with required dependencies
+RUN cat > Cargo.toml <<'EOF'
+[workspace]
+resolver = "2"
+members = ["tui-spawner", "tui-sidebar", "tui-popup", "docker-ctl", "mantle-shared", "hangar-config"]
+
+[workspace.dependencies]
+anyhow = "1"
+chrono = { version = "0.4", features = ["serde"] }
+clap = { version = "4", features = ["derive", "env"] }
+nix = { version = "0.29", features = ["poll", "fs", "signal"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+strum = { version = "0.26", features = ["derive"] }
+tempfile = "3"
+thiserror = "2"
+tokio = { version = "1", features = ["full"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+uuid = { version = "1", features = ["v4"] }
+EOF
 
 # Cache bust AFTER setup, BEFORE build - invalidates only the build step
 # Usage: docker compose build --build-arg RUST_CACHEBUST=$(date +%s) control-server

--- a/docker/zellij/Dockerfile
+++ b/docker/zellij/Dockerfile
@@ -15,8 +15,27 @@ COPY rust/tui-sidebar ./tui-sidebar
 COPY rust/mantle-shared ./mantle-shared
 COPY rust/hangar-config ./hangar-config
 
-# Create minimal workspace Cargo.toml (only crates needed for tui-popup)
-RUN echo '[workspace]\nresolver = "2"\nmembers = ["tui-popup", "tui-sidebar", "mantle-shared", "hangar-config"]' > Cargo.toml
+# Create minimal workspace Cargo.toml with required dependencies
+RUN cat > Cargo.toml <<'EOF'
+[workspace]
+resolver = "2"
+members = ["tui-popup", "tui-sidebar", "mantle-shared", "hangar-config"]
+
+[workspace.dependencies]
+anyhow = "1"
+chrono = { version = "0.4", features = ["serde"] }
+clap = { version = "4", features = ["derive", "env"] }
+nix = { version = "0.29", features = ["poll", "fs", "signal"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+strum = { version = "0.26", features = ["derive"] }
+tempfile = "3"
+thiserror = "2"
+tokio = { version = "1", features = ["full"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+uuid = { version = "1", features = ["v4"] }
+EOF
 
 # Build tui-popup
 RUN cargo build --release -p tui-popup && \

--- a/haskell/control-server/src/Tidepool/Control/ExoTools/SpawnAgents.hs
+++ b/haskell/control-server/src/Tidepool/Control/ExoTools/SpawnAgents.hs
@@ -19,14 +19,11 @@ where
 
 import Control.Monad (forM)
 import Control.Monad.Freer (Eff, Member)
-import Data.Aeson (FromJSON(..), ToJSON(..), (.:), (.:?), (.=), object, withObject, encode)
-import qualified Data.Aeson as Aeson
-import qualified Data.ByteString.Lazy as BL
+import Data.Aeson (FromJSON(..), ToJSON(..), (.:), (.:?), (.=), object, withObject)
 import Data.Either (partitionEithers)
-import Data.Maybe (fromMaybe, catMaybes)
+import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as T
-import qualified Data.Text.Encoding as TE
 import GHC.Generics (Generic)
 import System.FilePath ((</>), takeDirectory)
 
@@ -36,7 +33,7 @@ import Tidepool.Effects.Env (Env, getEnv)
 import Tidepool.Effects.Git (Git, WorktreeInfo(..), getWorktreeInfo)
 import Tidepool.Effects.Worktree (Worktree, WorktreeSpec(..), WorktreePath(..), createWorktree)
 
-import Tidepool.Effects.FileSystem (FileSystem, createDirectory, writeFileText, fileExists, directoryExists, readFileText)
+import Tidepool.Effects.FileSystem (FileSystem, fileExists, directoryExists)
 import Tidepool.Effects.Zellij (Zellij, TabConfig(..), TabId(..), checkZellijEnv, newTab)
 import Tidepool.Role (Role(..))
 import Tidepool.Graph.Generic (AsHandler, type (:-))
@@ -47,8 +44,6 @@ import Tidepool.Schema (HasJSONSchema(..), objectSchema, arraySchema, emptySchem
 
 import Tidepool.Control.ExoTools.Internal (slugify)
 import Tidepool.Control.Runtime.Paths as Paths
-import Tidepool.Control.Runtime.ProcessCompose as PC
-import qualified Data.Yaml as Yaml
 
 -- | Find the hangar root by checking ENV or walking up from repo root.
 findHangarRoot
@@ -75,27 +70,6 @@ findHangarRoot = do
           in if parent == path
              then pure Nothing
              else walkUp parent
-
--- | Build minimal issue context (task description only).
-buildIssueContext :: Issue -> Text -> Text
-buildIssueContext issue branchName = T.unlines
-  [
-    "# Task: " <> issue.issueTitle
-  , ""
-  , "**Issue Number:** #" <> T.pack (show issue.issueNumber)
-  , "**Branch:** " <> branchName
-  , ""
-  , "## Description"
-  , ""
-  , issue.issueBody
-  , ""
-  , if null issue.issueLabels
-      then ""
-      else T.unlines $
-        [ "## Labels"
-        , ""
-        ] ++ map (\l -> "- " <> l) issue.issueLabels
-  ]
 
 -- | Arguments for spawn_agents tool.
 data SpawnAgentsArgs = SpawnAgentsArgs
@@ -331,396 +305,61 @@ processIssue spawnMode mHangarRoot repoRoot wtBaseDir backend shortId = do
                       case mPath of
                         Left errTuple -> pure $ Left errTuple
                         Right path -> do
-                          -- b. Bootstrap .tidepool/ directory structure
-                          mSocketsPath <- getEnv "TIDEPOOL_SOCKETS_PATH"
-                          let socketDir = case (spawnMode, mSocketsPath) of
-                                (SpawnZellij, _) -> Paths.socketDirectoryFor shortId
-                                (_, Just sp)  -> T.unpack sp </> T.unpack shortId
-                                _             -> "/sockets" </> T.unpack shortId
-                              controlSocket = Paths.controlSocketPath socketDir
-                              tuiSocket = Paths.tuiSocketPath socketDir
-
-                              backendCmd = case backend of
+                          -- b. Configure environment for TCP control-server
+                          let backendCmd = case backend of
                                     "gemini" -> "gemini --debug"
                                     "claude" -> "claude --debug --verbose"
                                     _        -> "claude --debug --verbose"
+                              -- Subagents connect to shared control-server via TCP
+                              -- No local control-server startup needed
                               envVars =
                                 [
                                   ("SUBAGENT_CMD", backendCmd)
-                                , ("HANGAR_ROOT", T.pack hr)
-                                , ("TIDEPOOL_BIN_DIR", T.pack binDir)
-                                , ("TIDEPOOL_CONTAINER", "agent-" <> shortId)
-                                , ("TIDEPOOL_SOCKET_DIR", T.pack socketDir)
-                                , ("TIDEPOOL_CONTROL_SOCKET", T.pack controlSocket)
-                                , ("TIDEPOOL_TUI_SOCKET", T.pack tuiSocket)
+                                , ("CONTROL_SERVER_URL", "http://control-server:7432")
                                 , ("TIDEPOOL_ROLE", "dev")
                                 ]
 
-                          bootstrapRes <- bootstrapTidepool mHangarRoot repoRoot path backend socketDir controlSocket
-                          case bootstrapRes of
-                            Left errMsg -> pure $ Left (shortId, "Bootstrap failed: " <> errMsg)
-                            Right () -> do
-                              -- c. Write issue context
-                              let context = buildIssueContext issue branchName
-                              contextRes <- writeBeadContext path context
-                              case contextRes of
-                                Left errMsg -> pure $ Left (shortId, "Context write failed: " <> errMsg)
-                                Right () -> do
-                                  -- d. Launch agent (Zellij or Docker)
-                                  case spawnMode of
-                                    SpawnZellij -> do
-                                      let tabConfig = TabConfig
-                                            {
-                                              tcName = shortId
-                                            , tcLayout = repoRoot </> ".zellij" </> "worktree.kdl"
-                                            , tcCwd = path
-                                            , tcEnv = envVars
-                                            , tcCommand = Nothing
-                                            }
-                                      tabRes <- newTab tabConfig
-                                      case tabRes of
-                                        Left err -> pure $ Left (shortId, "Tab launch failed: " <> T.pack (show err))
-                                        Right tabId -> pure $ Right (shortId, path, tabId)
+                          -- Skip bootstrapTidepool - subagents use shared control-server
+                          -- entrypoint.sh writes .mcp.json based on CONTROL_SERVER_URL
+                          -- Issue context comes from GitHub (no bead.md needed)
 
-                                    SpawnDocker -> do
-                                      let config = SpawnConfig
-                                            { scIssueId = shortId
-                                            , scWorktreePath = path
-                                            , scBackend = backend
-                                            , scUid = Nothing
-                                            , scGid = Nothing
-                                            , scEnv = envVars  -- Pass env vars directly to container
-                                            }
-                                      containerResult <- spawnContainer config
+                          -- c. Launch agent (Zellij or Docker)
+                          case spawnMode of
+                            SpawnZellij -> do
+                              let tabConfig = TabConfig
+                                    { tcName = shortId
+                                    , tcLayout = repoRoot </> ".zellij" </> "worktree.kdl"
+                                    , tcCwd = path
+                                    , tcEnv = envVars
+                                    , tcCommand = Nothing
+                                    }
+                              tabRes <- newTab tabConfig
+                              case tabRes of
+                                Left err -> pure $ Left (shortId, "Tab launch failed: " <> T.pack (show err))
+                                Right tabId -> pure $ Right (shortId, path, tabId)
 
-                                      case containerResult of
-                                        Left err -> pure $ Left (shortId, "Container spawn failed: " <> T.pack (show err))
-                                        Right containerId -> do
-                                          let attachCmd = "docker attach " <> containerId.unContainerId
-                                              tabConfig = TabConfig
-                                                { tcName = shortId
-                                                , tcLayout = ""
-                                                , tcCwd = path
-                                                , tcEnv = envVars
-                                                , tcCommand = Just attachCmd
-                                                }
-
-                                          tabRes <- newTab tabConfig
-                                          case tabRes of
-                                            Left err -> pure $ Left (shortId, "Container spawned (" <> containerId.unContainerId <> ") but tab launch failed: " <> T.pack (show err))
-                                            Right tabId -> pure $ Right (shortId, path, tabId)
-
-
--- | Bootstrap .tidepool/ directory structure in a worktree.
-bootstrapTidepool
-  :: (Member FileSystem es)
-  => Maybe FilePath  -- ^ Hangar root (for templates)
-  -> FilePath        -- ^ Repo root (for symlink source)
-  -> FilePath        -- ^ Worktree path
-  -> Text            -- ^ Backend ("claude" or "gemini")
-  -> FilePath        -- ^ Socket directory (e.g., /tmp/tidepool-<id>)
-  -> FilePath        -- ^ Control socket path (e.g., /tmp/tidepool-<id>/control.sock)
-  -> Eff es (Either Text ())
-bootstrapTidepool mHangarRoot repoRoot worktreePath backend socketDir controlSocket = do
-  -- Create socket directory in /tmp (avoids SUN_LEN path length limits).
-  -- Unix sockets have ~104 byte path limit on macOS; worktree paths can exceed this.
-  res0 <- createDirectory socketDir
-  case res0 of
-    Left err -> pure $ Left $ "Failed to create socket directory " <> T.pack socketDir <> ": " <> T.pack (show err)
-    Right () -> do
-      -- Create .tidepool directory structure for logs (sockets are in /tmp now).
-      let logsDir = worktreePath </> ".tidepool" </> "logs"
-
-      -- Create directories (FileSystem.createDirectory creates parents automatically)
-      res2 <- createDirectory logsDir
-      case res2 of
-        Left err -> pure $ Left $ "Failed to create .tidepool/logs: " <> T.pack (show err)
-        Right () -> do
-          -- Generate process-compose.yaml from Haskell types
-          -- This ensures type safety and removes dependency on external template files
-          let binDir = Paths.runtimeBinDir (fromMaybe repoRoot mHangarRoot)
-              binPath = Paths.controlServerBin binDir
-              tuiSocket = Paths.tuiSocketPath socketDir
-              pcConfig = PC.generateSubagentConfig binPath socketDir controlSocket tuiSocket
-              dstConfig = worktreePath </> "process-compose.yaml"
-              pcYaml = TE.decodeUtf8 $ Yaml.encode pcConfig
-          
-          writePCRes <- writeFileText dstConfig pcYaml
-          case writePCRes of
-            Left err -> pure $ Left $ "Failed to write process-compose.yaml: " <> T.pack (show err)
-            Right () -> do
-              -- Write Claude local settings with SessionStart hooks
-              -- This bypasses FSWatcher issues with project-scope settings in worktrees
-              -- Use hangar root (or repo root fallback) to build absolute binary path
-              let hr = fromMaybe repoRoot mHangarRoot
-              settingsRes <- writeClaudeLocalSettings hr worktreePath
-              case settingsRes of
-                Left err -> pure $ Left $ "Failed to write Claude settings: " <> err
-                Right () -> do
-                  -- Write .mcp.json for Claude Code
-                  mcpRes <- writeClaudeMcpConfig controlSocket worktreePath "dev"
-                  case mcpRes of
-                    Left err -> pure $ Left $ "Failed to write MCP config: " <> err
-                    Right () -> do
-                      -- Write Gemini config if backend is "gemini"
-                      geminiRes <- if backend == "gemini"
-                                     then writeGeminiConfig hr worktreePath controlSocket "dev"
-                                     else pure $ Right ()
-                      case geminiRes of
-                        Left err -> pure $ Left $ "Failed to write Gemini config: " <> err
-                        Right () -> do
-                          -- Update .gitignore for both backends
-                          gitignoreRes <- appendBackendToGitignore worktreePath
-                          case gitignoreRes of
-                            Left err -> pure $ Left $ "Failed to update .gitignore: " <> err
-                            Right () -> pure $ Right ()
-
-
--- | Write bead context to .claude/context/bead.md.
-writeBeadContext
-  :: (Member FileSystem es)
-  => FilePath  -- ^ Worktree path
-  -> Text      -- ^ Context content
-  -> Eff es (Either Text ()) 
-writeBeadContext worktreePath context = do
-  let contextDir = worktreePath </> ".claude" </> "context"
-      contextFile = contextDir </> "bead.md"
-
-  dirRes <- createDirectory contextDir
-  case dirRes of
-    Left err -> pure $ Left $ T.pack (show err)
-    Right () -> do
-      writeRes <- writeFileText contextFile context
-      case writeRes of
-        Left err -> pure $ Left $ T.pack (show err)
-        Right () -> pure $ Right ()
-
-
--- | Common helper for writing backend settings files.
--- Reduces duplication between Claude and Gemini config generation.
-writeBackendSettings
-  :: (Member FileSystem es)
-  => FilePath       -- ^ Directory to create (e.g., ".claude", ".gemini")
-  -> FilePath       -- ^ Settings file path
-  -> Aeson.Value    -- ^ JSON settings object
-  -> Text           -- ^ Directory name for error messages
-  -> Text           -- ^ File name for error messages
-  -> Eff es (Either Text ()) 
-writeBackendSettings configDir settingsFile settings dirName fileName = do
-  let content = TE.decodeUtf8 . BL.toStrict $ encode settings
-
-  dirRes <- createDirectory configDir
-  case dirRes of
-    Left err -> pure $ Left $ "Failed to create " <> dirName <> " directory: " <> T.pack (show err)
-    Right () -> do
-      writeRes <- writeFileText settingsFile content
-      case writeRes of
-        Left err -> pure $ Left $ "Failed to write " <> fileName <> ": " <> T.pack (show err)
-        Right () -> pure $ Right ()
-
-
--- | Write .claude/settings.local.json with SessionStart hooks.
--- This bypasses FSWatcher issues with project-scope settings in worktrees.
--- Uses absolute path to mantle-agent (no environment variable dependency).
-writeClaudeLocalSettings
-  :: (Member FileSystem es)
-  => FilePath  -- ^ Hangar root (for building absolute binary path)
-  -> FilePath  -- ^ Worktree path
-  -> Eff es (Either Text ()) 
-writeClaudeLocalSettings hangarRoot worktreePath = do
-  let claudeDir = worktreePath </> ".claude"
-      settingsFile = claudeDir </> "settings.local.json"
-      binDir = Paths.runtimeBinDir hangarRoot
-      mantleAgentPath = Paths.mantleAgentBin binDir
-
-      settings = object
-        [
-          "hooks" .= object
-          [
-            "SessionStart" .= 
-              [
-                object
-                  [
-                    "matcher" .= ("startup" :: Text)
-                  , "hooks" .= 
-                    [
-                      object
-                        [
-                          "type" .= ("command" :: Text)
-                        , "command" .= (T.pack mantleAgentPath <> " hook session-start --role=dev")
-                        ]
-                    ]
-                  ]
-                ,
-                object
-                  [
-                    "matcher" .= ("resume" :: Text)
-                  , "hooks" .=
-                    [
-                      object
-                        [
-                          "type" .= ("command" :: Text)
-                        , "command" .= (T.pack mantleAgentPath <> " hook session-start --role=dev")
-                        ]
-                    ]
-                  ]
-              ]
-          ]
-        ]
-
-  writeBackendSettings claudeDir settingsFile settings ".claude" "settings.local.json"
-
-
--- | Write .mcp.json for Claude Code MCP configuration.
--- Points to control-server via role-prefixed endpoint.
-writeClaudeMcpConfig
-  :: (Member FileSystem es)
-  => FilePath  -- ^ Control socket path
-  -> FilePath  -- ^ Worktree path
-  -> Text      -- ^ Role (dev, tl, pm)
-  -> Eff es (Either Text ())
-writeClaudeMcpConfig controlSocket worktreePath role = do
-  let mcpFile = worktreePath </> ".mcp.json"
-
-      -- Build the HTTP+Unix URL with role path
-      -- Format: http+unix://<socket_path>/role/<role>/mcp
-      socketUrl = "http+unix://" <> T.pack controlSocket <> "/role/" <> role <> "/mcp"
-
-      config = object
-        [ "mcpServers" .= object
-          [ "tidepool" .= object
-            [ "transport" .= ("http" :: Text)
-            , "url" .= socketUrl
-            ]
-          ]
-        ]
-
-      content = TE.decodeUtf8 . BL.toStrict $ encode config
-
-  writeRes <- writeFileText mcpFile content
-  case writeRes of
-    Left err -> pure $ Left $ "Failed to write .mcp.json: " <> T.pack (show err)
-    Right () -> pure $ Right ()
-
-
--- | Write .gemini/settings.json with hooks and MCP configuration.
--- Gemini combines hooks and MCP in a single file (unlike Claude).
--- Uses absolute paths since Gemini CLI doesn't expand env vars in settings.json.
-writeGeminiConfig
-  :: (Member FileSystem es)
-  => FilePath  -- ^ Hangar root (for absolute path to mantle-agent)
-  -> FilePath  -- ^ Worktree path
-  -> FilePath  -- ^ Control socket path (short path in /tmp to avoid SUN_LEN limits)
-  -> Text      -- ^ Role
-  -> Eff es (Either Text ()) 
-writeGeminiConfig hangarRoot worktreePath controlSocket role = do
-  let geminiDir = worktreePath </> ".gemini"
-      settingsFile = geminiDir </> "settings.json"
-      -- Gemini CLI doesn't expand $GEMINI_PROJECT_DIR, so use absolute paths
-      binDir = Paths.runtimeBinDir hangarRoot
-      mantleAgent = Paths.mantleAgentBin binDir
-      hookCmd = mantleAgent <> " hook session-start --role=" <> T.unpack role
-      -- controlSocket is passed in (short path in /tmp to avoid SUN_LEN limits)
-
-      settings = object
-        [
-          "hooksConfig" .= object
-          [
-            "enabled" .= True
-          ]
-        , "hooks" .= object
-          [
-            "SessionStart" .= 
-              [
-                object
-                  [
-                    "matcher" .= ("startup" :: Text)
-                  , "hooks" .= 
-                    [
-                      object
-                        [
-                          "name" .= ("init-agent" :: Text)
-                        , "type" .= ("command" :: Text)
-                        , "command" .= T.pack hookCmd
-                        ]
-                    ]
-                  ]
-                ,
-                object
-                  [
-                    "matcher" .= ("resume" :: Text)
-                  , "hooks" .= 
-                    [
-                      object
-                        [
-                          "name" .= ("resume-agent" :: Text)
-                        , "type" .= ("command" :: Text)
-                        , "command" .= T.pack hookCmd
-                        ]
-                    ]
-                  ]
-              ]
-          ]
-        , "mcpServers" .= object
-          [
-            "tidepool" .= object
-            [
-              "command" .= T.pack mantleAgent
-            , "args" .= (["mcp", "--role", role] :: [Text])
-            , "env" .= object
-              [
-                "TIDEPOOL_CONTROL_SOCKET" .= T.pack controlSocket
-              ]
-            ]
-          ]
-        ]
-
-  writeBackendSettings geminiDir settingsFile settings ".gemini" "settings.json"
-
--- | Append .claude/ and .gemini/ to .gitignore if not already present.
--- Ensures both backend directories are gitignored for consistency.
-appendBackendToGitignore
-  :: (Member FileSystem es)
-  => FilePath  -- ^ Worktree path
-  -> Eff es (Either Text ()) 
-appendBackendToGitignore worktreePath = do
-  let gitignorePath = worktreePath </> ".gitignore"
-
-  -- Read existing .gitignore (or handle non-existent file)
-  readRes <- readFileText gitignorePath
-  case readRes of
-    Left _ -> do
-      -- .gitignore doesn't exist, create it with all entries
-      let content = T.unlines [".claude/", ".gemini/", ".mcp.json"]
-      writeRes <- writeFileText gitignorePath content
-      case writeRes of
-        Left err -> pure $ Left $ "Failed to create .gitignore: " <> T.pack (show err)
-        Right () -> pure $ Right ()
-
-    Right existingContent -> do
-      let lines' = T.lines existingContent
-          hasClaudeEntry = any (\line -> T.strip line == ".claude/") lines'
-          hasGeminiEntry = any (\line -> T.strip line == ".gemini/") lines'
-          hasMcpEntry = any (\line -> T.strip line == ".mcp.json") lines'
-
-      -- Determine what needs to be added
-      let needsClaudeEntry = not hasClaudeEntry
-          needsGeminiEntry = not hasGeminiEntry
-          needsMcpEntry = not hasMcpEntry
-
-      if not needsClaudeEntry && not needsGeminiEntry && not needsMcpEntry
-        then pure $ Right ()  -- Already has all entries
-        else do
-          -- Build list of entries to add
-          let entriesToAdd = catMaybes
-                [
-                  if needsClaudeEntry then Just ".claude/" else Nothing
-                , if needsGeminiEntry then Just ".gemini/" else Nothing
-                , if needsMcpEntry then Just ".mcp.json" else Nothing
-                ]
-          -- Append missing entries (preserve existing content)
-          let newContent = existingContent <> "\n" <> T.unlines entriesToAdd
-          writeRes <- writeFileText gitignorePath newContent
-          case writeRes of
-            Left err -> pure $ Left $ "Failed to update .gitignore: " <> T.pack (show err)
-            Right () -> pure $ Right ()
+                            SpawnDocker -> do
+                              let config = SpawnConfig
+                                    { scIssueId = shortId
+                                    , scWorktreePath = path
+                                    , scBackend = backend
+                                    , scUid = Nothing
+                                    , scGid = Nothing
+                                    , scEnv = envVars
+                                    }
+                              containerResult <- spawnContainer config
+                              case containerResult of
+                                Left err -> pure $ Left (shortId, "Container spawn failed: " <> T.pack (show err))
+                                Right containerId -> do
+                                  let attachCmd = "docker attach " <> containerId.unContainerId
+                                      tabConfig = TabConfig
+                                        { tcName = shortId
+                                        , tcLayout = ""
+                                        , tcCwd = path
+                                        , tcEnv = envVars
+                                        , tcCommand = Just attachCmd
+                                        }
+                                  tabRes <- newTab tabConfig
+                                  case tabRes of
+                                    Left err -> pure $ Left (shortId, "Container spawned (" <> containerId.unContainerId <> ") but tab launch failed: " <> T.pack (show err))
+                                    Right tabId -> pure $ Right (shortId, path, tabId)


### PR DESCRIPTION
## Summary

- Subagents now connect to the shared control-server container via TCP instead of starting their own local control-server
- Simplifies spawn_agents by removing ~370 lines of dead code (bootstrapTidepool, writeBeadContext, etc.)
- All agents (TL, PM, subagents) connect to shared control-server on different role paths

## Changes

**SpawnAgents.hs:**
- Pass `CONTROL_SERVER_URL` + `TIDEPOOL_ROLE=dev` instead of socket paths
- Remove bootstrapTidepool call (no local control-server needed)
- Remove dead code: bootstrapTidepool, writeBeadContext, writeClaudeLocalSettings, writeClaudeMcpConfig, writeGeminiConfig, appendBackendToGitignore, buildIssueContext

**entrypoint.sh:**
- Remove "Subagent Mode" block that started local control-server
- Remove Unix socket MCP config path
- Only TCP path remains (CONTROL_SERVER_URL → .mcp.json)

**Dockerfiles:**
- Fix zellij and control-server Dockerfiles to include `[workspace.dependencies]` (required by mantle-shared's workspace = true deps)

## Result

All agents connect to shared control-server:
- TL: `/role/tl/mcp`
- PM: `/role/pm/mcp`  
- Subagents: `/role/dev/mcp`

## Test plan

- [ ] Run `./refresh-ide` and verify TL/PM start with MCP connected
- [ ] Use TL to call `spawn_agents` and verify subagent container starts
- [ ] Verify subagent can call MCP tools via shared control-server

🤖 Generated with [Claude Code](https://claude.com/claude-code)