### PR TITLE
fix(control-server): return ControlResponse from hook API endpoint

### DIFF
--- a/haskell/control-server/src/ExoMonad/Control/API.hs
+++ b/haskell/control-server/src/ExoMonad/Control/API.hs
@@ -188,7 +188,7 @@ instance ToJSON McpContentItem where
 
 type ExoMonadControlAPI =
        -- | Hook event: (Input, Runtime, Role) -> (Output, ExitCode)
-       "hook" :> ReqBody '[JSON] (HookInput, Runtime, Role) :> Post '[JSON] (HookOutput, Int)
+       "hook" :> ReqBody '[JSON] (HookInput, Runtime, Role) :> Post '[JSON] ControlResponse
        -- | MCP tool call: Request -> Response
   :<|> "mcp" :> "call" :> ReqBody '[JSON] McpToolCallRequest :> Post '[JSON] ControlResponse
        -- | MCP tool list

--- a/haskell/control-server/src/ExoMonad/Control/Server.hs
+++ b/haskell/control-server/src/ExoMonad/Control/Server.hs
@@ -182,7 +182,7 @@ server logger config tracer cbMap =
   :<|> handleRoleMcpJsonRpc
   where
     handleHook (input, runtime, agentRole) = do
-      res <- liftIO $ do
+      liftIO $ do
         logDebug logger $ "[HOOK] " <> input.hookEventName <> " runtime=" <> T.pack (show runtime) <> " role=" <> T.pack (show agentRole)
         traceCtx <- newTraceContext
         handleMessage logger config tracer traceCtx cbMap (HookEvent input runtime agentRole)
@@ -190,10 +190,6 @@ server logger config tracer cbMap =
         -- Note: We do NOT flushTraces here because we use hs-opentelemetry (via Tracer)
         -- which handles export automatically via BatchSpanProcessor.
         -- Legacy ObservabilityConfig is skipped for Hooks.
-
-      case res of
-        HookResponse out ec -> pure (out, ec)
-        _ -> throwError $ err500 { errBody = "Unexpected response from handleHook" }
 
     handleMcpCall req = liftIO $ do
       logInfo logger $ "[MCP:" <> req.mcpId <> "] tool=" <> req.toolName


### PR DESCRIPTION
## Summary
Fixes a JSON protocol mismatch between the Haskell control server and the Rust CLI client (exomonad).

## Problem
Hooks like `SessionStart` and `PreToolUse` were failing with JSON parse errors:
```
Error: JSON parse error: invalid type: map, expected variant identifier at line 1 column 1
```
This occurred because the Haskell API endpoint was defined to return `(HookOutput, Int)`, which Aeson serializes as a JSON array (e.g., `[{...}, 0]`). The Rust client, however, expects a tagged `ControlResponse` enum object (e.g., `{"type": "HookResponse", "output": {...}, "exit_code": 0}`).

## Solution
*   Updated `ExoMonad.Control.API` to return `ControlResponse` instead of the tuple.
*   Updated `ExoMonad.Control.Server` to return the `ControlResponse` directly from `handleMessage`.

## Verification
*   `cabal build exomonad-control-server` passed.
*   `cargo test -p exomonad-shared` (protocol tests) passed.
