### PR TITLE
feat: pass templated initial prompt to spawned agents

### DIFF
--- a/haskell/control-server/exomonad-control-server.cabal
+++ b/haskell/control-server/exomonad-control-server.cabal
@@ -59,6 +59,7 @@ library
         ExoMonad.Control.ExoTools.Status.Types
         ExoMonad.Control.ExoTools.SpawnAgents
         ExoMonad.Control.ExoTools.SpawnAgents.Types
+        ExoMonad.Control.ExoTools.SpawnAgents.Prompt
         ExoMonad.Control.ExoTools.SpawnCleanup
         ExoMonad.Control.ExoTools.FilePR
         ExoMonad.Control.ExoTools.FilePR.Types

--- a/haskell/control-server/src/ExoMonad/Control/Effects/DockerCtl.hs
+++ b/haskell/control-server/src/ExoMonad/Control/Effects/DockerCtl.hs
@@ -42,6 +42,7 @@ doSpawn binPath cfg = do
              ] ++ maybe [] (\u -> ["--uid", show u]) (cfg.scUid)
                ++ maybe [] (\g -> ["--gid", show g]) (cfg.scGid)
                ++ envArgs
+               ++ maybe [] (\c -> "--" : map T.unpack c) (cfg.scCmd)
 
   (code, stdout, stderr) <- readProcessWithExitCode binPath args ""
   case code of

--- a/haskell/control-server/src/ExoMonad/Control/ExoTools/SpawnAgents/Prompt.hs
+++ b/haskell/control-server/src/ExoMonad/Control/ExoTools/SpawnAgents/Prompt.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module ExoMonad.Control.ExoTools.SpawnAgents.Prompt
+  ( renderInitialPrompt
+  ) where
+
+import Data.Text (Text)
+import Text.Parsec.Pos (SourcePos)
+import ExoMonad.Graph.Template (TypedTemplate, typedTemplateFile, runTypedTemplate)
+import ExoMonad.Control.ExoTools.SpawnAgents.Types (InitialPromptContext)
+
+initialPromptTpl :: TypedTemplate InitialPromptContext SourcePos
+initialPromptTpl = $(typedTemplateFile ''InitialPromptContext "templates/spawn/initial-prompt.jinja")
+
+renderInitialPrompt :: InitialPromptContext -> Text
+renderInitialPrompt ctx = runTypedTemplate ctx initialPromptTpl

--- a/haskell/control-server/src/ExoMonad/Control/ExoTools/SpawnAgents/Types.hs
+++ b/haskell/control-server/src/ExoMonad/Control/ExoTools/SpawnAgents/Types.hs
@@ -5,18 +5,36 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module ExoMonad.Control.ExoTools.SpawnAgents.Types
   ( SpawnAgentsArgs(..)
   , SpawnAgentsResult(..)
   , CleanupAgentsArgs(..)
   , CleanupAgentsResult(..)
+  , InitialPromptContext(..)
   ) where
 
 import Data.Aeson (FromJSON(..), ToJSON(..), (.:), (.=), object, withObject)
 import Data.Text (Text)
 import GHC.Generics (Generic)
+import Text.Ginger.GVal (ToGVal(..))
 import ExoMonad.Schema (deriveMCPTypeWith, defaultMCPOptions, (??), MCPOptions(..), HasJSONSchema(..), arraySchema, emptySchema, SchemaType(..), describeField)
+
+-- | Context for rendering the initial prompt.
+data InitialPromptContext = InitialPromptContext
+  { issue_number :: Text
+  , issue_title :: Text
+  , issue_body :: Text
+  , branch_name :: Text
+  , worktree_path :: Text
+  }
+  deriving stock (Show, Eq, Generic)
+  deriving anyclass (ToJSON)
+
+instance ToGVal m InitialPromptContext
 
 -- | Arguments for spawn_agents tool.
 data SpawnAgentsArgs = SpawnAgentsArgs

--- a/haskell/control-server/templates/spawn/initial-prompt.jinja
+++ b/haskell/control-server/templates/spawn/initial-prompt.jinja
@@ -1,0 +1,17 @@
+You are a dev agent assigned to issue #{{ issue_number }}: {{ issue_title }}
+
+## Issue Description
+{{ issue_body }}
+
+## Your Environment
+- Branch: `{{ branch_name }}`
+- Worktree: `{{ worktree_path }}`
+
+## Instructions
+1. Read the issue description carefully.
+2. Explore relevant CLAUDE.md files for codebase context.
+3. Implement the fix/feature.
+4. Ensure the code compiles and tests pass.
+5. The stop hook will verify your work before completion.
+
+Begin by understanding the codebase structure. Start now.

--- a/haskell/dsl/core/src/ExoMonad/Effects/DockerSpawner.hs
+++ b/haskell/dsl/core/src/ExoMonad/Effects/DockerSpawner.hs
@@ -73,6 +73,7 @@ data SpawnConfig = SpawnConfig
   , scUid :: Maybe Int
   , scGid :: Maybe Int
   , scEnv :: [(Text, Text)]  -- Environment variables to pass to container
+  , scCmd :: Maybe [Text] -- ^ Optional command override
   } deriving stock (Show, Eq, Generic)
 
 instance ToJSON SpawnConfig where

--- a/rust/docker-ctl/src/commands/spawn.rs
+++ b/rust/docker-ctl/src/commands/spawn.rs
@@ -22,6 +22,7 @@ pub async fn run(
     gid: Option<u32>,
     expires_at: Option<String>,
     env_vars: Vec<String>,
+    cmd_override: Vec<String>,
 ) -> anyhow::Result<String> {
     let docker = Docker::connect_with_local_defaults()?;
     let container_name = format!("exomonad-agent-{}", issue_id);
@@ -93,6 +94,7 @@ pub async fn run(
         image: Some(agent_image),
         labels: Some(labels),
         working_dir: Some(working_dir),
+        cmd: if cmd_override.is_empty() { None } else { Some(cmd_override) },
         tty: Some(true),
         open_stdin: Some(true),
         attach_stdin: Some(false),

--- a/rust/docker-ctl/src/main.rs
+++ b/rust/docker-ctl/src/main.rs
@@ -70,6 +70,10 @@ enum Commands {
         /// Environment variables (KEY=VALUE)
         #[arg(short = 'e', long = "env")]
         env: Vec<String>,
+
+        /// Custom command to override image CMD
+        #[arg(last = true)]
+        cmd: Vec<String>,
     },
     
     /// Stop and remove a container
@@ -102,8 +106,8 @@ async fn main() {
         Commands::Exec { container, local, workdir, user, env, cmd } => {
             commands::exec::run(container, local, workdir, user, env, cmd).await
         }
-        Commands::Spawn { issue_id, worktree_path, backend, uid, gid, expires_at, env } => {
-            commands::spawn::run(issue_id, worktree_path, backend, uid, gid, expires_at, env).await
+        Commands::Spawn { issue_id, worktree_path, backend, uid, gid, expires_at, env, cmd } => {
+            commands::spawn::run(issue_id, worktree_path, backend, uid, gid, expires_at, env, cmd).await
         }
         Commands::Stop { container, timeout } => {
             commands::stop::run(container, timeout).await


### PR DESCRIPTION
This PR implements the functionality to pass a templated initial prompt to spawned agents, ensuring they start working on their assigned issue immediately upon launch.

### Changes
- **docker-ctl**: Added `--cmd` argument to the `spawn` command to allow overriding the container's default command.
- **exomonad-control-server**:
    - Updated `DockerSpawner` effect and `DockerCtl` interpreter to support the command override.
    - Implemented `ExoMonad.Control.ExoTools.SpawnAgents.Prompt` to render the initial prompt using a new Jinja template.
    - Modified `SpawnAgents.hs` to generate the prompt (including issue details) and pass it to `claude` via the new `docker-ctl` capability.
- **Templates**: Added `haskell/control-server/templates/spawn/initial-prompt.jinja`.

### Verification
- Verified `docker-ctl` builds and runs.
- Verified `exomonad-control-server` builds and the template compilation is type-safe.
- Confirmed `claude` CLI accepts initial prompt as a positional argument.