### PR TITLE
feat(popup): add schema rendering details and time tracking

### DIFF
--- a/haskell/control-server/src/ExoMonad/Control/TUIInterpreter.hs
+++ b/haskell/control-server/src/ExoMonad/Control/TUIInterpreter.hs
@@ -65,20 +65,20 @@ spawnPopupFifo logger definition = do
       -- tui-spawner failed
       logError logger $ "[TUI] ERROR: tui-spawner failed with code " <> T.pack (show code)
       logError logger $ "[TUI] stderr: " <> T.pack (take 1000 stderr)
-      pure $ PopupResult "error" $ object
+      pure $ PopupResult "error" (object
         [ "message" .= T.pack ("tui-spawner failed with exit code " <> show code)
         , "stderr" .= T.pack stderr
-        ]
+        ]) Nothing
     ExitSuccess -> do
       -- Parse stdout as PopupResult JSON
       case eitherDecode (LBS.fromStrict $ TE.encodeUtf8 $ T.pack stdout) of
         Left err -> do
           logError logger $ "[TUI] ERROR: Failed to parse result JSON: " <> T.pack err
           logError logger $ "[TUI] stdout was: " <> T.pack (take 500 stdout)
-          pure $ PopupResult "error" $ object
+          pure $ PopupResult "error" (object
             [ "message" .= T.pack ("Failed to parse popup result: " <> err)
             , "stdout" .= T.pack stdout
-            ]
+            ]) Nothing
         Right result -> do
           logInfo logger $ "[TUI] Success: button=" <> result.prButton
           pure result

--- a/haskell/control-server/src/ExoMonad/Control/TUITools.hs
+++ b/haskell/control-server/src/ExoMonad/Control/TUITools.hs
@@ -56,7 +56,7 @@ popupLogic args = do
   let internalDef = toPopupDefinition args
 
   -- Show UI and get result
-  TUI.PopupResult button valuesMap <- showUI internalDef
+  TUI.PopupResult button valuesMap timeSpent <- showUI internalDef
 
   -- Zip values back into element structure
   let resultElements = zipWithValues (args.elements) valuesMap
@@ -65,6 +65,7 @@ popupLogic args = do
     { status = if button == "submit" then "completed" else "cancelled"
     , button = button
     , elements = resultElements
+    , timeSpentSeconds = timeSpent
     }
 
 -- | Convert PopupArgs to internal PopupDefinition.

--- a/haskell/control-server/src/ExoMonad/Control/TUITools/Types.hs
+++ b/haskell/control-server/src/ExoMonad/Control/TUITools/Types.hs
@@ -110,13 +110,13 @@ instance FromJSON PopupElement where
 
 instance HasJSONSchema PopupElement where
   jsonSchema = oneOfSchema
-    [ describeField "Static text display" $ objectSchema
+    [ describeField "Static text display - Renders as plain text, no interaction. Use for instructions or context." $ objectSchema
       [ ("type", enumSchema ["text"])
       , ("id", describeField "Unique element identifier" (emptySchema TString))
       , ("content", describeField "Text content to display" (emptySchema TString))
       ]
       ["type", "id", "content"]
-    , describeField "Numeric slider input" $ objectSchema
+    , describeField "Numeric slider input - Renders as: [Label] <-- [value] -->. Navigate with left/right arrows." $ objectSchema
       [ ("type", enumSchema ["slider"])
       , ("id", describeField "Unique element identifier" (emptySchema TString))
       , ("label", describeField "Label shown above slider" (emptySchema TString))
@@ -125,39 +125,39 @@ instance HasJSONSchema PopupElement where
       , ("default", describeField "Default value (optional)" (emptySchema TNumber))
       ]
       ["type", "id", "label", "min", "max"]
-    , describeField "Boolean checkbox input" $ objectSchema
+    , describeField "Boolean checkbox input - Renders as: [ ] Label or [x] Label. Toggle with Space key." $ objectSchema
       [ ("type", enumSchema ["checkbox"])
       , ("id", describeField "Unique element identifier" (emptySchema TString))
       , ("label", describeField "Label shown next to checkbox" (emptySchema TString))
       , ("default", describeField "Default checked state (optional)" (emptySchema TBoolean))
       ]
       ["type", "id", "label"]
-    , describeField "Text input field" $ objectSchema
+    , describeField "Text input field - Renders as editable box with cursor. Type normally, backspace to delete." $ objectSchema
       [ ("type", enumSchema ["textbox"])
       , ("id", describeField "Unique element identifier" (emptySchema TString))
       , ("label", describeField "Label shown above textbox" (emptySchema TString))
-      , ("placeholder", describeField "Placeholder text (optional)" (emptySchema TString))
+      , ("placeholder", describeField "Placeholder text shown when empty (optional)" (emptySchema TString))
       ]
       ["type", "id", "label"]
-    , describeField "Single-select dropdown" $ objectSchema
+    , describeField "Single-select dropdown - Renders options vertically. Navigate with up/down arrows, current selection highlighted." $ objectSchema
       [ ("type", enumSchema ["choice"])
       , ("id", describeField "Unique element identifier" (emptySchema TString))
       , ("label", describeField "Label shown above dropdown" (emptySchema TString))
-      , ("options", describeField "List of option strings" (arraySchema $ emptySchema TString))
-      , ("default", describeField "Default selected index (optional)" (emptySchema TInteger))
+      , ("options", describeField "List of option strings (displayed vertically)" (arraySchema $ emptySchema TString))
+      , ("default", describeField "Default selected index, 0-based (optional)" (emptySchema TInteger))
       ]
       ["type", "id", "label", "options"]
-    , describeField "Multiple selection list" $ objectSchema
+    , describeField "Multiple selection list - Renders with checkboxes for each option. Space toggles current item, up/down navigates." $ objectSchema
       [ ("type", enumSchema ["multiselect"])
       , ("id", describeField "Unique element identifier" (emptySchema TString))
       , ("label", describeField "Label shown above list" (emptySchema TString))
-      , ("options", describeField "List of option strings" (arraySchema $ emptySchema TString))
+      , ("options", describeField "List of option strings (each with checkbox)" (arraySchema $ emptySchema TString))
       ]
       ["type", "id", "label", "options"]
-    , describeField "Section header/separator" $ objectSchema
+    , describeField "Section header/separator - Renders as bold text separator. Use to organize sections visually." $ objectSchema
       [ ("type", enumSchema ["group"])
       , ("id", describeField "Unique element identifier" (emptySchema TString))
-      , ("label", describeField "Section header text" (emptySchema TString))
+      , ("label", describeField "Section header text (rendered bold)" (emptySchema TString))
       ]
       ["type", "id", "label"]
     ]
@@ -254,6 +254,8 @@ data PopupResult = PopupResult
     -- ^ "submit" or "cancel"
   , elements :: [PopupResultElement]
     -- ^ Elements with values filled in
+  , timeSpentSeconds :: Maybe Double
+    -- ^ Time user spent interacting with popup (seconds)
   }
   deriving stock (Show, Eq, Generic)
 
@@ -261,4 +263,5 @@ $(deriveMCPTypeWith defaultMCPOptions ''PopupResult
   [ mkName "status"   ?? "Result status: 'completed' or 'cancelled'"
   , mkName "button"   ?? "Button pressed: 'submit' or 'cancel'"
   , mkName "elements" ?? "Elements with values filled in"
+  , mkName "timeSpentSeconds" ?? "Time spent interacting with popup in seconds. Indicates user engagement: <2s suggests defaults acceptable, >10s may indicate confusion or difficult decisions."
   ])

--- a/haskell/dsl/core/src/ExoMonad/Effect/TUI.hs
+++ b/haskell/dsl/core/src/ExoMonad/Effect/TUI.hs
@@ -196,6 +196,8 @@ data PopupResult = PopupResult
     -- ^ Button pressed: "submit" or "decline"
   , prValues :: Value
     -- ^ JSON object with all visible component values
+  , prTimeSpent :: Maybe Double
+    -- ^ Time spent interacting with popup in seconds
   }
   deriving (Show, Eq, Generic)
 
@@ -371,12 +373,13 @@ instance FromJSON VisibilityRule where
           _ -> fail "Invalid VisibilityRule: ambiguous or missing fields"
 
 instance ToJSON PopupResult where
-  toJSON (PopupResult button values) = object
+  toJSON (PopupResult button values timeSpent) = object $
     [ "button" .= button
     , "values" .= values
-    ]
+    ] ++ maybe [] (\t -> ["time_spent_seconds" .= t]) timeSpent
 
 instance FromJSON PopupResult where
   parseJSON = withObject "PopupResult" $ \o -> PopupResult
     <$> o .: "button"
     <*> o .: "values"
+    <*> o .:? "time_spent_seconds"

--- a/rust/tui-popup/src/protocol.rs
+++ b/rust/tui-popup/src/protocol.rs
@@ -247,6 +247,8 @@ impl PopupState {
 pub struct PopupResult {
     pub button: String, // "submit" or "decline"
     pub values: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub time_spent_seconds: Option<f64>, // Time user spent interacting with popup
 }
 
 #[cfg(test)]

--- a/rust/tui-popup/src/realm/mod.rs
+++ b/rust/tui-popup/src/realm/mod.rs
@@ -3,6 +3,7 @@ use tuirealm::props::{BorderType, Props};
 use tuirealm::ratatui::layout::{Constraint, Layout as RatatuiLayout, Rect};
 use tuirealm::ratatui::widgets::{Block, Clear};
 use tuirealm::{Frame, MockComponent, State, StateValue};
+use std::time::Instant;
 
 use crate::protocol::{
     Component, ElementValue, PopupDefinition, PopupResult, PopupState, VisibilityRule,
@@ -32,6 +33,7 @@ pub struct PopupComponent {
     props: Props,
     component_areas: Vec<Rect>, // Track render areas for mouse click detection
     visibility_rules: Vec<Option<VisibilityRule>>, // Per-component visibility rules
+    start_time: Instant, // Track when popup was created for time tracking
 }
 
 /// Wrapper for individual components with their metadata
@@ -60,6 +62,7 @@ impl PopupComponent {
             props: Props::default(),
             component_areas,
             visibility_rules,
+            start_time: Instant::now(), // Track popup creation time
         };
 
         // Set initial focus to first focusable visible component
@@ -125,6 +128,7 @@ impl PopupComponent {
                 .clone()
                 .unwrap_or_else(|| "decline".to_string()),
             values: serde_json::Value::Object(result_values),
+            time_spent_seconds: Some(self.start_time.elapsed().as_secs_f64()),
         }
     }
 


### PR DESCRIPTION
## Summary
Implements #397 improvements to popup tool UX for AI agents.

## Changes

### 1. Enhanced Schema Documentation
- Added comprehensive rendering details to all `PopupElement` types
- Each element now includes:
  - Visual rendering description (how it appears in terminal)
  - Keyboard navigation patterns
  - Usage guidance

### 2. Time Tracking
- Added `timeSpentSeconds` field to `PopupResult` (both Haskell and Rust)
- Tracks elapsed time from popup creation to submission/cancellation
- Provides engagement signal:
  - `<2s` suggests defaults were acceptable
  - `>10s` may indicate confusion or difficult decisions
- Backward compatible (optional field)

## Implementation Details

**Haskell:**
- Updated `PopupResult` in `TUITools/Types.hs` with new field
- Modified `TUI.hs` effect to include time tracking
- Updated `TUITools.hs` to extract and pass through time data
- Fixed error cases in `TUIInterpreter.hs`

**Rust:**
- Added `Instant` tracking to `PopupComponent` struct
- Calculate elapsed time in `get_filtered_result()`
- Return `time_spent_seconds` in JSON response

## Testing
- ✅ Rust build: Successfully compiled `tui-popup`
- ✅ Haskell changes: All type signatures updated
- ✅ Git rebase: Clean rebase onto `main`
- ✅ Backward compatibility: Optional field won't break existing clients

## Benefits
- AI agents can design better popups with understanding of terminal rendering
- Time tracking provides actionable engagement metrics
- Improved UX for human users through better-designed popups

Closes #397

🤖 Generated with [Claude Code](https://claude.com/claude-code)