### PR TITLE
fix: Always use remote git execution for MCP tools

### DIFF
--- a/docker/claude-agent/entrypoint.sh
+++ b/docker/claude-agent/entrypoint.sh
@@ -170,12 +170,18 @@ if [ ! -f "$GEMINI_CONFIG_DIR/settings.json" ]; then
     # Prepare MCP config fragment if URL is available
     MCP_CONFIG=""
     if [ -n "${CONTROL_SERVER_URL:-}" ]; then
-        echo "Adding Gemini MCP config for: ${CONTROL_SERVER_URL}/role/${ROLE}/mcp"
+        # Derive container name for remote git execution
+        if [ -n "${EXOMONAD_ISSUE_ID:-}" ]; then
+            GEMINI_CONTAINER_NAME="exomonad-agent-${EXOMONAD_ISSUE_ID}"
+        else
+            GEMINI_CONTAINER_NAME="${HOSTNAME:-}"
+        fi
+        echo "Adding Gemini MCP config for: ${CONTROL_SERVER_URL}/role/${ROLE}/mcp?container=${GEMINI_CONTAINER_NAME}"
         MCP_CONFIG=",
   \"mcpServers\": {
     \"exomonad\": {
       \"type\": \"http\",
-      \"url\": \"${CONTROL_SERVER_URL}/role/${ROLE}/mcp\"
+      \"url\": \"${CONTROL_SERVER_URL}/role/${ROLE}/mcp?container=${GEMINI_CONTAINER_NAME}\"
     }
   }"
     fi
@@ -251,12 +257,19 @@ write_mcp_config() {
 }
 
 if [ -n "${CONTROL_SERVER_URL:-}" ]; then
-    echo "Configuring MCP via TCP: ${CONTROL_SERVER_URL}/role/${ROLE}/mcp"
+    # Derive container name for remote git execution
+    if [ -n "${EXOMONAD_ISSUE_ID:-}" ]; then
+        CONTAINER_NAME="exomonad-agent-${EXOMONAD_ISSUE_ID}"
+    else
+        CONTAINER_NAME="${HOSTNAME:-}"  # For TL/PM, HOSTNAME is container name
+    fi
+
+    echo "Configuring MCP via TCP: ${CONTROL_SERVER_URL}/role/${ROLE}/mcp?container=${CONTAINER_NAME}"
     write_mcp_config '{
   "mcpServers": {
     "exomonad": {
       "type": "http",
-      "url": "'"${CONTROL_SERVER_URL}/role/${ROLE}/mcp"'"
+      "url": "'"${CONTROL_SERVER_URL}/role/${ROLE}/mcp?container=${CONTAINER_NAME}"'"
     }
   }
 }'

--- a/haskell/control-server/src/ExoMonad/Control/API.hs
+++ b/haskell/control-server/src/ExoMonad/Control/API.hs
@@ -212,12 +212,12 @@ type ExoMonadControlAPI =
     -- \| Health check
     :<|> "ping" :> Get '[JSON] Text
     -- \| Role-based MCP tool list (legacy REST endpoint)
-    :<|> "role" :> Capture "slug" Text :> "mcp" :> "tools" :> Header "Mcp-Session-Id" Text :> Get '[JSON] [ToolDefinition]
+    :<|> "role" :> Capture "slug" Text :> "mcp" :> "tools" :> Header "Mcp-Session-Id" Text :> QueryParam "container" Text :> Get '[JSON] [ToolDefinition]
     -- \| Role-based MCP tool call (legacy REST endpoint)
-    :<|> "role" :> Capture "slug" Text :> "mcp" :> "call" :> Header "Mcp-Session-Id" Text :> ReqBody '[JSON] McpToolCallRequest :> Post '[JSON] ControlResponse
+    :<|> "role" :> Capture "slug" Text :> "mcp" :> "call" :> Header "Mcp-Session-Id" Text :> QueryParam "container" Text :> ReqBody '[JSON] McpToolCallRequest :> Post '[JSON] ControlResponse
     -- \| Unified MCP JSON-RPC endpoint (for Claude Code HTTP transport)
     -- Handles: initialize, notifications/initialized, tools/list, tools/call, ping
-    :<|> "role" :> Capture "slug" Text :> "mcp" :> Header "Mcp-Session-Id" Text :> ReqBody '[JSON] McpJsonRpcRequest :> Post '[JSON] McpJsonRpcResponse
+    :<|> "role" :> Capture "slug" Text :> "mcp" :> Header "Mcp-Session-Id" Text :> QueryParam "container" Text :> ReqBody '[JSON] McpJsonRpcRequest :> Post '[JSON] McpJsonRpcResponse
     -- \| Agent status dashboard
     :<|> "api" :> "agents" :> Get '[JSON] AgentsResponse
     -- \| Agent logs

--- a/haskell/control-server/src/ExoMonad/Control/Effects/Git.hs
+++ b/haskell/control-server/src/ExoMonad/Control/Effects/Git.hs
@@ -93,6 +93,21 @@ runGitRemote container workDir = interpret $ \case
           [(n, "")] -> n
           _ -> 0
         else 0
+  FetchRemote remote mRefspec -> do
+    let args = case mRefspec of
+          Just refspec -> ["fetch", remote, refspec]
+          Nothing -> ["fetch", remote]
+    _ <-
+      execCommand $
+        ExecRequest
+          { container = Just container,
+            command = "git",
+            args = args,
+            workingDir = workDir,
+            env = [],
+            timeout = 120 -- Fetches can take longer
+          }
+    pure ()
 
 -- | Helper to run a git command via SshExec
 gitCommand :: (Member SshExec effs) => Text -> FilePath -> [Text] -> Eff effs (Maybe Text)

--- a/haskell/control-server/src/ExoMonad/Control/Protocol.hs
+++ b/haskell/control-server/src/ExoMonad/Control/Protocol.hs
@@ -157,7 +157,7 @@ data ToolDefinition = ToolDefinition
 -- Note: Rust uses snake_case (tool_name, container_id), so we apply CamelToSnake.
 data ControlMessage
   = HookEvent {input :: HookInput, runtime :: Runtime, role :: Role, containerId :: Maybe Text}
-  | MCPToolCall {id :: Text, toolName :: Text, arguments :: Value}
+  | MCPToolCall {id :: Text, toolName :: Text, arguments :: Value, containerId :: Maybe Text}
   | ToolsListRequest
   | Ping
   deriving stock (Show, Eq, Generic)

--- a/haskell/effects/git-interpreter/src/ExoMonad/Git/Interpreter.hs
+++ b/haskell/effects/git-interpreter/src/ExoMonad/Git/Interpreter.hs
@@ -1,45 +1,23 @@
-{-# LANGUAGE TypeApplications #-}
-
--- | Git effect interpreter - CLI client.
---
--- Implements Git effect by calling git CLI commands.
--- All queries are read-only.
+-- | Git effect interpreter - pure handler injection for testing.
 module ExoMonad.Git.Interpreter
-  ( -- * Interpreter
-    runGit,
-    runGitIO,
-
-    -- * Utilities (for testing)
+  ( runGit,
     worktreeName,
   )
 where
 
-import Control.Exception (SomeException, try)
-import Control.Monad.Freer (Eff, LastMember, interpret, sendM)
+import Control.Monad.Freer (Eff, interpret)
 import Data.Text (Text)
 import Data.Text qualified as T
-import ExoMonad.Effects.Git (Git (..), WorktreeInfo (..))
-import System.Exit (ExitCode (..))
-import System.FilePath (takeDirectory, takeFileName)
-import System.Process (readProcessWithExitCode)
+import ExoMonad.Effects.Git (Git (..), WorktreeInfo)
+import System.FilePath (takeFileName)
 
--- ════════════════════════════════════════════════════════════════════════════
--- INTERPRETER
--- ════════════════════════════════════════════════════════════════════════════
-
--- | Run Git effects with a pure handler.
+-- | Run Git effects with pure handlers (for testing).
 runGit ::
-  -- | Handler for GetWorktreeInfo
   Eff effs (Maybe WorktreeInfo) ->
-  -- | Handler for GetDirtyFiles
   Eff effs [FilePath] ->
-  -- | Handler for GetRecentCommits
   (Int -> Eff effs [Text]) ->
-  -- | Handler for GetCurrentBranch
   Eff effs Text ->
-  -- | Handler for GetCommitsAhead
   (Text -> Eff effs Int) ->
-  -- | Handler for FetchRemote
   (Text -> Maybe Text -> Eff effs ()) ->
   Eff (Git ': effs) a ->
   Eff effs a
@@ -50,73 +28,6 @@ runGit hWorktree hDirty hCommits hBranch hAhead hFetch = interpret $ \case
   GetCurrentBranch -> hBranch
   GetCommitsAhead ref -> hAhead ref
   FetchRemote remote refspec -> hFetch remote refspec
-
--- | Run Git effects using the git CLI.
-runGitIO :: (LastMember IO effs) => Eff (Git ': effs) a -> Eff effs a
-runGitIO = interpret $ \case
-  GetWorktreeInfo -> sendM detectWorktree
-  GetDirtyFiles -> sendM getGitDirtyFiles
-  GetRecentCommits n -> sendM $ getGitRecentCommits n
-  GetCurrentBranch -> sendM getGitCurrentBranch
-  GetCommitsAhead ref -> sendM $ getGitCommitsAhead ref
-  FetchRemote remote refspec -> sendM $ gitFetchRemote remote refspec
-
--- ════════════════════════════════════════════════════════════════════════════
--- GIT CLI FUNCTIONS
--- ════════════════════════════════════════════════════════════════════════════
-
--- | Detect worktree information.
-detectWorktree :: IO (Maybe WorktreeInfo)
-detectWorktree = do
-  -- Get the toplevel of current repo (works for both worktree and main)
-  mPath <- gitCommand ["rev-parse", "--show-toplevel"]
-  case mPath of
-    Nothing -> pure Nothing
-    Just path -> do
-      let cleanPath = T.unpack $ T.strip $ T.pack path
-
-      -- Get current branch
-      -- Use rev-parse --abbrev-ref HEAD for robustness (handles detached HEAD as "HEAD")
-      mBranch <- gitCommand ["rev-parse", "--abbrev-ref", "HEAD"]
-      let branch = case mBranch of
-            Nothing -> "HEAD"
-            Just b -> T.strip $ T.pack b
-
-      -- Check if we're in a worktree by looking for .git file (not dir)
-      mGitDir <- gitCommand ["rev-parse", "--git-dir"]
-
-      case mGitDir of
-        Nothing -> pure Nothing
-        Just gitDir -> do
-          let cleanGitDir = T.unpack $ T.strip $ T.pack gitDir
-
-          -- If git-dir contains "/worktrees/", we're in a worktree
-          let inWorktree = "/worktrees/" `T.isInfixOf` T.pack cleanGitDir
-
-          -- Get the main repo root
-          mMainRoot <-
-            if inWorktree
-              then gitCommand ["rev-parse", "--path-format=absolute", "--git-common-dir"]
-              else pure (Just cleanPath)
-
-          let mainRoot = case mMainRoot of
-                Just r -> takeDirectory $ T.unpack $ T.strip $ T.pack r -- Remove .git suffix
-                Nothing -> cleanPath
-
-          let name =
-                if inWorktree
-                  then worktreeName cleanPath
-                  else "main"
-
-          pure $
-            Just
-              WorktreeInfo
-                { wiName = name,
-                  wiPath = cleanPath,
-                  wiBranch = branch,
-                  wiRepoRoot = mainRoot,
-                  wiIsWorktree = inWorktree
-                }
 
 -- | Extract worktree name from path.
 worktreeName :: FilePath -> Text
@@ -130,68 +41,3 @@ worktreeName path =
    in case findAfterWorktrees parts of
         Just name -> name
         Nothing -> T.pack $ takeFileName path
-
--- | Get list of dirty (uncommitted) files.
-getGitDirtyFiles :: IO [FilePath]
-getGitDirtyFiles = do
-  result <- try $ readProcessWithExitCode "git" ["status", "--porcelain"] ""
-  case result of
-    Left (_ :: SomeException) -> pure []
-    Right (ExitSuccess, stdout, _) ->
-      pure $ map (drop 3) $ lines stdout -- Drop status prefix "XY "
-    Right _ -> pure []
-
--- | Get recent commit subjects.
-getGitRecentCommits :: Int -> IO [Text]
-getGitRecentCommits n = do
-  result <-
-    try $
-      readProcessWithExitCode
-        "git"
-        ["log", "--oneline", "-" ++ show n, "--format=%s"]
-        ""
-  case result of
-    Left (_ :: SomeException) -> pure []
-    Right (ExitSuccess, stdout, _) ->
-      pure $ map T.pack $ take n $ lines stdout
-    Right _ -> pure []
-
--- | Get current branch name.
-getGitCurrentBranch :: IO Text
-getGitCurrentBranch = do
-  result <- try $ readProcessWithExitCode "git" ["branch", "--show-current"] ""
-  case result of
-    Left (_ :: SomeException) -> pure "HEAD"
-    Right (ExitSuccess, stdout, _) -> pure $ T.strip $ T.pack stdout
-    Right _ -> pure "HEAD"
-
--- | Get number of commits ahead of a ref.
-getGitCommitsAhead :: Text -> IO Int
-getGitCommitsAhead ref = do
-  let refStr = T.unpack ref <> "..HEAD"
-  result <- try $ readProcessWithExitCode "git" ["rev-list", "--count", refStr] ""
-  case result of
-    Left (_ :: SomeException) -> pure 0
-    Right (ExitSuccess, stdout, _) ->
-      case reads (T.unpack $ T.strip $ T.pack stdout) of
-        [(n, "")] -> pure n
-        _ -> pure 0
-    Right _ -> pure 0
-
--- | Fetch from a remote, optionally with a refspec.
-gitFetchRemote :: Text -> Maybe Text -> IO ()
-gitFetchRemote remote mRefspec = do
-  let args = case mRefspec of
-        Just refspec -> ["fetch", T.unpack remote, T.unpack refspec]
-        Nothing -> ["fetch", T.unpack remote]
-  _ <- try @SomeException $ readProcessWithExitCode "git" args ""
-  pure ()
-
--- | Run a git command and return stdout on success.
-gitCommand :: [String] -> IO (Maybe String)
-gitCommand args = do
-  result <- try $ readProcessWithExitCode "git" args ""
-  case result of
-    Left (_ :: SomeException) -> pure Nothing
-    Right (ExitSuccess, stdout, _) -> pure $ Just stdout
-    Right (ExitFailure _, _, _) -> pure Nothing


### PR DESCRIPTION
## Summary
- Fix `file_pr` and other MCP tools that use git by always executing in agent container
- Add container ID to MCP URL query param (`?container=...`)
- Remove `runGitIO` entirely - all git execution now goes through `runGitRemote`

## Test plan
- [ ] Start Docker compose environment
- [ ] In TL pane, create test branch and commit
- [ ] Call `file_pr` tool - should work with correct worktree info
- [ ] Verify control-server logs show `docker-ctl exec {container} git ...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)