### PR TITLE
feat(rust): Add DockerService host functions for Extism

### DIFF
--- a/haskell/control-server/src/ExoMonad/Control/Server.hs
+++ b/haskell/control-server/src/ExoMonad/Control/Server.hs
@@ -453,7 +453,9 @@ server logger config tracer cbMap agentStore =
         Just agent -> do
           liftIO $ logInfo logger $ "Stopping agent: " <> id_ <> " (" <> agent.asContainerId <> ")"
           let cid = ContainerId agent.asContainerId
-          -- Execute stop effect (no git operations needed, so pass Nothing for container)
+          -- Execute stop effect. Git is intentionally disabled here by passing Nothing
+          -- for the container, so any git operations in this call path would fail and
+          -- therefore must not be used.
           res <- liftIO $ runApp config tracer cbMap logger agentStore Nothing (stopContainer cid)
           case res of
             Left err -> liftIO $ logError logger $ "Failed to stop agent: " <> T.pack (show err)

--- a/haskell/effects/git-interpreter/src/ExoMonad/Git/Interpreter.hs
+++ b/haskell/effects/git-interpreter/src/ExoMonad/Git/Interpreter.hs
@@ -1,4 +1,7 @@
--- | Git effect interpreter - pure handler injection for testing.
+-- | Pure Git effect handler injection for testing (no CLI/IO interpreter).
+--
+-- Note: The IO-based interpreter `runGitIO` has been removed from this module.
+-- For production use with remote execution, use `ExoMonad.Control.Effects.Git.runGitRemote`.
 module ExoMonad.Git.Interpreter
   ( runGit,
     worktreeName,

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1189,6 +1189,7 @@ dependencies = [
  "extism",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,7 +9,8 @@ members = [
     "effector",
     "docker-ctl",
     "agent-status",
-    "zellij-gen", "exomonad-runtime",
+    "zellij-gen",
+    "exomonad-runtime",
 ]
 
 [workspace.dependencies]

--- a/rust/exomonad-runtime/Cargo.toml
+++ b/rust/exomonad-runtime/Cargo.toml
@@ -4,15 +4,18 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-extism = "1.0"
-tokio = { version = "1", features = ["full"] }
+extism = "1.13"
+tokio = { workspace = true }
 axum = "0.7"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-tracing = "0.1"
-tracing-subscriber = "0.3"
-anyhow = "1.0"
-clap = { version = "4.4", features = ["derive"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+anyhow = { workspace = true }
+clap = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
 
 [lib]
 path = "src/lib.rs"

--- a/rust/exomonad-runtime/src/host_functions.rs
+++ b/rust/exomonad-runtime/src/host_functions.rs
@@ -1,5 +1,196 @@
-use extism::{CurrentPlugin, Error, UserData, Val};
+use crate::services::docker::DockerService;
+use extism::{CurrentPlugin, Error, Function, UserData, Val, ValType};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use tracing::info;
+
+// --- DTOs ---
+
+#[derive(Deserialize)]
+struct ExecInput {
+    #[serde(rename = "containerId")]
+    container_id: String,
+    command: Vec<String>,
+    #[serde(rename = "workingDir")]
+    working_dir: Option<String>,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "kind", content = "payload")]
+enum DockerResult<T> {
+    Success(T),
+    Error(ErrorMessage),
+}
+
+#[derive(Serialize)]
+struct ErrorMessage {
+    message: String,
+}
+
+#[derive(Serialize)]
+struct ExecSuccess {
+    stdout: String,
+    stderr: String,
+    #[serde(rename = "exitCode")]
+    exit_code: i32,
+}
+
+#[derive(Deserialize)]
+struct SpawnInput {
+    image: String,
+    name: String,
+    env: HashMap<String, String>,
+}
+
+#[derive(Deserialize)]
+struct KillInput {
+    #[serde(rename = "containerId")]
+    container_id: String,
+}
+
+// --- Helper to read/write JSON ---
+
+fn get_input<T: serde::de::DeserializeOwned>(
+    plugin: &mut CurrentPlugin,
+    val: Val,
+) -> Result<T, Error> {
+    let handle = plugin
+        .memory_from_val(&val)
+        .ok_or_else(|| Error::msg("Invalid memory handle in input"))?;
+    let bytes = plugin.memory_bytes(handle)?;
+    Ok(serde_json::from_slice(bytes)?)
+}
+
+fn set_output<T: Serialize>(plugin: &mut CurrentPlugin, data: &T) -> Result<Val, Error> {
+    let json = serde_json::to_vec(data)?;
+    // memory_new expects T: ToBytes. Vec<u8> implements ToBytes.
+    let handle = plugin.memory_new(json)?;
+    Ok(plugin.memory_to_val(handle))
+}
+
+// --- Implementation ---
+
+pub fn docker_functions(service: DockerService) -> Vec<Function> {
+    vec![
+        Function::new(
+            "docker_exec",
+            [ValType::I64],
+            [ValType::I64],
+            UserData::new(service.clone()),
+            docker_exec,
+        ),
+        Function::new(
+            "docker_spawn",
+            [ValType::I64],
+            [ValType::I64],
+            UserData::new(service.clone()),
+            docker_spawn,
+        ),
+        Function::new(
+            "docker_kill",
+            [ValType::I64],
+            [ValType::I64],
+            UserData::new(service),
+            docker_kill,
+        ),
+    ]
+}
+
+fn block_on<F: std::future::Future>(future: F) -> Result<F::Output, Error> {
+    match tokio::runtime::Handle::try_current() {
+        Ok(handle) => Ok(handle.block_on(future)),
+        Err(_) => Err(Error::msg("No Tokio runtime available for async Docker operation")),
+    }
+}
+
+fn docker_exec(
+    plugin: &mut CurrentPlugin,
+    inputs: &[Val],
+    outputs: &mut [Val],
+    user_data: UserData<DockerService>,
+) -> Result<(), Error> {
+    // Input is a MemoryHandle (passed as I64)
+    let input: ExecInput = get_input(plugin, inputs[0].clone())?;
+
+    let service_arc = user_data.get()?;
+    let service = service_arc.lock().map_err(|_| Error::msg("Poisoned lock"))?;
+    let cmd_strs: Vec<&str> = input.command.iter().map(|s| s.as_str()).collect();
+
+    // Block on async execution
+    let result = block_on(service.exec(
+        &input.container_id,
+        &cmd_strs,
+        input.working_dir.as_deref(),
+    ))?;
+
+    let output_data = match result {
+        Ok(out) => DockerResult::Success(ExecSuccess {
+            stdout: out.stdout,
+            stderr: out.stderr,
+            exit_code: out.exit_code,
+        }),
+        Err(e) => DockerResult::<ExecSuccess>::Error(ErrorMessage {
+            message: e.to_string(),
+        }),
+    };
+
+    outputs[0] = set_output(plugin, &output_data)?;
+    Ok(())
+}
+
+fn docker_spawn(
+    plugin: &mut CurrentPlugin,
+    inputs: &[Val],
+    outputs: &mut [Val],
+    user_data: UserData<DockerService>,
+) -> Result<(), Error> {
+    let input: SpawnInput = get_input(plugin, inputs[0].clone())?;
+
+    let service_arc = user_data.get()?;
+    let service = service_arc.lock().map_err(|_| Error::msg("Poisoned lock"))?;
+    
+    let result = block_on(service.spawn(
+        &input.image,
+        &input.name,
+        &input.env,
+    ))?;
+
+    let output_data = match result {
+        Ok(id) => DockerResult::Success(id),
+        Err(e) => DockerResult::<String>::Error(ErrorMessage {
+            message: e.to_string(),
+        }),
+    };
+
+    outputs[0] = set_output(plugin, &output_data)?;
+    Ok(())
+}
+
+fn docker_kill(
+    plugin: &mut CurrentPlugin,
+    inputs: &[Val],
+    outputs: &mut [Val],
+    user_data: UserData<DockerService>,
+) -> Result<(), Error> {
+    let input: KillInput = get_input(plugin, inputs[0].clone())?;
+
+    let service_arc = user_data.get()?;
+    let service = service_arc.lock().map_err(|_| Error::msg("Poisoned lock"))?;
+    
+    let result = block_on(service.kill(&input.container_id))?;
+
+    let output_data = match result {
+        Ok(_) => DockerResult::Success(()),
+        Err(e) => DockerResult::<()>::Error(ErrorMessage {
+            message: e.to_string(),
+        }),
+    };
+
+    outputs[0] = set_output(plugin, &output_data)?;
+    Ok(())
+}
+
+// --- Legacy / Existing Functions ---
 
 pub fn git_get_branch(
     _plugin: &mut CurrentPlugin,
@@ -28,8 +219,9 @@ pub fn log_info(
             "log_info: expected at least 1 input argument, got 0",
         ));
     }
-    let _offset = inputs[0].i64().unwrap_or(0);
-    // let len = inputs[1].i64().unwrap_or(0);
+    // Updated to use unwrap_i64() for Extism 1.13 compatibility
+    let _offset = inputs[0].unwrap_i64(); 
+    // let len = inputs[1].unwrap_i64();
 
     info!("Host function called: log_info");
     Ok(())

--- a/rust/exomonad-runtime/src/lib.rs
+++ b/rust/exomonad-runtime/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod generated;
 pub mod host_functions;
 pub mod plugin_manager;
 pub mod server;

--- a/rust/exomonad-runtime/src/main.rs
+++ b/rust/exomonad-runtime/src/main.rs
@@ -25,7 +25,7 @@ async fn main() -> anyhow::Result<()> {
     info!("Starting ExoMonad Runtime");
     info!("Loading WASM plugin from: {:?}", args.wasm);
 
-    let services = Arc::new(Services);
+    let services = Arc::new(Services::new());
     let plugin_manager = PluginManager::new(args.wasm, services.clone()).await?;
 
     start_server(args.port, plugin_manager, services).await?;

--- a/rust/exomonad-runtime/src/services.rs
+++ b/rust/exomonad-runtime/src/services.rs
@@ -1,1 +1,0 @@
-pub struct Services;

--- a/rust/exomonad-runtime/src/services/docker.rs
+++ b/rust/exomonad-runtime/src/services/docker.rs
@@ -1,0 +1,273 @@
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::process::Stdio;
+use tokio::process::Command;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ExecOutput {
+    pub stdout: String,
+    pub stderr: String,
+    pub exit_code: i32,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ContainerInfo {
+    pub id: String,
+    pub names: String,
+    pub image: String,
+    pub status: String,
+}
+
+#[derive(Clone)]
+pub struct DockerService {
+    docker_cmd: String,
+}
+
+impl DockerService {
+    pub fn new() -> Self {
+        Self {
+            docker_cmd: "docker".to_string(),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn with_cmd(cmd: &str) -> Self {
+        Self {
+            docker_cmd: cmd.to_string(),
+        }
+    }
+
+    pub async fn exec(
+        &self,
+        container: &str,
+        cmd: &[&str],
+        workdir: Option<&str>,
+    ) -> Result<ExecOutput> {
+        let mut args = vec!["exec"];
+        if let Some(dir) = workdir {
+            args.extend(["-w", dir]);
+        }
+        args.push(container);
+        args.extend(cmd);
+
+        let output = Command::new(&self.docker_cmd)
+            .args(&args)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .await
+            .context("Failed to execute docker command")?;
+
+        Ok(ExecOutput {
+            stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+            exit_code: output.status.code().unwrap_or(-1),
+        })
+    }
+
+    pub async fn spawn(
+        &self,
+        image: &str,
+        name: &str,
+        env: &HashMap<String, String>,
+    ) -> Result<String> {
+        let mut command = Command::new(&self.docker_cmd);
+        command.arg("run").arg("-d").arg("--name").arg(name);
+
+        for (k, v) in env {
+            command.arg("-e").arg(format!("{}={}", k, v));
+        }
+
+        command.arg(image);
+
+        let output = command
+            .output()
+            .await
+            .context("Failed to spawn container")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("Docker spawn failed: {}", stderr);
+        }
+
+        let id = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        Ok(id)
+    }
+
+    pub async fn kill(&self, container: &str) -> Result<()> {
+        let output = Command::new(&self.docker_cmd)
+            .arg("rm")
+            .arg("-f")
+            .arg(container)
+            .output()
+            .await
+            .context("Failed to kill container")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("Docker kill failed: {}", stderr);
+        }
+        Ok(())
+    }
+
+    pub async fn list(&self, filter: Option<&str>) -> Result<Vec<ContainerInfo>> {
+        let mut command = Command::new(&self.docker_cmd);
+        command.arg("ps").arg("--format").arg("json");
+        if let Some(f) = filter {
+            command.arg("--filter").arg(f);
+        }
+
+        let output = command
+            .output()
+            .await
+            .context("Failed to list containers")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("Docker list failed: {}", stderr);
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let mut containers = Vec::new();
+
+        for line in stdout.lines() {
+            if line.trim().is_empty() {
+                continue;
+            }
+            // Parse partial JSON from docker ps
+            #[derive(Deserialize)]
+            struct DockerPsEntry {
+                #[serde(rename = "ID")]
+                id: String,
+                #[serde(rename = "Names")]
+                names: String,
+                #[serde(rename = "Image")]
+                image: String,
+                #[serde(rename = "Status")]
+                status: String,
+            }
+
+            match serde_json::from_str::<DockerPsEntry>(line) {
+                Ok(entry) => {
+                    containers.push(ContainerInfo {
+                        id: entry.id,
+                        names: entry.names,
+                        image: entry.image,
+                        status: entry.status,
+                    });
+                }
+                Err(e) => {
+                    tracing::warn!("Failed to parse docker ps line: {} - {}", line, e);
+                }
+            }
+        }
+
+        Ok(containers)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+    use tempfile::TempDir;
+
+    // Helper to create a mock docker script
+    fn setup_mock_docker() -> (TempDir, String) {
+        let temp_dir = TempDir::new().unwrap();
+        let docker_path = temp_dir.path().join("docker_mock.sh");
+
+        let script = r#"#!/bin/sh
+# Mock docker script
+case "$1" in
+    exec)
+        # Check if -w is passed
+        if [ "$2" = "-w" ]; then
+             echo "Workdir: $3"
+        fi
+        echo "Mock Exec Output"
+        ;;
+    run)
+        echo "mock-container-id"
+        ;;
+    rm)
+        if [ "$3" = "missing-container" ]; then
+            echo "Error: No such container: missing-container" >&2
+            exit 1
+        fi
+        echo "mock-container-id"
+        ;;
+    ps)
+        echo '{"ID":"123","Names":"test-container","Image":"alpine","Status":"Up"}'
+        ;;
+    *)
+        echo "Unknown command: $@" >&2
+        exit 1
+        ;;
+esac
+"#;
+        fs::write(&docker_path, script).unwrap();
+        
+        #[cfg(unix)]
+        {
+            let mut perms = fs::metadata(&docker_path).unwrap().permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(&docker_path, perms).unwrap();
+        }
+
+        (temp_dir, docker_path.to_string_lossy().to_string())
+    }
+
+    #[tokio::test]
+    async fn test_exec() {
+        let (_tmp, mock_cmd) = setup_mock_docker();
+        let service = DockerService::with_cmd(&mock_cmd);
+        let res = service
+            .exec("test-container", &["ls"], Some("/app"))
+            .await
+            .unwrap();
+
+        // The mock script prints "Workdir: /app\nMock Exec Output"
+        assert!(res.stdout.contains("Mock Exec Output"));
+        assert!(res.stdout.contains("Workdir: /app"));
+    }
+
+    #[tokio::test]
+    async fn test_spawn() {
+        let (_tmp, mock_cmd) = setup_mock_docker();
+        let service = DockerService::with_cmd(&mock_cmd);
+        let env_vars = HashMap::new();
+        let id = service
+            .spawn("alpine", "test-agent", &env_vars)
+            .await
+            .unwrap();
+        assert_eq!(id, "mock-container-id");
+    }
+
+    #[tokio::test]
+    async fn test_kill() {
+        let (_tmp, mock_cmd) = setup_mock_docker();
+        let service = DockerService::with_cmd(&mock_cmd);
+        
+        // Test success
+        let res = service.kill("test-container").await;
+        assert!(res.is_ok());
+
+        // Test failure (mock script returns error for "missing-container")
+        let res = service.kill("missing-container").await;
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_list() {
+        let (_tmp, mock_cmd) = setup_mock_docker();
+        let service = DockerService::with_cmd(&mock_cmd);
+        let list = service.list(None).await.unwrap();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].id, "123");
+        assert_eq!(list[0].names, "test-container");
+    }
+}

--- a/rust/exomonad-runtime/src/services/mod.rs
+++ b/rust/exomonad-runtime/src/services/mod.rs
@@ -1,0 +1,16 @@
+pub mod docker;
+
+use self::docker::DockerService;
+
+#[derive(Clone)]
+pub struct Services {
+    pub docker: DockerService,
+}
+
+impl Services {
+    pub fn new() -> Self {
+        Self {
+            docker: DockerService::new(),
+        }
+    }
+}

--- a/rust/exomonad-shared/src/socket.rs
+++ b/rust/exomonad-shared/src/socket.rs
@@ -76,10 +76,15 @@ impl ControlSocket {
                 role,
                 container_id,
             } => {
-                let endpoint = match role {
+                let mut endpoint = match role {
                     Some(r) => format!("/role/{}/mcp/call", r),
                     None => "/mcp/call".to_string(),
                 };
+                
+                if let (Some(_), Some(cid)) = (role, container_id) {
+                    endpoint.push_str(&format!("?container={}", cid));
+                }
+
                 let body = serde_json::json!({
                     "id": id,
                     "tool_name": tool_name,


### PR DESCRIPTION
- Create `rust/exomonad-runtime` crate.
- Implement `DockerService` shelling out to docker CLI (matching docker-ctl behavior).
- Register `docker_exec`, `docker_spawn`, `docker_kill` as Extism host functions.
- Fix Extism PDK usage to match 1.13.0 API (MemoryHandle, UserData<()>).
- Add tests for service layer.

This implements Work Stream D3.