### PR TITLE
feat(hooks): Add runtime-agnostic SubagentStop hook for Gemini support

### DIFF
--- a/haskell/wasm-guest/src/ExoMonad/Guest/Tool/Runtime.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Guest/Tool/Runtime.hs
@@ -20,7 +20,7 @@ import ExoMonad.Guest.Effects.StopHook (runStopHookChecks)
 import ExoMonad.Guest.Tool.Class (MCPCallOutput (..), toMCPFormat)
 import ExoMonad.Guest.Tool.Mode (AsHandler)
 import ExoMonad.Guest.Tool.Record (DispatchRecord (..), ReifyRecord (..))
-import ExoMonad.Guest.Types (HookInput, MCPCallInput (..), allowResponse, hiHookEventName)
+import ExoMonad.Guest.Types (HookInput (..), MCPCallInput (..), allowResponse)
 import Extism.PDK (input, output)
 import Foreign.C.Types (CInt (..))
 
@@ -46,6 +46,9 @@ listHandlerRecord = do
   pure 0
 
 -- | Hook handler - handles PreToolUse, SessionEnd, and SubagentStop hooks.
+--
+-- For stop hooks (SessionEnd, SubagentStop), runs the stop hook checks
+-- that verify uncommitted changes, unpushed commits, PR status, etc.
 hookHandler :: IO CInt
 hookHandler = do
   inp <- input @ByteString

--- a/rust/exomonad-shared/src/protocol.rs
+++ b/rust/exomonad-shared/src/protocol.rs
@@ -94,6 +94,10 @@ pub struct HookInput {
     /// The hook event name (PreToolUse, PostToolUse, etc.).
     pub hook_event_name: String,
 
+    /// Runtime environment (claude, gemini). Injected by Rust before WASM call.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime: Option<Runtime>,
+
     // ----- Tool-related fields (PreToolUse, PostToolUse, PermissionRequest) -----
     /// Tool name for tool-related hooks.
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## Summary

- Add unified hook system that works with both Claude and Gemini runtimes via adapter pattern
- Implement `Runtime` enum and domain types (`AgentStopInput`, `AgentStopOutput`) in Haskell
- Add runtime-aware JSON serialization (Claude: empty object = allow; Gemini: explicit decision)
- Route `SubagentStop` events to new `handle_subagent_stop` WASM function
- Inject runtime from `--runtime` CLI flag before WASM call

## Test plan

- [x] Rust build succeeds: `cargo build -p exomonad-sidecar`
- [x] Haskell build succeeds: `cabal build wasm-guest-internal`
- [x] All 56 tests pass: `cargo test -p exomonad-shared`
- [ ] E2E: Test Claude format with `--runtime claude`
- [ ] E2E: Test Gemini format with `--runtime gemini`

🤖 Generated with [Claude Code](https://claude.com/claude-code)