### PR TITLE
feat(mcp): add file_pr tool and wait_for_copilot_review host function

### DIFF
--- a/haskell/wasm-guest/src/Dev/Tools.hs
+++ b/haskell/wasm-guest/src/Dev/Tools.hs
@@ -1,7 +1,7 @@
 -- | Dev role tool record.
 --
 -- Dev agents use Claude Code native tools for most operations.
--- This provides a minimal ping tool to verify WASM guest is responsive.
+-- This provides tools for WASM guest health checks and PR operations.
 module Dev.Tools
   ( DevTools (..),
     devToolsHandler,
@@ -9,25 +9,36 @@ module Dev.Tools
   )
 where
 
+import ExoMonad.Guest.Records.FilePR (FilePRTools (..), filePRToolsHandler, filePRToolsSchema)
 import ExoMonad.Guest.Records.Ping (PingTools (..), pingToolsHandler, pingToolsSchema)
 import ExoMonad.Guest.Tool.Mode (AsHandler, AsSchema, ToolMode ((:-)))
 import GHC.Generics (Generic)
 
 -- | Tools available to the Dev role.
 --
--- Minimal toolset:
+-- Toolset:
 -- - ping: Verify WASM guest is responsive
+-- - file_pr: Create or update PRs for the current branch
 --
 -- All other operations use Claude Code native tools.
 data DevTools mode = DevTools
-  { util :: PingTools mode
+  { util :: PingTools mode,
+    pr :: FilePRTools mode
   }
   deriving (Generic)
 
 -- | Dev tools handler record.
 devToolsHandler :: DevTools AsHandler
-devToolsHandler = DevTools {util = pingToolsHandler}
+devToolsHandler =
+  DevTools
+    { util = pingToolsHandler,
+      pr = filePRToolsHandler
+    }
 
 -- | Dev tools schema record.
 devToolsSchema :: DevTools AsSchema
-devToolsSchema = DevTools {util = pingToolsSchema}
+devToolsSchema =
+  DevTools
+    { util = pingToolsSchema,
+      pr = filePRToolsSchema
+    }

--- a/haskell/wasm-guest/src/ExoMonad/Guest/HostCall.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Guest/HostCall.hs
@@ -32,6 +32,10 @@ module ExoMonad.Guest.HostCall
     -- Filesystem
     host_fs_read_file,
     host_fs_write_file,
+    -- File PR
+    host_file_pr,
+    -- Copilot Review
+    host_wait_for_copilot_review,
   )
 where
 
@@ -91,6 +95,12 @@ foreign import ccall "agent_list" host_agent_list :: Word64 -> IO Word64
 foreign import ccall "fs_read_file" host_fs_read_file :: Word64 -> IO Word64
 
 foreign import ccall "fs_write_file" host_fs_write_file :: Word64 -> IO Word64
+
+-- File PR host function (create/update PRs via gh CLI)
+foreign import ccall "file_pr" host_file_pr :: Word64 -> IO Word64
+
+-- Copilot Review host function (poll for Copilot review comments)
+foreign import ccall "wait_for_copilot_review" host_wait_for_copilot_review :: Word64 -> IO Word64
 
 callHost :: (ToJSON req, FromJSON resp) => (Word64 -> IO Word64) -> req -> IO (Either String resp)
 callHost rawFn request = do

--- a/haskell/wasm-guest/src/ExoMonad/Guest/Records/FilePR.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Guest/Records/FilePR.hs
@@ -1,0 +1,25 @@
+-- | FilePR tool record.
+module ExoMonad.Guest.Records.FilePR
+  ( FilePRTools (..),
+    filePRToolsHandler,
+    filePRToolsSchema,
+  )
+where
+
+import ExoMonad.Guest.Tool.Mode (AsHandler, AsSchema, ToolMode ((:-)), mkHandler, mkSchema)
+import ExoMonad.Guest.Tools.FilePR (FilePR)
+import GHC.Generics (Generic)
+
+-- | FilePR tools record.
+data FilePRTools mode = FilePRTools
+  { filePR :: mode :- FilePR
+  }
+  deriving (Generic)
+
+-- | FilePR tools handler.
+filePRToolsHandler :: FilePRTools AsHandler
+filePRToolsHandler = FilePRTools {filePR = mkHandler @FilePR}
+
+-- | FilePR tools schema.
+filePRToolsSchema :: FilePRTools AsSchema
+filePRToolsSchema = FilePRTools {filePR = mkSchema @FilePR}

--- a/haskell/wasm-guest/src/ExoMonad/Guest/Tools/FilePR.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Guest/Tools/FilePR.hs
@@ -1,0 +1,123 @@
+-- | File PR tool - creates or updates a PR for the current branch.
+module ExoMonad.Guest.Tools.FilePR
+  ( FilePR,
+    FilePRArgs (..),
+  )
+where
+
+import Data.Aeson (FromJSON, ToJSON, Value, object, withObject, (.:), (.=))
+import Data.Aeson qualified as Aeson
+import Data.Text (Text)
+import Data.Text qualified as T
+import ExoMonad.Guest.HostCall (callHost, host_file_pr)
+import ExoMonad.Guest.Tool.Class
+import GHC.Generics (Generic)
+
+-- | File PR tool marker type.
+data FilePR
+
+-- | Arguments for file_pr tool.
+data FilePRArgs = FilePRArgs
+  { fpTitle :: Text,
+    fpBody :: Text
+  }
+  deriving (Show, Eq, Generic)
+
+instance FromJSON FilePRArgs where
+  parseJSON = withObject "FilePRArgs" $ \v ->
+    FilePRArgs
+      <$> v .: "title"
+      <*> v .: "body"
+
+-- | Input type for host function (matches Rust FilePRInput).
+data FilePRInput = FilePRInput
+  { fpiTitle :: Text,
+    fpiBody :: Text
+  }
+  deriving (Show, Generic)
+
+instance ToJSON FilePRInput where
+  toJSON (FilePRInput t b) =
+    object
+      [ "title" .= t,
+        "body" .= b
+      ]
+
+-- | Output type from host function (matches Rust FilePROutput).
+data FilePROutput = FilePROutput
+  { fpoUrl :: Text,
+    fpoNumber :: Int,
+    fpoHeadBranch :: Text,
+    fpoBaseBranch :: Text,
+    fpoCreated :: Bool
+  }
+  deriving (Show, Eq, Generic)
+
+instance FromJSON FilePROutput where
+  parseJSON = withObject "FilePROutput" $ \v ->
+    FilePROutput
+      <$> v .: "pr_url"
+      <*> v .: "pr_number"
+      <*> v .: "head_branch"
+      <*> v .: "base_branch"
+      <*> v .: "created"
+
+instance ToJSON FilePROutput where
+  toJSON (FilePROutput u n h b c) =
+    object
+      [ "pr_url" .= u,
+        "pr_number" .= n,
+        "head_branch" .= h,
+        "base_branch" .= b,
+        "created" .= c
+      ]
+
+-- | Host result wrapper (matches Rust HostResult).
+data HostResult a
+  = Success a
+  | HostError Text
+  deriving (Show, Eq, Generic)
+
+instance (FromJSON a) => FromJSON (HostResult a) where
+  parseJSON = withObject "HostResult" $ \v -> do
+    kind <- v .: "kind"
+    case (kind :: Text) of
+      "Success" -> Success <$> v .: "payload"
+      "Error" -> do
+        errObj <- v .: "payload"
+        HostError <$> (errObj .: "message")
+      _ -> fail "Unknown HostResult kind"
+
+instance MCPTool FilePR where
+  type ToolArgs FilePR = FilePRArgs
+  toolName = "file_pr"
+  toolDescription = "Create or update a pull request for the current branch"
+  toolSchema =
+    object
+      [ "type" .= ("object" :: Text),
+        "required" .= (["title", "body"] :: [Text]),
+        "properties"
+          .= object
+            [ "title"
+                .= object
+                  [ "type" .= ("string" :: Text),
+                    "description" .= ("PR title" :: Text)
+                  ],
+              "body"
+                .= object
+                  [ "type" .= ("string" :: Text),
+                    "description" .= ("PR body/description" :: Text)
+                  ]
+            ]
+      ]
+  toolHandler args = do
+    let input =
+          FilePRInput
+            { fpiTitle = fpTitle args,
+              fpiBody = fpBody args
+            }
+    result <- callHost host_file_pr input :: IO (Either String (HostResult FilePROutput))
+    case result of
+      Left err -> pure $ errorResult (T.pack err)
+      Right (Success output) -> pure $ successResult (Aeson.toJSON output)
+      Right (HostError msg) -> pure $ errorResult msg

--- a/haskell/wasm-guest/wasm-guest.cabal
+++ b/haskell/wasm-guest/wasm-guest.cabal
@@ -46,9 +46,11 @@ library wasm-guest-internal
         -- Tools
         ExoMonad.Guest.Tools.Ping
         ExoMonad.Guest.Tools.Agent
+        ExoMonad.Guest.Tools.FilePR
         -- Tool records
         ExoMonad.Guest.Records.Ping
         ExoMonad.Guest.Records.Agent
+        ExoMonad.Guest.Records.FilePR
         -- Effects (for internal composition)
         ExoMonad.Guest.Effects.AgentControl
         ExoMonad.Guest.Effects.FileSystem

--- a/rust/exomonad-runtime/src/plugin_manager.rs
+++ b/rust/exomonad-runtime/src/plugin_manager.rs
@@ -1,4 +1,6 @@
 use crate::services::agent_control;
+use crate::services::copilot_review;
+use crate::services::file_pr;
 use crate::services::filesystem;
 use crate::services::git;
 use crate::services::github;
@@ -67,6 +69,12 @@ impl PluginManager {
         functions.extend(filesystem::register_host_functions(
             services.filesystem.clone(),
         ));
+
+        // File PR functions (1 function) - create/update PRs via gh CLI
+        functions.extend(file_pr::register_host_functions());
+
+        // Copilot review functions (1 function) - poll for Copilot review comments
+        functions.extend(copilot_review::register_host_functions());
 
         Plugin::new(&manifest, functions, true).context("Failed to create plugin")
     }

--- a/rust/exomonad-runtime/src/services/copilot_review.rs
+++ b/rust/exomonad-runtime/src/services/copilot_review.rs
@@ -1,0 +1,378 @@
+// Copilot Review service - polls for GitHub Copilot review comments
+//
+// Uses `gh api` to check for Copilot review comments on a PR.
+// Blocks until comments are found or timeout is reached.
+
+use anyhow::{Context, Result};
+use extism::{CurrentPlugin, Error, Function, UserData, Val, ValType};
+use serde::{Deserialize, Serialize};
+use std::process::Command;
+use std::thread;
+use std::time::{Duration, Instant};
+use tracing::{debug, info, warn};
+
+// ============================================================================
+// Types
+// ============================================================================
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct WaitForCopilotReviewInput {
+    pub pr_number: u64,
+    #[serde(default = "default_timeout")]
+    pub timeout_secs: u64,
+    #[serde(default = "default_poll_interval")]
+    pub poll_interval_secs: u64,
+}
+
+fn default_timeout() -> u64 {
+    300 // 5 minutes
+}
+
+fn default_poll_interval() -> u64 {
+    30
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CopilotReviewOutput {
+    pub status: String, // "reviewed", "pending", "timeout"
+    pub comments: Vec<CopilotComment>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CopilotComment {
+    pub path: String,
+    pub line: Option<u64>,
+    pub body: String,
+    pub diff_hunk: Option<String>,
+}
+
+// ============================================================================
+// Host Output Wrapper
+// ============================================================================
+
+#[derive(Serialize)]
+#[serde(tag = "kind", content = "payload")]
+enum HostResult<T> {
+    Success(T),
+    Error(HostError),
+}
+
+#[derive(Serialize)]
+struct HostError {
+    message: String,
+    code: String,
+}
+
+impl<T> From<Result<T>> for HostResult<T> {
+    fn from(res: Result<T>) -> Self {
+        match res {
+            Ok(val) => HostResult::Success(val),
+            Err(e) => {
+                let msg = e.to_string();
+                let code = if msg.contains("404") || msg.contains("not found") {
+                    "pr_not_found"
+                } else if msg.contains("401") || msg.contains("403") {
+                    "not_authorized"
+                } else {
+                    "internal_error"
+                };
+                HostResult::Error(HostError {
+                    message: msg,
+                    code: code.to_string(),
+                })
+            }
+        }
+    }
+}
+
+// ============================================================================
+// Implementation
+// ============================================================================
+
+/// Get repo owner/name from git remote
+fn get_repo_info() -> Result<(String, String)> {
+    let output = Command::new("gh")
+        .args(["repo", "view", "--json", "owner,name"])
+        .output()
+        .context("Failed to execute gh repo view")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("Failed to get repo info: {}", stderr.trim());
+    }
+
+    #[derive(Deserialize)]
+    struct RepoInfo {
+        owner: RepoOwner,
+        name: String,
+    }
+
+    #[derive(Deserialize)]
+    struct RepoOwner {
+        login: String,
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let info: RepoInfo =
+        serde_json::from_str(&stdout).context("Failed to parse repo info JSON")?;
+
+    Ok((info.owner.login, info.name))
+}
+
+/// Fetch PR review comments using gh api
+fn fetch_pr_comments(owner: &str, repo: &str, pr_number: u64) -> Result<Vec<CopilotComment>> {
+    let endpoint = format!("/repos/{}/{}/pulls/{}/comments", owner, repo, pr_number);
+
+    debug!(
+        "[CopilotReview] Fetching comments from: {}",
+        endpoint
+    );
+
+    let output = Command::new("gh")
+        .args(["api", &endpoint])
+        .output()
+        .context("Failed to execute gh api for PR comments")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("Failed to fetch PR comments: {}", stderr.trim());
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Parse the comments - GitHub API returns array of comment objects
+    #[derive(Deserialize)]
+    struct PRComment {
+        path: String,
+        #[serde(default)]
+        line: Option<u64>,
+        body: String,
+        #[serde(default)]
+        diff_hunk: Option<String>,
+        user: CommentUser,
+    }
+
+    #[derive(Deserialize)]
+    struct CommentUser {
+        login: String,
+        #[serde(rename = "type")]
+        user_type: Option<String>,
+    }
+
+    let comments: Vec<PRComment> =
+        serde_json::from_str(&stdout).context("Failed to parse PR comments JSON")?;
+
+    // Filter for Copilot comments
+    // Copilot appears as "github-actions[bot]" or "copilot" user, or type "Bot"
+    let copilot_comments: Vec<CopilotComment> = comments
+        .into_iter()
+        .filter(|c| is_copilot_comment(&c.user.login, c.user.user_type.as_deref()))
+        .map(|c| CopilotComment {
+            path: c.path,
+            line: c.line,
+            body: c.body,
+            diff_hunk: c.diff_hunk,
+        })
+        .collect();
+
+    debug!(
+        "[CopilotReview] Found {} Copilot comments",
+        copilot_comments.len()
+    );
+
+    Ok(copilot_comments)
+}
+
+/// Check if a comment is from Copilot
+fn is_copilot_comment(login: &str, user_type: Option<&str>) -> bool {
+    let login_lower = login.to_lowercase();
+
+    // GitHub Copilot code review appears as "copilot" user
+    if login_lower.contains("copilot") {
+        return true;
+    }
+
+    // Also check for Bot type with copilot-related names
+    if user_type == Some("Bot") && login_lower.contains("copilot") {
+        return true;
+    }
+
+    // GitHub's AI code review (if using different branding)
+    if login_lower == "github-advanced-security[bot]" {
+        return true;
+    }
+
+    false
+}
+
+/// Also check PR reviews (not just inline comments)
+fn fetch_pr_reviews(owner: &str, repo: &str, pr_number: u64) -> Result<bool> {
+    let endpoint = format!("/repos/{}/{}/pulls/{}/reviews", owner, repo, pr_number);
+
+    debug!("[CopilotReview] Fetching reviews from: {}", endpoint);
+
+    let output = Command::new("gh")
+        .args(["api", &endpoint])
+        .output()
+        .context("Failed to execute gh api for PR reviews")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("Failed to fetch PR reviews: {}", stderr.trim());
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    #[derive(Deserialize)]
+    struct PRReview {
+        user: ReviewUser,
+        #[allow(dead_code)]
+        state: String,
+    }
+
+    #[derive(Deserialize)]
+    struct ReviewUser {
+        login: String,
+        #[serde(rename = "type")]
+        user_type: Option<String>,
+    }
+
+    let reviews: Vec<PRReview> =
+        serde_json::from_str(&stdout).context("Failed to parse PR reviews JSON")?;
+
+    // Check if any Copilot review exists (any state - APPROVED, CHANGES_REQUESTED, COMMENTED)
+    let has_copilot_review = reviews
+        .iter()
+        .any(|r| is_copilot_comment(&r.user.login, r.user.user_type.as_deref()));
+
+    if has_copilot_review {
+        debug!("[CopilotReview] Found Copilot review");
+    }
+
+    Ok(has_copilot_review)
+}
+
+/// Main wait_for_copilot_review implementation
+pub fn wait_for_copilot_review(input: &WaitForCopilotReviewInput) -> Result<CopilotReviewOutput> {
+    info!(
+        "[CopilotReview] Waiting for Copilot review on PR #{} (timeout: {}s, poll: {}s)",
+        input.pr_number, input.timeout_secs, input.poll_interval_secs
+    );
+
+    let (owner, repo) = get_repo_info()?;
+    info!("[CopilotReview] Repository: {}/{}", owner, repo);
+
+    let deadline = Instant::now() + Duration::from_secs(input.timeout_secs);
+    let poll_interval = Duration::from_secs(input.poll_interval_secs);
+
+    loop {
+        // Check for inline comments
+        let comments = fetch_pr_comments(&owner, &repo, input.pr_number)?;
+
+        if !comments.is_empty() {
+            info!(
+                "[CopilotReview] Found {} Copilot comments",
+                comments.len()
+            );
+            return Ok(CopilotReviewOutput {
+                status: "reviewed".to_string(),
+                comments,
+            });
+        }
+
+        // Also check for review (without inline comments)
+        if fetch_pr_reviews(&owner, &repo, input.pr_number)? {
+            info!("[CopilotReview] Found Copilot review (no inline comments)");
+            return Ok(CopilotReviewOutput {
+                status: "reviewed".to_string(),
+                comments: vec![],
+            });
+        }
+
+        // Check timeout
+        if Instant::now() > deadline {
+            warn!("[CopilotReview] Timeout reached waiting for Copilot review");
+            return Ok(CopilotReviewOutput {
+                status: "timeout".to_string(),
+                comments: vec![],
+            });
+        }
+
+        debug!(
+            "[CopilotReview] No Copilot review yet, sleeping for {}s",
+            input.poll_interval_secs
+        );
+        thread::sleep(poll_interval);
+    }
+}
+
+// ============================================================================
+// Host Functions
+// ============================================================================
+
+fn get_input<T: serde::de::DeserializeOwned>(
+    plugin: &mut CurrentPlugin,
+    val: Val,
+) -> std::result::Result<T, Error> {
+    let handle = plugin
+        .memory_from_val(&val)
+        .ok_or_else(|| Error::msg("Invalid memory handle in input"))?;
+    let bytes = plugin.memory_bytes(handle)?;
+    Ok(serde_json::from_slice(bytes)?)
+}
+
+fn set_output<T: Serialize>(
+    plugin: &mut CurrentPlugin,
+    data: &T,
+) -> std::result::Result<Val, Error> {
+    let json = serde_json::to_vec(data)?;
+    let handle = plugin.memory_new(json)?;
+    Ok(plugin.memory_to_val(handle))
+}
+
+pub fn register_host_functions() -> Vec<Function> {
+    vec![Function::new(
+        "wait_for_copilot_review",
+        [ValType::I64],
+        [ValType::I64],
+        UserData::new(()),
+        wait_for_copilot_review_host_fn,
+    )
+    .with_namespace("env")]
+}
+
+fn wait_for_copilot_review_host_fn(
+    plugin: &mut CurrentPlugin,
+    inputs: &[Val],
+    outputs: &mut [Val],
+    _user_data: UserData<()>,
+) -> std::result::Result<(), Error> {
+    let input: WaitForCopilotReviewInput = get_input(plugin, inputs[0].clone())?;
+
+    let result = wait_for_copilot_review(&input);
+    let output: HostResult<CopilotReviewOutput> = result.into();
+
+    outputs[0] = set_output(plugin, &output)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_copilot_comment() {
+        assert!(is_copilot_comment("copilot", None));
+        assert!(is_copilot_comment("copilot[bot]", Some("Bot")));
+        assert!(is_copilot_comment("Copilot", None));
+        assert!(is_copilot_comment("github-advanced-security[bot]", Some("Bot")));
+        assert!(!is_copilot_comment("octocat", None));
+        assert!(!is_copilot_comment("github-actions[bot]", Some("Bot")));
+    }
+
+    #[test]
+    fn test_default_values() {
+        assert_eq!(default_timeout(), 300);
+        assert_eq!(default_poll_interval(), 30);
+    }
+}

--- a/rust/exomonad-runtime/src/services/file_pr.rs
+++ b/rust/exomonad-runtime/src/services/file_pr.rs
@@ -1,0 +1,319 @@
+// File PR service - creates/updates GitHub PRs using gh CLI
+//
+// Uses `gh pr create` / `gh pr view` for idempotent PR management.
+// Returns immediately with PR URL and number.
+
+use anyhow::{Context, Result};
+use extism::{CurrentPlugin, Error, Function, UserData, Val, ValType};
+use serde::{Deserialize, Serialize};
+use std::process::Command;
+use tracing::{debug, error, info};
+
+// ============================================================================
+// Types
+// ============================================================================
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct FilePRInput {
+    pub title: String,
+    pub body: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FilePROutput {
+    pub pr_url: String,
+    pub pr_number: u64,
+    pub head_branch: String,
+    pub base_branch: String,
+    pub created: bool, // true if newly created, false if already existed
+}
+
+// ============================================================================
+// Host Output Wrapper
+// ============================================================================
+
+#[derive(Serialize)]
+#[serde(tag = "kind", content = "payload")]
+enum HostResult<T> {
+    Success(T),
+    Error(HostError),
+}
+
+#[derive(Serialize)]
+struct HostError {
+    message: String,
+    code: String,
+}
+
+impl<T> From<Result<T>> for HostResult<T> {
+    fn from(res: Result<T>) -> Self {
+        match res {
+            Ok(val) => HostResult::Success(val),
+            Err(e) => {
+                let msg = e.to_string();
+                let code = if msg.contains("not on a branch")
+                    || msg.contains("not a git repository")
+                {
+                    "not_git_repo"
+                } else if msg.contains("no remote") || msg.contains("No remote") {
+                    "no_remote"
+                } else if msg.contains("gh auth") || msg.contains("not logged") {
+                    "not_authenticated"
+                } else if msg.contains("already exists") {
+                    "pr_exists"
+                } else {
+                    "internal_error"
+                };
+                HostResult::Error(HostError {
+                    message: msg,
+                    code: code.to_string(),
+                })
+            }
+        }
+    }
+}
+
+// ============================================================================
+// Implementation
+// ============================================================================
+
+/// Check if a PR already exists for the current branch
+fn check_existing_pr() -> Result<Option<(String, u64, String, String)>> {
+    info!("[FilePR] Checking for existing PR");
+
+    let output = Command::new("gh")
+        .args(["pr", "view", "--json", "url,number,headRefName,baseRefName"])
+        .output()
+        .context("Failed to execute gh pr view")?;
+
+    debug!(
+        "[FilePR] gh pr view exit code: {}",
+        output.status.code().unwrap_or(-1)
+    );
+
+    if !output.status.success() {
+        // No existing PR is not an error - just means we need to create one
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        debug!("[FilePR] No existing PR found: {}", stderr.trim());
+        return Ok(None);
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    debug!("[FilePR] Existing PR found: {}", stdout.trim());
+
+    #[derive(Deserialize)]
+    struct PRView {
+        url: String,
+        number: u64,
+        #[serde(rename = "headRefName")]
+        head_ref_name: String,
+        #[serde(rename = "baseRefName")]
+        base_ref_name: String,
+    }
+
+    let pr: PRView =
+        serde_json::from_str(&stdout).context("Failed to parse gh pr view JSON output")?;
+
+    Ok(Some((pr.url, pr.number, pr.head_ref_name, pr.base_ref_name)))
+}
+
+/// Get current branch name
+fn get_current_branch() -> Result<String> {
+    let output = Command::new("git")
+        .args(["branch", "--show-current"])
+        .output()
+        .context("Failed to execute git branch --show-current")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("Not on a branch: {}", stderr.trim());
+    }
+
+    let branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if branch.is_empty() {
+        anyhow::bail!("Not on a branch (detached HEAD?)");
+    }
+
+    Ok(branch)
+}
+
+/// Create a new PR using gh CLI
+fn create_pr(input: &FilePRInput) -> Result<FilePROutput> {
+    info!("[FilePR] Creating new PR: {}", input.title);
+
+    let head_branch = get_current_branch()?;
+    info!("[FilePR] Current branch: {}", head_branch);
+
+    let args = vec![
+        "pr",
+        "create",
+        "--title",
+        &input.title,
+        "--body",
+        &input.body,
+    ];
+
+    info!("[FilePR] Executing: gh {}", args.join(" "));
+
+    let output = Command::new("gh")
+        .args(&args)
+        .output()
+        .context("Failed to execute gh pr create")?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    info!("[FilePR] gh pr create exit code: {:?}", output.status.code());
+    if !stderr.is_empty() {
+        debug!("[FilePR] stderr: {}", stderr.trim());
+    }
+
+    if !output.status.success() {
+        error!("[FilePR] FAILED: {}", stderr.trim());
+        anyhow::bail!("Failed to create PR: {}", stderr.trim());
+    }
+
+    // gh pr create outputs the PR URL on success
+    let pr_url = stdout.trim().to_string();
+    info!("[FilePR] Created PR: {}", pr_url);
+
+    // Extract PR number from URL (format: https://github.com/owner/repo/pull/123)
+    let pr_number = pr_url
+        .rsplit('/')
+        .next()
+        .and_then(|s| s.parse::<u64>().ok())
+        .context("Failed to extract PR number from URL")?;
+
+    // Get base branch from the created PR
+    let base_branch = get_pr_base_branch(pr_number)?;
+
+    Ok(FilePROutput {
+        pr_url,
+        pr_number,
+        head_branch,
+        base_branch,
+        created: true,
+    })
+}
+
+/// Get base branch for a PR number
+fn get_pr_base_branch(pr_number: u64) -> Result<String> {
+    let output = Command::new("gh")
+        .args([
+            "pr",
+            "view",
+            &pr_number.to_string(),
+            "--json",
+            "baseRefName",
+        ])
+        .output()
+        .context("Failed to get PR base branch")?;
+
+    if !output.status.success() {
+        // Default to main if we can't get it
+        return Ok("main".to_string());
+    }
+
+    #[derive(Deserialize)]
+    struct PRBase {
+        #[serde(rename = "baseRefName")]
+        base_ref_name: String,
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let pr: PRBase = serde_json::from_str(&stdout).unwrap_or(PRBase {
+        base_ref_name: "main".to_string(),
+    });
+
+    Ok(pr.base_ref_name)
+}
+
+/// Main file_pr implementation
+pub fn file_pr(input: &FilePRInput) -> Result<FilePROutput> {
+    info!("[FilePR] Starting file_pr operation");
+
+    // First check if PR already exists for current branch
+    if let Some((url, number, head, base)) = check_existing_pr()? {
+        info!("[FilePR] PR already exists: {} (#{number})", url);
+        return Ok(FilePROutput {
+            pr_url: url,
+            pr_number: number,
+            head_branch: head,
+            base_branch: base,
+            created: false,
+        });
+    }
+
+    // Create new PR
+    create_pr(input)
+}
+
+// ============================================================================
+// Host Functions
+// ============================================================================
+
+fn get_input<T: serde::de::DeserializeOwned>(
+    plugin: &mut CurrentPlugin,
+    val: Val,
+) -> std::result::Result<T, Error> {
+    let handle = plugin
+        .memory_from_val(&val)
+        .ok_or_else(|| Error::msg("Invalid memory handle in input"))?;
+    let bytes = plugin.memory_bytes(handle)?;
+    Ok(serde_json::from_slice(bytes)?)
+}
+
+fn set_output<T: Serialize>(
+    plugin: &mut CurrentPlugin,
+    data: &T,
+) -> std::result::Result<Val, Error> {
+    let json = serde_json::to_vec(data)?;
+    let handle = plugin.memory_new(json)?;
+    Ok(plugin.memory_to_val(handle))
+}
+
+pub fn register_host_functions() -> Vec<Function> {
+    vec![Function::new(
+        "file_pr",
+        [ValType::I64],
+        [ValType::I64],
+        UserData::new(()),
+        file_pr_host_fn,
+    )
+    .with_namespace("env")]
+}
+
+fn file_pr_host_fn(
+    plugin: &mut CurrentPlugin,
+    inputs: &[Val],
+    outputs: &mut [Val],
+    _user_data: UserData<()>,
+) -> std::result::Result<(), Error> {
+    let input: FilePRInput = get_input(plugin, inputs[0].clone())?;
+
+    let result = file_pr(&input);
+    let output: HostResult<FilePROutput> = result.into();
+
+    outputs[0] = set_output(plugin, &output)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_host_error_codes() {
+        let err: HostResult<()> = Err(anyhow::anyhow!("not on a branch")).into();
+        match err {
+            HostResult::Error(e) => assert_eq!(e.code, "not_git_repo"),
+            _ => panic!("Expected error"),
+        }
+
+        let err: HostResult<()> = Err(anyhow::anyhow!("gh auth login required")).into();
+        match err {
+            HostResult::Error(e) => assert_eq!(e.code, "not_authenticated"),
+            _ => panic!("Expected error"),
+        }
+    }
+}

--- a/rust/exomonad-runtime/src/services/mod.rs
+++ b/rust/exomonad-runtime/src/services/mod.rs
@@ -1,5 +1,7 @@
 pub mod agent_control;
+pub mod copilot_review;
 pub mod docker;
+pub mod file_pr;
 pub mod filesystem;
 pub mod git;
 pub mod github;


### PR DESCRIPTION
## Summary

- Adds `file_pr` MCP tool for dev agents to create/update PRs
- Adds `wait_for_copilot_review` host function for stop hooks to poll for Copilot review

## Changes

**Rust (exomonad-runtime):**
- `services/file_pr.rs`: Uses `gh pr create` / `gh pr view` for idempotent PR management
- `services/copilot_review.rs`: Polls GitHub API for Copilot review comments with configurable timeout

**Haskell (wasm-guest):**
- `Tools/FilePR.hs`: MCPTool instance with schema and handler
- `Records/FilePR.hs`: Mode-parameterized tool record
- `Dev/Tools.hs`: Wire FilePR into DevTools

## Tool Schema

```json
{
  "name": "file_pr",
  "description": "Create or update a pull request for the current branch",
  "inputSchema": {
    "type": "object",
    "required": ["title", "body"],
    "properties": {
      "title": { "type": "string" },
      "body": { "type": "string" }
    }
  }
}
```

## Test plan

- [ ] Build Rust: `cargo build -p exomonad-runtime`
- [ ] Build Haskell: `cabal build wasm-guest:wasm-guest-internal`
- [ ] Manual test: Call `file_pr` in a git repo with remote

🤖 Generated with [Claude Code](https://claude.com/claude-code)