### PR TITLE
feat: display exomonad-plugin as fixed sidebar in agent tabs

### DIFF
--- a/rust/exomonad-runtime/src/services/agent_control.rs
+++ b/rust/exomonad-runtime/src/services/agent_control.rs
@@ -474,6 +474,9 @@ impl AgentControlService {
             cwd "{cwd}"
             close_on_exit true
         }}
+        pane size=3 borderless=true {{
+            plugin location="file:~/.config/zellij/plugins/exomonad-plugin.wasm"
+        }}
     }}
 }}"#,
                 name = name,


### PR DESCRIPTION
Updates `new_zellij_tab` to include the `exomonad-plugin` as a fixed 3-line borderless pane at the bottom of each agent tab. This replaces the previous behavior where the plugin had to be loaded as a floating pane.

Fixes #454
