### PR TITLE
feat: Add .claude/rules for language-specific coding guidelines

### DIFF
--- a/.claude/rules/haskell.md
+++ b/.claude/rules/haskell.md
@@ -1,0 +1,66 @@
+---
+paths:
+  - "**/*.hs"
+---
+
+# Applied Haskell
+
+## Core Philosophy
+
+**Parse, don't validate.** Transform unstructured input into structured types at boundaries. Interior code operates on already-parsed types and never re-checks.
+
+**Make illegal states unrepresentable.** Structure types so invalid states cannot be constructed. Sum types with data per branch, newtypes for validated data, smart constructors with opaque exports.
+
+## Type Design
+
+- Newtype domain concepts aggressively (`UserId`, `Email`, `SourcePath` vs `DestPath`)
+- Sum types carry data specific to each state - pattern matching provides proof
+- Export type but not constructor; validation lives in `mk-` smart constructor
+- Constructive safety (invariant in type structure) over extrinsic (module discipline)
+
+## Applicative Over Monad
+
+Static dependencies = Applicative (parallelizable, all errors accumulate).
+Dynamic dependencies = Monad (sequential, short-circuit).
+
+```haskell
+-- Applicative: all validations run
+validateUser form = User
+  <$> validateName form.name
+  <*> validateEmail form.email
+
+-- Monad: short-circuit on first error
+validateUser form = do
+  name <- validateName form.name
+  email <- validateEmail form.email
+  pure $ User name email
+```
+
+## Module Organization
+
+- Organize by domain feature, not code type
+- Split at ~300-500 lines or when import cycles emerge
+- `.Internal` modules for escape hatches (testing, debugging)
+- Types colocate with their operations
+
+## Error Handling
+
+Recoverable errors as data; programmer errors as exceptions.
+
+```haskell
+data ProcessingError
+  = InputError FilePath ValidationError
+  | TransformError Stage TransformError
+```
+
+Error wrapping adds context as errors propagate up.
+
+## Naming
+
+- `mk-` smart constructor, `un-` unwrapper, `run-` effect runner
+- Types are nouns describing the space (`Document`, `Request`)
+- Constructors are states/variants (`Pending`, `Validated`)
+
+## Complexity Budget
+
+Advanced features (GADTs, type families, DataKinds) earn their place in DSL/library internals to simplify user code. Bread-and-butter techniques first.

--- a/.claude/rules/rust.md
+++ b/.claude/rules/rust.md
@@ -1,0 +1,65 @@
+---
+paths:
+  - "**/*.rs"
+---
+
+# Functional Rust
+
+## Core Philosophy
+
+**Think -> Type -> Implement.** Sketch in comments, get types compiling with `todo!()`, then fill in implementation. Don't implement to discover - discover, then implement.
+
+```rust
+fn process(data: RawData) -> Result<Clean, Error> {
+    todo!("validate, transform, ensure invariants")
+}
+```
+
+## Type Design
+
+- Newtype pattern by default for domain concepts
+- Validate at construction: public constructor returns `Result`, private fields ensure invariants
+- Once a type exists, it's valid (`UserId::new(s)` validates, then `UserId` is always valid)
+- State transitions expressed through the type system
+
+## Iterator Chains
+
+Default to functional composition: `.iter().map().filter().collect()`
+
+Iterator chains are acts of communication - readable as declarative descriptions of intent. Use combinators for straightforward cases, pattern matching for complex logic.
+
+## Mutation & Cloning
+
+- `clone()` by default, `mut` only when performance is proven necessary
+- Local `&mut` is fine - controlled state transformation within scope
+- Mutation within function boundaries acceptable; APIs should appear immutable
+- Never use `unsafe` - restructure the design instead
+
+## Error Handling
+
+- `?` operator for propagation by default
+- `thiserror` for domain-specific error types
+- Structured errors over stringly-typed
+- Fail fast and loud with clear messages
+- Compose errors at module boundaries using `#[from]}
+
+## Module Organization
+
+- ~500 lines before considering a split
+- Orthogonality principle: separate things that could exist independently
+- Clear boundaries with focused responsibilities
+- Use visibility to highlight conceptual boundaries
+
+## Comments
+
+Comments describe what is, not what was. Git history tracks what was.
+
+```rust
+// BAD: "Changed from HashMap to BTreeMap for ordering"
+// GOOD: "Maintains sorted order for consistent iteration"
+
+// BAD: "Removed caching because it caused issues"
+// GOOD: No comment, or: "Direct fetch ensures fresh data"
+```
+
+If something was removed, don't comment about its absence.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,25 @@ The repository should be kept clean of dead code, placeholders, and half-done he
 
 Always prefer failure to an undocumented heuristic or fallback.
 
+### CROSSCUTTING RULES
+
+When you learn something that applies to a crosscutting context (a programming language, a tool like git worktrees, a pattern that spans directories), **create or update a `.claude/rules/*.md` file** rather than documenting it in a directory-specific CLAUDE.md.
+
+Examples of crosscutting concerns:
+- Language idioms (`.claude/rules/haskell.md`, `.claude/rules/rust.md`)
+- Tool usage patterns (git, cabal, cargo, zellij)
+- Architectural patterns that span the codebase
+
+Rules files use YAML frontmatter to scope when they load:
+```yaml
+---
+paths:
+  - "**/*.hs"
+---
+```
+
+Keep rules files focused and concise. If a rule only applies to one directory, put it in that directory's CLAUDE.md instead.
+
 ### AGGRESSIVE LOGGING
 
 Silent failures are unacceptable. When code shells out to subprocesses, calls external services, or crosses process/container boundaries, **log aggressively**:


### PR DESCRIPTION
## Summary

- Add `.claude/rules/haskell.md` with Applied Haskell patterns (path-scoped to `**/*.hs`)
- Add `.claude/rules/rust.md` with Functional Rust patterns (path-scoped to `**/*.rs`)
- Add "CROSSCUTTING RULES" section to CLAUDE.md instructing agents to create/update rules files for patterns that span directories

## What are rules files?

Claude Code's `.claude/rules/*.md` files are modular, topic-specific instructions that auto-load based on glob patterns. This replaces putting language-specific guidance in every CLAUDE.md.

**Haskell rules cover:** parse don't validate, illegal states unrepresentable, applicative over monad, newtype discipline, module organization, error handling patterns

**Rust rules cover:** think->type->implement workflow, iterator chains, clone by default, thiserror patterns, comment philosophy

## Test plan

- [ ] Run `/memory` in Claude Code to verify rules files load
- [ ] Edit a `.hs` file and confirm Haskell rules are in context
- [ ] Edit a `.rs` file and confirm Rust rules are in context

🤖 Generated with [Claude Code](https://claude.com/claude-code)