### PR TITLE
feat: Add semantic slug to zellij tab names

### DIFF
--- a/rust/exomonad-runtime/CLAUDE.md
+++ b/rust/exomonad-runtime/CLAUDE.md
@@ -79,18 +79,18 @@ Methods:
 
 **Spawn flow:**
 1. Fetch issue from GitHub API
-2. Create git worktree: `worktrees/gh-{issue}-{title}-{agent}/`
-3. Create branch: `gh-{issue}/{title}-{agent}`
+2. Create git worktree: `worktrees/gh-{issue}-{slug}-{agent}/`
+3. Create branch: `gh-{issue}/{slug}-{agent}`
 4. Write `.exomonad/config.toml` (role="dev") and `.mcp.json`
 5. Build initial prompt with full issue context
 6. Generate KDL layout with agent-specific command:
    - Claude: `claude --prompt '...'`
    - Gemini: `gemini --prompt-interactive '...'`
-7. Create Zellij tab: `zellij action new-tab --layout /tmp/exomonad-layouts/<name>.kdl`
+7. Create Zellij tab: `zellij action new-tab --layout /tmp/exomonad-layouts/<name>.kdl` (where name is exactly the worktree name)
 8. Tab auto-closes when agent exits (`close_on_exit true`)
 
 **Cleanup flow:**
-1. Close Zellij tab: `zellij action close-tab`
+1. Close Zellij tab: `zellij action close-tab` (using full worktree name)
 2. Remove git worktree: `git worktree remove`
 
 ### FileSystemService

--- a/rust/exomonad-runtime/src/services/agent_control.rs
+++ b/rust/exomonad-runtime/src/services/agent_control.rs
@@ -253,8 +253,7 @@ impl AgentControlService {
             );
 
             // Open Zellij tab with agent command and initial prompt
-            let tab_slug = slugify_short(&issue.title, 15);
-            let tab_name = format!("gh-{}-{}-{}", issue_id, tab_slug, agent_suffix);
+            let tab_name = format!("gh-{}-{}-{}", issue_id, slug, agent_suffix);
             self.new_zellij_tab(
                 &tab_name,
                 &worktree_path,
@@ -338,19 +337,9 @@ impl AgentControlService {
             let path = Path::new(&agent.worktree_path);
             if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
                 if name.starts_with(&prefix) {
-                    // Extract agent suffix from worktree name: gh-{issue}-{slug}-{agent}
-                    let parts: Vec<&str> = name.rsplitn(2, '-').collect();
-                    let agent_suffix = parts.first().unwrap_or(&"");
-
-                    // Extract slug to reconstruct tab name
-                    let gh_issue_slug = parts.get(1).unwrap_or(&"");
-                    let slug = gh_issue_slug.strip_prefix(&prefix).unwrap_or("");
-                    let short_slug = truncate_slug(slug, 15);
-
-                    // Close Zellij tab with correct agent suffix and short slug
-                    let tab_name = format!("gh-{}-{}-{}", issue_id, short_slug, agent_suffix);
-                    if let Err(e) = self.close_zellij_tab(&tab_name).await {
-                        warn!(tab_name, error = %e, "Failed to close Zellij tab (may not exist)");
+                    // Close Zellij tab with the full worktree name (which is also the tab name)
+                    if let Err(e) = self.close_zellij_tab(name).await {
+                        warn!(tab_name = name, error = %e, "Failed to close Zellij tab (may not exist)");
                     }
 
                     self.delete_worktree(path, force).await?;
@@ -956,27 +945,6 @@ fn slugify(title: &str) -> String {
         .collect()
 }
 
-/// Create a short URL-safe slug from a title.
-fn slugify_short(title: &str, max_chars: usize) -> String {
-    let slug = slugify(title);
-    truncate_slug(&slug, max_chars)
-}
-
-/// Truncate a slug to a maximum number of characters, trying to break at a hyphen.
-fn truncate_slug(slug: &str, max_chars: usize) -> String {
-    if slug.len() <= max_chars {
-        return slug.to_string();
-    }
-
-    let truncated: String = slug.chars().take(max_chars).collect();
-    if let Some(last_hyphen) = truncated.rfind('-') {
-        if last_hyphen > 0 {
-            return truncated[..last_hyphen].trim_end_matches('-').to_string();
-        }
-    }
-    truncated.trim_end_matches('-').to_string()
-}
-
 // ============================================================================ 
 // Host Functions for WASM
 // ============================================================================ 
@@ -1222,22 +1190,6 @@ mod tests {
         assert_eq!(slugify("Fix the Bug"), "fix-the-bug");
         assert_eq!(slugify("Add new feature!"), "add-new-feature");
         assert_eq!(slugify("CamelCase"), "camelcase");
-    }
-
-    #[test]
-    fn test_slugify_short() {
-        assert_eq!(slugify_short("Fix the Bug", 15), "fix-the-bug");
-        assert_eq!(slugify_short("Extremely long title that should be truncated", 15), "extremely-long");
-        assert_eq!(slugify_short("short", 15), "short");
-    }
-
-    #[test]
-    fn test_truncate_slug() {
-        assert_eq!(truncate_slug("fix-the-bug", 15), "fix-the-bug");
-        assert_eq!(truncate_slug("extremely-long-title", 15), "extremely-long");
-        assert_eq!(truncate_slug("extremely-long-title", 10), "extremely");
-        assert_eq!(truncate_slug("no-hyphens-here", 5), "no");
-        assert_eq!(truncate_slug("abc", 10), "abc");
     }
 
     #[test]


### PR DESCRIPTION
Uses full slug for Zellij tab names and simplifies cleanup logic.