### PR TITLE
fix: Clean up Rust lint warnings across codebase

### DIFF
--- a/rust/exomonad-plugin/src/main.rs
+++ b/rust/exomonad-plugin/src/main.rs
@@ -114,10 +114,6 @@ impl ratatui::backend::Backend for ZellijBackend {
 
         // Ensure we leave the terminal in a default style state after drawing.
         write!(buffer, "\x1b[0m").unwrap();
-        // Reset tracking state to match the terminal reset
-        current_fg = None;
-        current_bg = None;
-        current_mod = Modifier::empty();
 
         use std::io::Write as IoWrite;
         std::io::stdout().write_all(buffer.as_bytes())?;
@@ -262,14 +258,12 @@ impl ZellijPlugin for ExoMonadPlugin {
                                             state.values.get_mut(id)
                                         {
                                             s.push(c);
-                                            should_render = true;
                                             return true;
                                         }
                                     }
                                 } else if let BareKey::Backspace = key.bare_key {
                                     if let Some(ElementValue::Text(s)) = state.values.get_mut(id) {
                                         s.pop();
-                                        should_render = true;
                                         return true;
                                     }
                                 }
@@ -279,14 +273,12 @@ impl ZellijPlugin for ExoMonadPlugin {
                                     if let Some(ElementValue::Number(v)) = state.values.get_mut(id)
                                     {
                                         *v = (*v - 1.0).max(*min);
-                                        should_render = true;
                                         return true;
                                     }
                                 } else if let BareKey::Right = key.bare_key {
                                     if let Some(ElementValue::Number(v)) = state.values.get_mut(id)
                                     {
                                         *v = (*v + 1.0).min(*max);
-                                        should_render = true;
                                         return true;
                                     }
                                 }
@@ -295,13 +287,11 @@ impl ZellijPlugin for ExoMonadPlugin {
                                 if let BareKey::Left = key.bare_key {
                                     if self.sub_index > 0 {
                                         self.sub_index -= 1;
-                                        should_render = true;
                                         return true;
                                     }
                                 } else if let BareKey::Right = key.bare_key {
                                     if self.sub_index < options.len().saturating_sub(1) {
                                         self.sub_index += 1;
-                                        should_render = true;
                                         return true;
                                     }
                                 } else if let BareKey::Char(' ') = key.bare_key {
@@ -310,7 +300,6 @@ impl ZellijPlugin for ExoMonadPlugin {
                                     {
                                         if let Some(val) = vec.get_mut(self.sub_index) {
                                             *val = !*val;
-                                            should_render = true;
                                             return true;
                                         }
                                     }
@@ -627,15 +616,5 @@ fn evaluate_visibility(rule: &VisibilityRule, state: &PopupState) -> bool {
             true
         }
         _ => true,
-    }
-}
-
-trait KeyModifierExt {
-    fn has_modifiers(&self, modifiers: &[KeyModifier]) -> bool;
-}
-
-impl KeyModifierExt for KeyWithModifier {
-    fn has_modifiers(&self, modifiers: &[KeyModifier]) -> bool {
-        modifiers.iter().all(|m| self.key_modifiers.contains(m))
     }
 }

--- a/rust/exomonad-runtime/tests/ffi_property_tests.rs
+++ b/rust/exomonad-runtime/tests/ffi_property_tests.rs
@@ -127,7 +127,7 @@ where
 {
     let state: Arc<Mutex<Option<(I, O)>>> = Arc::new(Mutex::new(None));
     let host_fn = host_fn_factory(state.clone());
-    let mut plugin = build_test_plugin(host_fn);
+    let plugin = build_test_plugin(host_fn);
     
     let mut runner = TestRunner::new(Config::with_cases(10));
     
@@ -201,7 +201,7 @@ where
             let inner_arc = &*inner_arc_guard;
             
             // 2. Lock the inner mutex
-            let mut guard = inner_arc.lock().unwrap();
+            let guard = inner_arc.lock().unwrap();
             
             let (expected_input, output_val) = (*guard).as_ref().expect("State not set by test runner");
             


### PR DESCRIPTION
This PR fixes various Rust lint warnings identified in Issue #471.

Changes:
- Removed unused `mut` modifiers in `rust/exomonad-runtime/tests/ffi_property_tests.rs`.
- Removed redundant `should_render = true` assignments in `rust/exomonad-plugin/src/main.rs`.
- Removed unused variable assignments in `rust/exomonad-plugin/src/main.rs`.
- Removed redundant `KeyModifierExt` trait in `rust/exomonad-plugin/src/main.rs`.

Fixes #471.