### PR TITLE
fix: Address Copilot review comments from #482

### DIFF
--- a/rust/zellij-gen/CLAUDE.md
+++ b/rust/zellij-gen/CLAUDE.md
@@ -85,6 +85,8 @@ curl -sL "https://github.com/vdbulcke/ghost/releases/latest/download/ghost.wasm"
 curl -sL "https://github.com/karimould/zellij-forgot/releases/latest/download/zellij_forgot.wasm" -o zellij_forgot.wasm
 ```
 
+**Security note:** These commands download plugins from `releases/latest` URLs without checksum verification. For production environments, consider pinning to specific versioned releases and verifying checksums. The plugins run with access to your terminal session.
+
 ## Color Scheme: Solarized Dark
 
 | Role | Color | Hex | Usage |

--- a/rust/zellij-gen/src/main.rs
+++ b/rust/zellij-gen/src/main.rs
@@ -78,10 +78,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             // Determine output path
             let output_path = output.unwrap_or_else(|| {
-                // Sanitize tab name for filename
+                // Sanitize tab name for filename (ASCII-safe, consistent with agent_control.rs)
                 let safe_name: String = tab_name
                     .chars()
-                    .map(|c| if c.is_alphanumeric() || c == '-' || c == '_' { c } else { '-' })
+                    .map(|c| if c.is_ascii_alphanumeric() || c == '-' || c == '_' { c } else { '-' })
                     .collect();
                 PathBuf::from(OUTPUT_DIR).join(format!("{}.kdl", safe_name))
             });


### PR DESCRIPTION
## Summary

Follow-up fixes addressing Copilot review comments from #482 (Zellij UI overhaul).

### Changes

1. **Consistent character filtering** - Use `is_ascii_alphanumeric()` in `zellij-gen/main.rs` to match `agent_control.rs`

2. **Extract `parse_worktree_name()` helper** - Testable function for parsing worktree names with explicit validation

3. **Log warning for unknown agent suffix** - Instead of silently defaulting to Gemini, log a warning and skip tab close

4. **Add unit tests** - 5 new tests covering worktree name parsing edge cases:
   - Claude suffix
   - Gemini suffix  
   - Slug with hyphens
   - Unknown suffix
   - Invalid formats

5. **Security note** - Document that plugin downloads use `latest` URLs without checksum verification

## Test plan

- [x] `cargo test -p exomonad-runtime parse_worktree` - 5 tests pass
- [x] `cargo build -p zellij-gen -p exomonad-runtime` - builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)