### PR TITLE
Issue #535: list_agents report union of tab/worktree state + gh-based file_pr

### DIFF
--- a/docs/ffi-coverage-matrix.md
+++ b/docs/ffi-coverage-matrix.md
@@ -26,12 +26,12 @@
 | `agent_spawn_batch` | `SpawnAgentsInput` | `BatchSpawnResult` | 🟡 | `proptest_ffi.rs` (types only) |
 | `agent_cleanup` | `CleanupAgentInput` | `()` | 🟡 | `proptest_ffi.rs` (types only) |
 | `agent_cleanup_batch` | `CleanupAgentsInput` | `BatchCleanupResult` | 🟡 | `proptest_ffi.rs` (types only) |
-| `agent_list` | `ListAgentsInput` | `[AgentInfo]` | 🟡 | `proptest_ffi.rs` (types only) |
+| `agent_list` | `()` | `[AgentInfo]` | 🟢 | `proptest_ffi.rs`, `agent_control.rs` (unit tests) |
 | **Filesystem** | | | | |
 | `fs_read_file` | `ReadFileInput` | `ReadFileOutput` | 🟢 | `ffi_property_tests.rs` |
 | `fs_write_file` | `WriteFileInput` | `WriteFileOutput` | 🟢 | `ffi_property_tests.rs` |
 | **Other** | | | | |
-| `file_pr` | `FilePRInput` | `PR` | 🔴 | |
+| `file_pr` | `FilePRInput` | `FilePROutput` | 🟢 | `file_pr.rs` (octocrab) |
 | `wait_for_copilot_review` | `WaitForCopilotReviewInput` | `ReviewResult` | 🔴 | |
 
 ## Legend

--- a/haskell/wasm-guest/test/FFISerializationSpec.hs
+++ b/haskell/wasm-guest/test/FFISerializationSpec.hs
@@ -34,8 +34,23 @@ instance Arbitrary SpawnResult where
 instance Arbitrary AgentPrInfo where
   arbitrary = AgentPrInfo <$> arbitrary <*> arbText <*> arbText <*> arbText
 
+instance Arbitrary AgentStatus where
+  arbitrary = elements [RUNNING, ORPHAN_WORKTREE, ORPHAN_TAB]
+
 instance Arbitrary AgentInfo where
-  arbitrary = AgentInfo <$> arbText <*> arbText <*> arbText <*> arbitrary <*> arbMaybeText <*> arbMaybeText <*> arbitrary
+  arbitrary =
+    AgentInfo
+      <$> arbText
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbMaybeText
+      <*> arbMaybeText
+      <*> arbMaybeText
+      <*> arbMaybeText
+      <*> arbitrary
 
 instance Arbitrary BatchSpawnResult where
   arbitrary = BatchSpawnResult <$> listOf arbitrary <*> listOf ((,) <$> arbText <*> arbText)

--- a/rust/exomonad-runtime/tests/proptest_ffi.rs
+++ b/rust/exomonad-runtime/tests/proptest_ffi.rs
@@ -183,21 +183,38 @@ prop_compose! {
     }
 }
 
+fn arb_agent_status() -> BoxedStrategy<AgentStatus> {
+    prop_oneof![
+        Just(AgentStatus::Running),
+        Just(AgentStatus::OrphanWorktree),
+        Just(AgentStatus::OrphanTab),
+    ]
+    .boxed()
+}
+
 prop_compose! {
     fn arb_agent_info()(
         issue_id in "[0-9]+",
-        worktree_path in "/tmp/worktrees/[a-z0-9-]+",
-        branch_name in "gh-[0-9]+-[a-z0-9-]+",
-        has_changes in any::<bool>(),
+        has_tab in any::<bool>(),
+        has_worktree in any::<bool>(),
+        has_changes in proptest::option::of(any::<bool>()),
+        has_unpushed in proptest::option::of(any::<bool>()),
+        status in arb_agent_status(),
+        worktree_path in proptest::option::of("/tmp/worktrees/[a-z0-9-]+"),
+        branch_name in proptest::option::of("gh-[0-9]+-[a-z0-9-]+"),
         slug in proptest::option::of("[a-z0-9-]+"),
         agent_type in proptest::option::of(prop_oneof!["claude", "gemini"]),
         pr in proptest::option::of(arb_agent_pr_info()),
     ) -> AgentInfo {
         AgentInfo {
             issue_id,
+            has_tab,
+            has_worktree,
+            has_changes,
+            has_unpushed,
+            status,
             worktree_path,
             branch_name,
-            has_changes,
             slug,
             agent_type,
             pr,


### PR DESCRIPTION
## Summary

This PR addresses issue #535 by redesigning `list_agents` to report the **union** of all state sources (Zellij tabs and git worktrees) with explicit status flags. It also refactors the `file_pr` tool to use the `gh` CLI for improved idempotency and better integration with the local environment.

### Key Changes

#### 1. Redesigned `list_agents`
- Queries Zellij for active tab names.
- Computes union of issues from worktrees and tabs.
- Reports status: `RUNNING`, `ORPHAN_WORKTREE`, or `ORPHAN_TAB`.
- Includes `has_unpushed` and `has_changes` flags to help TL make cleanup decisions.

#### 2. Refactored `file_pr`
- Now uses `gh pr create` and `gh pr list` instead of direct `octocrab` calls.
- Automatically pushes the branch to origin before filing.
- Dynamically detects the base branch from the repository configuration.

#### 3. FFI and Testing
- Updated Haskell types and JSON instances in `wasm-guest`.
- Updated Rust proptests to cover new response structures.
- Verified all roundtrip serialization.

### Verification
- Ran unit tests for `agent_control.rs` and `file_pr.rs`.
- Verified FFI proptests pass.