### PR TITLE
fix(plugin): deduplicate inject-input across tab instances

### DIFF
--- a/rust/exomonad-plugin/src/main.rs
+++ b/rust/exomonad-plugin/src/main.rs
@@ -378,14 +378,13 @@ impl ZellijPlugin for ExoMonadPlugin {
                             }
                         };
 
-                        // Dedup: only the instance in the target tab should write
-                        let is_target_tab = self.own_tab_name.as_deref() == Some(tab_name);
-                        if !is_target_tab {
-                            // Not our tab — silently ignore
-                            if let PipeSource::Cli(id) = &pipe_message.source {
-                                unblock_cli_pipe_input(id);
+                        // Dedup: only the instance in the target tab should write.
+                        // If own_tab_name is None (before first PaneUpdate), fall through
+                        // to avoid silently dropping the message from all instances.
+                        if let Some(own_tab) = &self.own_tab_name {
+                            if own_tab != tab_name {
+                                return true;
                             }
-                            return true;
                         }
 
                         let text = match val["text"].as_str() {


### PR DESCRIPTION
## Summary
- Zellij broadcasts pipe messages to ALL instances of a plugin. Since exomonad-plugin runs as a status-bar in every tab, `inject-input` writes were duplicated N times (once per tab).
- Fix: each plugin instance tracks its own tab by correlating `get_plugin_ids()` pane ID against `PaneManifest`, then only acts on inject-input when the target tab matches its own tab.

## Test plan
- [ ] Build plugin: `cd rust/exomonad-plugin && cargo build --target wasm32-wasip1`
- [ ] Deploy to Zellij and verify inject-input writes happen exactly once per invocation
- [ ] Verify popup and event pipe handlers still work (unaffected by change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)