### PR TITLE
feat(core): composable handler group functions

### DIFF
--- a/rust/exomonad-core/src/effects/mod.rs
+++ b/rust/exomonad-core/src/effects/mod.rs
@@ -125,6 +125,11 @@ impl EffectRegistry {
         self.register(Arc::new(handler));
     }
 
+    /// Register a boxed effect handler.
+    pub fn register_boxed(&mut self, handler: Box<dyn EffectHandler>) {
+        self.register(Arc::from(handler));
+    }
+
     /// Dispatch an effect to the appropriate handler.
     ///
     /// Routes based on namespace prefix extracted from the effect type.

--- a/rust/exomonad-core/src/handlers/mod.rs
+++ b/rust/exomonad-core/src/handlers/mod.rs
@@ -24,6 +24,7 @@ pub mod file_pr;
 pub mod fs;
 pub mod git;
 pub mod github;
+pub mod groups;
 pub mod jj;
 pub mod kv;
 pub mod log;
@@ -40,6 +41,7 @@ pub use fs::FsHandler;
 
 pub use git::GitHandler;
 pub use github::GitHubHandler;
+pub use groups::{core_handlers, git_handlers, orchestration_handlers};
 pub use jj::JjHandler;
 pub use kv::KvHandler;
 pub use log::LogHandler;


### PR DESCRIPTION
## Summary
- Adds `core_handlers()`, `git_handlers()`, `orchestration_handlers()` as composable building blocks for library consumers
- Adds `RuntimeBuilder::with_handlers()` and `EffectRegistry::register_boxed()` for bulk registration
- Rewrites `register_builtin_handlers()` to delegate to group functions (no behavior change)

## Test plan
- [x] `cargo check -p exomonad-core` passes
- [x] `cargo check -p exomonad` passes (binary unchanged)
- [x] Unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)