### PR TITLE
docs: document session registry and fork-session feature

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,6 +309,15 @@ Human in Zellij session
 9. Claude Code proceeds or blocks
 ```
 
+**Session Start Hook:**
+```
+1. Claude Code starts (exomonad hook session-start)
+2. Server calls WASM handle_session_start
+3. Haskell yields SessionRegister effect with claude_session_id
+4. Server stores ID in in-memory ClaudeSessionRegistry
+5. Later, spawn_subtree uses this ID to enable --fork-session
+```
+
 **Fail-open:** If the server is unreachable, `exomonad hook` prints `{"continue":true}` and exits 0.
 
 ### Configuration
@@ -390,7 +399,7 @@ All tools are implemented in Haskell WASM (`haskell/wasm-guest/src/ExoMonad/Gues
 
 | Tool | Description |
 |------|-------------|
-| `spawn_subtree` | Fork a worktree node off your current branch (Claude-only). Creates isolated git worktree + Zellij tab. |
+| `spawn_subtree` | Fork a worktree node off your current branch (Claude-only). Creates isolated git worktree + Zellij tab. Auto-resolves parent session ID. |
 | `spawn_workers` | Spawn multiple ephemeral Gemini worker agents as panes in parent dir (no branch, no worktree) |
 | `spawn_leaf_subtree` | Spawn a Gemini agent in its own git worktree + branch + Zellij tab (isolated, files PR) |
 | `file_pr` | Create or update a PR for the current branch (auto-detects base branch from naming convention) |

--- a/haskell/wasm-guest/CLAUDE.md
+++ b/haskell/wasm-guest/CLAUDE.md
@@ -11,6 +11,7 @@ These are defined in `ExoMonad.Effects.*` and interpreted by the Rust host.
 - `GitHub`: GitHub API interactions (issues, PRs).
 - `Jj`: Jujutsu VCS operations (bookmark, push, fetch, log, new, status).
 - **`Events`**: Inter-agent synchronization (wait/notify).
+- **`Session`**: Session lifecycle management (register Claude session ID).
 - `Log`: Logging to the host console.
 - `FS`: File system access.
 - `Agent`: Agent lifecycle management.
@@ -36,3 +37,12 @@ The guest exports MCP tools that agents can call. These are defined in `ExoMonad
 - `popup`
 - `note`, `question` (dev role)
 - `get_agent_messages`, `answer_question` (TL role)
+
+## Hooks
+
+The guest handles hooks invoked by Claude Code:
+- **`onSessionStart`**: Captures Claude session ID and yields `SessionRegister` effect.
+- **`onPreToolUse`**: Validates tool calls (stops restricted tools).
+- **`onPostToolUse`**: Logs tool usage.
+- **`onSubagentStop`**: Validates child agent exit status.
+- **`onSessionEnd`**: Cleans up resources.

--- a/proto/CLAUDE.md
+++ b/proto/CLAUDE.md
@@ -19,7 +19,8 @@ proto/
     ├── fs.proto            # fs.* effects
     ├── agent.proto         # agent.* effects
     ├── jj.proto            # jj.* effects (Jujutsu VCS)
-    └── log.proto           # log.* effects
+    ├── log.proto           # log.* effects
+    └── session.proto       # session.* effects
 ```
 
 ## Codegen
@@ -203,6 +204,11 @@ Agent lifecycle (`agent.*` namespace):
 - `CleanupMerged`: Clean up agents with merged branches
 - `List`: List active agents
 
+### effects/session.proto
+
+Session management (`session.*` namespace):
+- `RegisterClaudeSession`: Register mapping between internal session ID and Claude UUID.
+
 ### effects/log.proto
 
 Logging and events (`log.*` namespace):
@@ -283,6 +289,7 @@ just proto-test  # Run wire format compatibility tests
 | fs.proto | ✅ | Pending | ✅ |
 | agent.proto | ✅ | ✅ | ✅ |
 | jj.proto | ✅ | ✅ | Pending |
+| session.proto | ✅ | ✅ | Pending |
 
 ## Related Files
 

--- a/rust/CLAUDE.md
+++ b/rust/CLAUDE.md
@@ -177,7 +177,7 @@ All tools are defined in Haskell WASM and executed via host functions.
 | `github_list_issues` | List GitHub issues |
 | `github_get_issue` | Get single issue details |
 | `github_list_prs` | List GitHub pull requests |
-| `spawn_subtree` | Fork a worktree node off current branch (Claude-only, creates `.exomonad/worktrees/{slug}/`) |
+| `spawn_subtree` | Fork a worktree node off current branch (Claude-only, creates `.exomonad/worktrees/{slug}/`). Auto-resolves session ID for --fork-session. |
 | `spawn_leaf_subtree` | Spawn Gemini agent in own worktree + branch + tab (isolated, files PR) |
 | `spawn_workers` | Spawn ephemeral Gemini agents as panes in parent dir (no branch, no worktree) |
 | `file_pr` | Create/update PR for current branch (auto-detects base branch from naming) |
@@ -220,6 +220,7 @@ Haskell: Either EffectError GetBranchResponse
 | `events.*` | EventHandler | wait_for_event, notify_event |
 | `jj.*` | JjHandler | bookmark_create, git_push, git_fetch, log, new, status |
 | `merge_pr.*` | MergePRHandler | merge_pr (gh pr merge + jj git fetch) |
+| `session.*` | SessionHandler | register_claude_id |
 
 **Zellij Integration:**
 - Uses declarative KDL layouts (not CLI flags)

--- a/rust/exomonad-core/src/handlers/CLAUDE.md
+++ b/rust/exomonad-core/src/handlers/CLAUDE.md
@@ -24,3 +24,14 @@ This allows worker agents running in isolated processes (or even machines) to no
 - The handler is initialized with an optional `session_id`.
 - If not provided, it defaults to `"default"`.
 - This ID is used to scope event queues, ensuring events are delivered to the correct listener.
+
+## SessionHandler (`handlers/session.rs`)
+
+Handles effects in the `session.*` namespace.
+
+### Capabilities
+
+- **`register_claude_id`**: Registers a mapping between a session's unique ID and its Claude Code session UUID.
+  - This is called by the `SessionStart` hook handler in WASM.
+  - The ID is stored in the `ClaudeSessionRegistry`.
+  - Used by `spawn_subtree` to resolve the parent's Claude session ID when spawning children with `--resume --fork-session`.

--- a/rust/exomonad/CLAUDE.md
+++ b/rust/exomonad/CLAUDE.md
@@ -165,6 +165,23 @@ Claude Code hook JSON (stdin)
     Claude Code receives response
 ```
 
+**Session Start Flow:**
+```
+Claude Code hook session-start (stdin)
+         ↓
+    exomonad hook session-start (thin HTTP client)
+         ↓
+    HTTP POST localhost:{port}/hook?event=session-start&runtime=claude
+         ↓
+    Server: call WASM handle_session_start
+         ↓
+    Haskell yields SessionRegister effect
+         ↓
+    Server registers Claude session ID in memory (for spawn_subtree)
+         ↓
+    Server returns success
+```
+
 ## Related Documentation
 
 - **[exomonad-core](../exomonad-core/)** - Framework, handlers, services, protocol types, UI protocol


### PR DESCRIPTION
Updates documentation to reflect the new Claude session ID registration and fork-session feature.

## Changes
- Updated CLAUDE.md files to include session registry and fork-session details.
- Added session.proto to effects structure in proto/CLAUDE.md.
- Updated spawn_subtree description in root CLAUDE.md.
