### PR TITLE
feat: type system hardening — newtypes, enums, and unit tests

### DIFF
--- a/rust/exomonad-core/src/handlers/agent.rs
+++ b/rust/exomonad-core/src/handlers/agent.rs
@@ -207,7 +207,7 @@ impl AgentEffects for AgentHandler {
                     "No Claude session UUID registered — child will start without --fork-session context. Ensure SessionStart hook is configured."
                 );
             }
-            claude_uuid
+            claude_uuid.map(|s| ClaudeSessionUuid::from(s.as_str()))
         } else if !req.parent_session_id.is_empty() {
             Some(ClaudeSessionUuid::from(req.parent_session_id.as_str()))
         } else {

--- a/rust/exomonad-core/src/protocol/hook.rs
+++ b/rust/exomonad-core/src/protocol/hook.rs
@@ -574,6 +574,20 @@ mod tests {
     }
 
     #[test]
+    fn test_hook_input_unknown_permission_mode() {
+        let json = r#"{"session_id":"s","hook_event_name":"Stop","permission_mode":"futureMode"}"#;
+        let input: HookInput = serde_json::from_str(json).unwrap();
+        assert_eq!(input.permission_mode, PermissionMode::Default);
+    }
+
+    #[test]
+    fn test_hook_input_missing_permission_mode() {
+        let json = r#"{"session_id":"s","hook_event_name":"Stop"}"#;
+        let input: HookInput = serde_json::from_str(json).unwrap();
+        assert_eq!(input.permission_mode, PermissionMode::Default);
+    }
+
+    #[test]
     fn test_hook_input_all_fields() {
         let json = r#"{
             "session_id": "sess-123",

--- a/rust/exomonad-core/src/protocol/mcp.rs
+++ b/rust/exomonad-core/src/protocol/mcp.rs
@@ -27,3 +27,24 @@ pub struct McpError {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub suggestion: Option<String>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tool_definition_serde_roundtrip() {
+        let td = ToolDefinition {
+            name: ToolName::from("spawn_subtree"),
+            description: "Fork a worktree".into(),
+            input_schema: serde_json::json!({"type": "object"}),
+        };
+        let json = serde_json::to_value(&td).unwrap();
+        assert_eq!(json["name"], "spawn_subtree");
+        assert_eq!(json["inputSchema"]["type"], "object");
+        assert!(!json.as_object().unwrap().contains_key("input_schema"));
+
+        let back: ToolDefinition = serde_json::from_value(json).unwrap();
+        assert_eq!(back.name.as_str(), "spawn_subtree");
+    }
+}

--- a/rust/exomonad-core/src/services/git.rs
+++ b/rust/exomonad-core/src/services/git.rs
@@ -346,4 +346,32 @@ mod tests {
         // Empty string
         assert_eq!(extract_agent_id(""), None);
     }
+
+    #[test]
+    fn test_parse_github_url_https() {
+        let (owner, repo) = parse_github_url("https://github.com/anthropics/claude-code").unwrap();
+        assert_eq!(owner.as_str(), "anthropics");
+        assert_eq!(repo.as_str(), "claude-code");
+    }
+
+    #[test]
+    fn test_parse_github_url_ssh() {
+        let (owner, repo) = parse_github_url("git@github.com:anthropics/claude-code.git").unwrap();
+        assert_eq!(owner.as_str(), "anthropics");
+        assert_eq!(repo.as_str(), "claude-code");
+    }
+
+    #[test]
+    fn test_parse_github_url_with_git_suffix() {
+        let (owner, repo) =
+            parse_github_url("https://github.com/anthropics/claude-code.git").unwrap();
+        assert_eq!(owner.as_str(), "anthropics");
+        assert_eq!(repo.as_str(), "claude-code");
+    }
+
+    #[test]
+    fn test_parse_github_url_invalid() {
+        assert!(parse_github_url("not-a-url").is_none());
+        assert!(parse_github_url("").is_none());
+    }
 }


### PR DESCRIPTION
## Summary
- Replace stringly-typed domain values with validated newtypes (`GithubOwner`, `GithubRepo`, `ToolName` in `ToolDefinition`, `FilterState`, `MessageFilter`, `PermissionMode`)
- Add custom `Deserialize` for `PermissionMode` that falls back to `Default` for unknown wire values (forward compatibility)
- Add 13 new unit tests covering serde roundtrips, unknown-value fallback, and `parse_github_url`
- Fix stale `with_event_session_id` call in main.rs

## Test plan
- [x] All 251 lib tests pass (`cargo test -p exomonad-core --lib`)
- [x] Full pre-push checks pass (fmt, cargo check all targets, WASM build)
- [x] `PermissionMode` unknown values deserialize to `Default` (not error)
- [x] `FilterState` rejects unknown values (strict enum)
- [x] `ToolDefinition` serializes `input_schema` as `inputSchema` on wire

🤖 Generated with [Claude Code](https://claude.com/claude-code)