### PR TITLE
Migrate JjHandler to jj-lib for bookmark and git operations

### DIFF
--- a/rust/exomonad-core/src/handlers/groups.rs
+++ b/rust/exomonad-core/src/handlers/groups.rs
@@ -10,6 +10,7 @@ use crate::services::event_queue::EventQueue;
 use crate::services::filesystem::FileSystemService;
 use crate::services::git::GitService;
 use crate::services::github::GitHubService;
+use crate::services::jj_workspace::JjWorkspaceService;
 use crate::services::questions::QuestionRegistry;
 
 use super::{
@@ -43,10 +44,11 @@ pub fn core_handlers(
 pub fn git_handlers(
     git: Arc<GitService>,
     github: Option<GitHubService>,
+    jj: Arc<JjWorkspaceService>,
 ) -> Vec<Box<dyn EffectHandler>> {
     let mut handlers: Vec<Box<dyn EffectHandler>> = vec![
         Box::new(GitHandler::new(git)),
-        Box::new(JjHandler),
+        Box::new(JjHandler::new(jj)),
         Box::new(FilePRHandler::new()),
         Box::new(MergePRHandler),
         Box::new(CopilotHandler::new()),

--- a/rust/exomonad-core/src/lib.rs
+++ b/rust/exomonad-core/src/lib.rs
@@ -33,7 +33,7 @@
 //! let mut builder = RuntimeBuilder::new()
 //!     .with_wasm_path(wasm_path)
 //!     .with_handlers(core_handlers(project_dir.clone(), None))
-//!     .with_handlers(git_handlers(git, github));
+//!     .with_handlers(git_handlers(git, github, jj));
 //!
 //! // Add custom domain handlers
 //! builder = builder.with_effect_handler(MyDomainHandler::new());

--- a/rust/exomonad/src/main.rs
+++ b/rust/exomonad/src/main.rs
@@ -887,6 +887,9 @@ async fn main() -> Result<()> {
             let github = secrets
                 .github_token()
                 .and_then(|t| exomonad_core::services::github::GitHubService::new(t).ok());
+            let jj = Arc::new(exomonad_core::services::jj_workspace::JjWorkspaceService::new(
+                project_dir.clone(),
+            ));
 
             if github.is_some() {
                 exomonad_core::services::validate_gh_cli().context("Failed to validate gh CLI")?;
@@ -954,7 +957,7 @@ async fn main() -> Result<()> {
                 project_dir.clone(),
                 event_log.clone(),
             ));
-            builder = builder.with_handlers(exomonad_core::git_handlers(git, github));
+            builder = builder.with_handlers(exomonad_core::git_handlers(git, github, jj));
             let (orch_handlers, question_registry) = exomonad_core::orchestration_handlers(
                 agent_control.clone(),
                 event_queue.clone(),


### PR DESCRIPTION
Migrated JjHandler from CLI subprocess calls to jj-lib for bookmark_create, git_push, and git_fetch.
Other methods (log, new, status) remain as CLI calls.
Updated JjHandler to take Arc<JjWorkspaceService> and updated git_handlers accordingly.
Updated the main runner in rust/exomonad/src/main.rs to instantiate and provide the JjWorkspaceService.