### PR TITLE
Add handler macro for pass-through pattern and refactor log.rs

### DIFF
--- a/rust/exomonad-core/src/handlers/fs.rs
+++ b/rust/exomonad-core/src/handlers/fs.rs
@@ -3,7 +3,7 @@
 //! Uses proto-generated types from `exomonad_proto::effects::fs`.
 
 use crate::effects::{
-    dispatch_fs_effect, EffectError, EffectHandler, EffectResult, FilesystemEffects, ResultExt,
+    dispatch_fs_effect, EffectError, EffectResult, FilesystemEffects, ResultExt,
 };
 use crate::services::filesystem::FileSystemService;
 use async_trait::async_trait;
@@ -24,21 +24,7 @@ impl FsHandler {
     }
 }
 
-#[async_trait]
-impl EffectHandler for FsHandler {
-    fn namespace(&self) -> &str {
-        "fs"
-    }
-
-    async fn handle(
-        &self,
-        effect_type: &str,
-        payload: &[u8],
-        ctx: &crate::effects::EffectContext,
-    ) -> EffectResult<Vec<u8>> {
-        dispatch_fs_effect(self, effect_type, payload, ctx).await
-    }
-}
+crate::impl_pass_through_handler!(FsHandler, "fs", dispatch_fs_effect);
 
 #[async_trait]
 impl FilesystemEffects for FsHandler {

--- a/rust/exomonad-core/src/handlers/git.rs
+++ b/rust/exomonad-core/src/handlers/git.rs
@@ -4,7 +4,7 @@
 
 use super::working_dir_or_default;
 use crate::effects::{
-    dispatch_git_effect, EffectHandler, EffectResult, GitEffects, ResultExt,
+    dispatch_git_effect, EffectResult, GitEffects, ResultExt,
 };
 use crate::services::git::GitService;
 use async_trait::async_trait;
@@ -27,21 +27,7 @@ impl GitHandler {
     }
 }
 
-#[async_trait]
-impl EffectHandler for GitHandler {
-    fn namespace(&self) -> &str {
-        "git"
-    }
-
-    async fn handle(
-        &self,
-        effect_type: &str,
-        payload: &[u8],
-        ctx: &crate::effects::EffectContext,
-    ) -> EffectResult<Vec<u8>> {
-        dispatch_git_effect(self, effect_type, payload, ctx).await
-    }
-}
+crate::impl_pass_through_handler!(GitHandler, "git", dispatch_git_effect);
 
 #[async_trait]
 impl GitEffects for GitHandler {

--- a/rust/exomonad-core/src/handlers/jj.rs
+++ b/rust/exomonad-core/src/handlers/jj.rs
@@ -7,7 +7,7 @@
 use super::{non_empty, working_dir_or_default, working_dir_path_or_default};
 use crate::domain::{BranchName, Revision};
 use crate::effects::{
-    dispatch_jj_effect, EffectHandler, EffectResult, JjEffects, ResultExt,
+    dispatch_jj_effect, EffectResult, JjEffects, ResultExt,
     spawn_blocking_effect,
 };
 use crate::services::jj_workspace::JjWorkspaceService;
@@ -27,21 +27,7 @@ impl JjHandler {
     }
 }
 
-#[async_trait]
-impl EffectHandler for JjHandler {
-    fn namespace(&self) -> &str {
-        "jj"
-    }
-
-    async fn handle(
-        &self,
-        effect_type: &str,
-        payload: &[u8],
-        ctx: &crate::effects::EffectContext,
-    ) -> EffectResult<Vec<u8>> {
-        dispatch_jj_effect(self, effect_type, payload, ctx).await
-    }
-}
+crate::impl_pass_through_handler!(JjHandler, "jj", dispatch_jj_effect);
 
 #[async_trait]
 impl JjEffects for JjHandler {

--- a/rust/exomonad-core/src/handlers/kv.rs
+++ b/rust/exomonad-core/src/handlers/kv.rs
@@ -3,7 +3,7 @@
 //! Stores values as JSON files under `.exo/kv/{key}.json`.
 //! Keys are validated to contain only alphanumeric characters, underscores, and hyphens.
 
-use crate::effects::{dispatch_kv_effect, EffectError, EffectHandler, EffectResult, KvEffects};
+use crate::effects::{dispatch_kv_effect, EffectError, EffectResult, KvEffects};
 use async_trait::async_trait;
 use exomonad_proto::effects::kv::*;
 use std::path::PathBuf;
@@ -49,21 +49,7 @@ impl KvHandler {
     }
 }
 
-#[async_trait]
-impl EffectHandler for KvHandler {
-    fn namespace(&self) -> &str {
-        "kv"
-    }
-
-    async fn handle(
-        &self,
-        effect_type: &str,
-        payload: &[u8],
-        ctx: &crate::effects::EffectContext,
-    ) -> EffectResult<Vec<u8>> {
-        dispatch_kv_effect(self, effect_type, payload, ctx).await
-    }
-}
+crate::impl_pass_through_handler!(KvHandler, "kv", dispatch_kv_effect);
 
 #[async_trait]
 impl KvEffects for KvHandler {

--- a/rust/exomonad-core/src/handlers/merge_pr.rs
+++ b/rust/exomonad-core/src/handlers/merge_pr.rs
@@ -1,5 +1,5 @@
 use crate::effects::{
-    dispatch_merge_pr_effect, EffectHandler, EffectResult, MergePrEffects, ResultExt,
+    dispatch_merge_pr_effect, EffectResult, MergePrEffects, ResultExt,
 };
 use crate::services::jj_workspace::JjWorkspaceService;
 use crate::services::merge_pr;
@@ -17,20 +17,7 @@ impl MergePRHandler {
     }
 }
 
-#[async_trait]
-impl EffectHandler for MergePRHandler {
-    fn namespace(&self) -> &str {
-        "merge_pr"
-    }
-    async fn handle(
-        &self,
-        effect_type: &str,
-        payload: &[u8],
-        ctx: &crate::effects::EffectContext,
-    ) -> EffectResult<Vec<u8>> {
-        dispatch_merge_pr_effect(self, effect_type, payload, ctx).await
-    }
-}
+crate::impl_pass_through_handler!(MergePRHandler, "merge_pr", dispatch_merge_pr_effect);
 
 #[async_trait]
 impl MergePrEffects for MergePRHandler {

--- a/rust/exomonad-core/src/handlers/mod.rs
+++ b/rust/exomonad-core/src/handlers/mod.rs
@@ -76,3 +76,31 @@ pub fn working_dir_path_or_default(dir: &str) -> std::path::PathBuf {
         std::path::PathBuf::from(dir)
     }
 }
+
+// ============================================================================
+// Macro helpers
+// ============================================================================
+
+/// Macro for simple pass-through effect handlers.
+///
+/// Implements [`EffectHandler`] for a struct by delegating to a dispatch function.
+#[macro_export]
+macro_rules! impl_pass_through_handler {
+    ($handler:ident, $namespace:literal, $dispatch:ident) => {
+        #[async_trait::async_trait]
+        impl $crate::effects::EffectHandler for $handler {
+            fn namespace(&self) -> &str {
+                $namespace
+            }
+
+            async fn handle(
+                &self,
+                effect_type: &str,
+                payload: &[u8],
+                ctx: &$crate::effects::EffectContext,
+            ) -> $crate::effects::EffectResult<Vec<u8>> {
+                $dispatch(self, effect_type, payload, ctx).await
+            }
+        }
+    };
+}

--- a/rust/exomonad-core/src/handlers/popup.rs
+++ b/rust/exomonad-core/src/handlers/popup.rs
@@ -3,7 +3,7 @@
 //! Uses proto-generated types from `exomonad_proto::effects::popup`.
 
 use crate::effects::{
-    dispatch_popup_effect, EffectError, EffectHandler, EffectResult, PopupEffects, ResultExt,
+    dispatch_popup_effect, EffectError, EffectResult, PopupEffects, ResultExt,
 };
 use crate::services::popup::{PopupInput, PopupService};
 use async_trait::async_trait;
@@ -23,21 +23,7 @@ impl PopupHandler {
     }
 }
 
-#[async_trait]
-impl EffectHandler for PopupHandler {
-    fn namespace(&self) -> &str {
-        "popup"
-    }
-
-    async fn handle(
-        &self,
-        effect_type: &str,
-        payload: &[u8],
-        ctx: &crate::effects::EffectContext,
-    ) -> EffectResult<Vec<u8>> {
-        dispatch_popup_effect(self, effect_type, payload, ctx).await
-    }
-}
+crate::impl_pass_through_handler!(PopupHandler, "popup", dispatch_popup_effect);
 
 #[async_trait]
 impl PopupEffects for PopupHandler {

--- a/rust/exomonad-core/src/handlers/session.rs
+++ b/rust/exomonad-core/src/handlers/session.rs
@@ -3,7 +3,7 @@
 //! Stores Claude Code session UUIDs so spawn_subtree can use --resume --fork-session.
 
 use crate::domain::ClaudeSessionUuid;
-use crate::effects::{dispatch_session_effect, EffectHandler, EffectResult, SessionEffects};
+use crate::effects::{dispatch_session_effect, EffectResult, SessionEffects};
 use crate::services::claude_session_registry::ClaudeSessionRegistry;
 use async_trait::async_trait;
 use exomonad_proto::effects::session::*;
@@ -21,21 +21,7 @@ impl SessionHandler {
     }
 }
 
-#[async_trait]
-impl EffectHandler for SessionHandler {
-    fn namespace(&self) -> &str {
-        "session"
-    }
-
-    async fn handle(
-        &self,
-        effect_type: &str,
-        payload: &[u8],
-        ctx: &crate::effects::EffectContext,
-    ) -> EffectResult<Vec<u8>> {
-        dispatch_session_effect(self, effect_type, payload, ctx).await
-    }
-}
+crate::impl_pass_through_handler!(SessionHandler, "session", dispatch_session_effect);
 
 #[async_trait]
 impl SessionEffects for SessionHandler {


### PR DESCRIPTION
This PR introduces a impl_pass_through_handler! macro in rust/exomonad-core/src/handlers/mod.rs to reduce boilerplate in simple effect handlers.