### PR TITLE
refactor: replace auto-filing stop hook with context-aware nudges

### DIFF
--- a/haskell/wasm-guest/src/ExoMonad/Effects/GitHub.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Effects/GitHub.hs
@@ -25,6 +25,7 @@ module ExoMonad.Effects.GitHub
     GitHubListPullRequests,
     GitHubGetPullRequest,
     GitHubGetPullRequestForBranch,
+    GitHubGetPullRequestReviewComments,
     GitHubCreatePullRequest,
 
     -- * Smart Constructors
@@ -33,6 +34,7 @@ module ExoMonad.Effects.GitHub
     listPullRequests,
     getPullRequest,
     getPullRequestForBranch,
+    getPullRequestReviewComments,
     createPullRequest,
 
     -- * Re-exported proto types
@@ -83,6 +85,13 @@ instance Effect GitHubGetPullRequestForBranch where
   type Output GitHubGetPullRequestForBranch = GetPullRequestForBranchResponse
   effectId = "github.get_pull_request_for_branch"
 
+data GitHubGetPullRequestReviewComments
+
+instance Effect GitHubGetPullRequestReviewComments where
+  type Input GitHubGetPullRequestReviewComments = GetPullRequestReviewCommentsRequest
+  type Output GitHubGetPullRequestReviewComments = GetPullRequestReviewCommentsResponse
+  effectId = "github.get_pull_request_review_comments"
+
 data GitHubCreatePullRequest
 
 instance Effect GitHubCreatePullRequest where
@@ -108,6 +117,9 @@ getPullRequest = runEffect @GitHubGetPullRequest
 
 getPullRequestForBranch :: GetPullRequestForBranchRequest -> IO (Either EffectError GetPullRequestForBranchResponse)
 getPullRequestForBranch = runEffect @GitHubGetPullRequestForBranch
+
+getPullRequestReviewComments :: GetPullRequestReviewCommentsRequest -> IO (Either EffectError GetPullRequestReviewCommentsResponse)
+getPullRequestReviewComments = runEffect @GitHubGetPullRequestReviewComments
 
 createPullRequest :: CreatePullRequestRequest -> IO (Either EffectError CreatePullRequestResponse)
 createPullRequest = runEffect @GitHubCreatePullRequest


### PR DESCRIPTION
## Summary
- Delete `autoFilePR` — stop hook no longer auto-files PRs (was flaky, raced with agent's own file_pr)
- Delete blocking check pipeline (`runChecks`, `CheckResult`, `checkReviewCommentsInner`)
- Replace with `performNudges`: gathers context and logs informational messages
- Stop hook **never blocks** — always returns exit 0
- Add `GitHubGetPullRequestReviewComments` effect for checking review state

## Nudge logic
| Context | Message |
|---------|---------|
| PR with unresolved comments | "PR #N has unresolved review comments." |
| PR open, no reviews | "PR #N is open but hasn't been reviewed yet." |
| No PR + uncommitted changes | "You have uncommitted changes on {branch} but no PR filed." |
| No PR + unpushed commits | "Commits on {branch} aren't in a PR yet." |
| Everything clean | Silent |

## Test plan
- [ ] Stop on main branch: no nudge, clean exit
- [ ] Stop on feature branch with PR: appropriate nudge
- [ ] Stop on feature branch without PR: appropriate nudge
- [ ] Verify `just wasm-all` builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)