### PR TITLE
Add Claude Teams integration for native inter-agent messaging

### DIFF
--- a/haskell/proto/src/Effects/Session.hs
+++ b/haskell/proto/src/Effects/Session.hs
@@ -168,3 +168,152 @@ instance (HsJSONPB.ToJSON RegisterClaudeSessionResponse) where
 
 instance (HsJSONPB.FromJSON RegisterClaudeSessionResponse) where
   parseJSON = HsJSONPB.parseJSONPB
+
+data RegisterTeamRequest = RegisterTeamRequest
+  { registerTeamRequestTeamName :: Hs.Text,
+    registerTeamRequestInboxName :: Hs.Text
+  }
+  deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)
+
+instance (Hs.NFData RegisterTeamRequest)
+
+instance (HsProtobuf.Named RegisterTeamRequest) where
+  nameOf _ = Hs.fromString "RegisterTeamRequest"
+
+instance (HsProtobuf.HasDefault RegisterTeamRequest)
+
+instance (HsProtobuf.Message RegisterTeamRequest) where
+  encodeMessage
+    _
+    RegisterTeamRequest {registerTeamRequestTeamName, registerTeamRequestInboxName} =
+      ( HsProtobuf.encodeMessageField
+          (HsProtobuf.FieldNumber 1)
+          ( (Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
+              registerTeamRequestTeamName
+          )
+      )
+        Hs.<> ( HsProtobuf.encodeMessageField
+                  (HsProtobuf.FieldNumber 2)
+                  ( (Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
+                      registerTeamRequestInboxName
+                  )
+              )
+  decodeMessage _ =
+    Hs.pure RegisterTeamRequest
+      <*> ( (HsProtobuf.coerceOver @(HsProtobuf.String Hs.Text) @Hs.Text)
+              ( HsProtobuf.at
+                  HsProtobuf.decodeMessageField
+                  (HsProtobuf.FieldNumber 1)
+              )
+          )
+      <*> ( (HsProtobuf.coerceOver @(HsProtobuf.String Hs.Text) @Hs.Text)
+              ( HsProtobuf.at
+                  HsProtobuf.decodeMessageField
+                  (HsProtobuf.FieldNumber 2)
+              )
+          )
+  dotProto _ =
+    [ HsProtobufAST.DotProtoField
+        (HsProtobuf.FieldNumber 1)
+        (HsProtobufAST.Prim HsProtobufAST.String)
+        (HsProtobufAST.Single "team_name")
+        []
+        "",
+      HsProtobufAST.DotProtoField
+        (HsProtobuf.FieldNumber 2)
+        (HsProtobufAST.Prim HsProtobufAST.String)
+        (HsProtobufAST.Single "inbox_name")
+        []
+        ""
+    ]
+
+instance (HsJSONPB.ToJSONPB RegisterTeamRequest) where
+  toJSONPB (RegisterTeamRequest f1 f2) =
+    HsJSONPB.object
+      [ "team_name"
+          .= ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text)) f1),
+        "inbox_name"
+          .= ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text)) f2)
+      ]
+  toEncodingPB (RegisterTeamRequest f1 f2) =
+    HsJSONPB.pairs
+      [ "team_name"
+          .= ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text)) f1),
+        "inbox_name"
+          .= ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text)) f2)
+      ]
+
+instance (HsJSONPB.FromJSONPB RegisterTeamRequest) where
+  parseJSONPB =
+    HsJSONPB.withObject
+      "RegisterTeamRequest"
+      ( \obj ->
+          Hs.pure RegisterTeamRequest
+            <*> ( (HsProtobuf.coerceOver @(HsProtobuf.String Hs.Text) @Hs.Text)
+                    (obj .: "team_name")
+                )
+            <*> ( (HsProtobuf.coerceOver @(HsProtobuf.String Hs.Text) @Hs.Text)
+                    (obj .: "inbox_name")
+                )
+      )
+
+instance (HsJSONPB.ToJSON RegisterTeamRequest) where
+  toJSON = HsJSONPB.toAesonValue
+  toEncoding = HsJSONPB.toAesonEncoding
+
+instance (HsJSONPB.FromJSON RegisterTeamRequest) where
+  parseJSON = HsJSONPB.parseJSONPB
+
+newtype RegisterTeamResponse
+  = RegisterTeamResponse {registerTeamResponseSuccess :: Hs.Bool}
+  deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)
+
+instance (Hs.NFData RegisterTeamResponse)
+
+instance (HsProtobuf.Named RegisterTeamResponse) where
+  nameOf _ = Hs.fromString "RegisterTeamResponse"
+
+instance (HsProtobuf.HasDefault RegisterTeamResponse)
+
+instance (HsProtobuf.Message RegisterTeamResponse) where
+  encodeMessage
+    _
+    RegisterTeamResponse {registerTeamResponseSuccess} =
+      ( HsProtobuf.encodeMessageField
+          (HsProtobuf.FieldNumber 1)
+          registerTeamResponseSuccess
+      )
+  decodeMessage _ =
+    Hs.pure RegisterTeamResponse
+      <*> HsProtobuf.at
+        HsProtobuf.decodeMessageField
+        (HsProtobuf.FieldNumber 1)
+  dotProto _ =
+    [ HsProtobufAST.DotProtoField
+        (HsProtobuf.FieldNumber 1)
+        (HsProtobufAST.Prim HsProtobufAST.Bool)
+        (HsProtobufAST.Single "success")
+        []
+        ""
+    ]
+
+instance (HsJSONPB.ToJSONPB RegisterTeamResponse) where
+  toJSONPB (RegisterTeamResponse f1) =
+    HsJSONPB.object ["success" .= f1]
+  toEncodingPB (RegisterTeamResponse f1) =
+    HsJSONPB.pairs ["success" .= f1]
+
+instance (HsJSONPB.FromJSONPB RegisterTeamResponse) where
+  parseJSONPB =
+    HsJSONPB.withObject
+      "RegisterTeamResponse"
+      ( \obj ->
+          Hs.pure RegisterTeamResponse <*> obj .: "success"
+      )
+
+instance (HsJSONPB.ToJSON RegisterTeamResponse) where
+  toJSON = HsJSONPB.toAesonValue
+  toEncoding = HsJSONPB.toAesonEncoding
+
+instance (HsJSONPB.FromJSON RegisterTeamResponse) where
+  parseJSON = HsJSONPB.parseJSONPB

--- a/haskell/wasm-guest/src/ExoMonad/Effects/Session.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Effects/Session.hs
@@ -1,10 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeFamilies #-}
 
--- | Session effects for registering Claude Code session IDs.
+-- | Session effects for registering Claude Code session IDs and Teams info.
 module ExoMonad.Effects.Session
   ( SessionRegisterClaudeId,
     registerClaudeSession,
+    SessionRegisterTeam,
+    registerTeam,
   )
 where
 
@@ -27,4 +29,21 @@ registerClaudeSession claudeSessionId =
   runEffect @SessionRegisterClaudeId $
     Proto.RegisterClaudeSessionRequest
       { Proto.registerClaudeSessionRequestClaudeSessionId = fromText claudeSessionId
+      }
+
+-- | Register Claude Teams info effect.
+data SessionRegisterTeam
+
+instance Effect SessionRegisterTeam where
+  type Input SessionRegisterTeam = Proto.RegisterTeamRequest
+  type Output SessionRegisterTeam = Proto.RegisterTeamResponse
+  effectId = "session.register_team"
+
+-- | Register Claude Teams info for inbox-based message delivery.
+registerTeam :: Text -> Text -> IO (Either EffectError Proto.RegisterTeamResponse)
+registerTeam teamName inboxName =
+  runEffect @SessionRegisterTeam $
+    Proto.RegisterTeamRequest
+      { Proto.registerTeamRequestTeamName = fromText teamName,
+        Proto.registerTeamRequestInboxName = fromText inboxName
       }

--- a/proto/effects/session.proto
+++ b/proto/effects/session.proto
@@ -9,6 +9,16 @@ message RegisterClaudeSessionResponse {
   bool success = 1;
 }
 
+message RegisterTeamRequest {
+  string team_name = 1;
+  string inbox_name = 2;
+}
+
+message RegisterTeamResponse {
+  bool success = 1;
+}
+
 service SessionEffects {
   rpc RegisterClaudeId(RegisterClaudeSessionRequest) returns (RegisterClaudeSessionResponse);
+  rpc RegisterTeam(RegisterTeamRequest) returns (RegisterTeamResponse);
 }

--- a/rust/exomonad-core/src/handlers/session.rs
+++ b/rust/exomonad-core/src/handlers/session.rs
@@ -1,10 +1,12 @@
 //! Session effect handler for the `session.*` namespace.
 //!
 //! Stores Claude Code session UUIDs so spawn_subtree can use --resume --fork-session.
+//! Stores Claude Teams info so notify_parent can route via Teams inbox.
 
 use crate::domain::ClaudeSessionUuid;
 use crate::effects::{dispatch_session_effect, EffectResult, SessionEffects};
 use crate::services::claude_session_registry::ClaudeSessionRegistry;
+use crate::services::team_registry::{TeamInfo, TeamRegistry};
 use async_trait::async_trait;
 use exomonad_proto::effects::session::*;
 use std::sync::Arc;
@@ -13,11 +15,20 @@ use tracing::info;
 /// Session effect handler.
 pub struct SessionHandler {
     registry: Arc<ClaudeSessionRegistry>,
+    team_registry: Option<Arc<TeamRegistry>>,
 }
 
 impl SessionHandler {
     pub fn new(registry: Arc<ClaudeSessionRegistry>) -> Self {
-        Self { registry }
+        Self {
+            registry,
+            team_registry: None,
+        }
+    }
+
+    pub fn with_team_registry(mut self, team_registry: Arc<TeamRegistry>) -> Self {
+        self.team_registry = Some(team_registry);
+        self
     }
 }
 
@@ -54,5 +65,57 @@ impl SessionEffects for SessionHandler {
         }
 
         Ok(RegisterClaudeSessionResponse { success: true })
+    }
+
+    async fn register_team(
+        &self,
+        req: RegisterTeamRequest,
+        ctx: &crate::effects::EffectContext,
+    ) -> EffectResult<RegisterTeamResponse> {
+        let agent_name = &ctx.agent_name;
+        let key = if agent_name.as_str().is_empty() {
+            "root".to_string()
+        } else {
+            agent_name.to_string()
+        };
+
+        info!(
+            key = %key,
+            team_name = %req.team_name,
+            inbox_name = %req.inbox_name,
+            "Registering Claude Teams info via effect"
+        );
+
+        if let Some(ref team_registry) = self.team_registry {
+            team_registry
+                .register(
+                    &key,
+                    TeamInfo {
+                        team_name: req.team_name.clone(),
+                        inbox_name: req.inbox_name.clone(),
+                    },
+                )
+                .await;
+
+            // Also store under slug variant for broader lookup
+            if let Some(slug) = key.strip_suffix("-claude") {
+                team_registry
+                    .register(
+                        slug,
+                        TeamInfo {
+                            team_name: req.team_name,
+                            inbox_name: req.inbox_name,
+                        },
+                    )
+                    .await;
+            }
+        } else {
+            tracing::warn!(
+                key = %key,
+                "TeamRegistry not available; register_team is a no-op"
+            );
+        }
+
+        Ok(RegisterTeamResponse { success: true })
     }
 }

--- a/rust/exomonad-core/src/hooks.rs
+++ b/rust/exomonad-core/src/hooks.rs
@@ -119,6 +119,17 @@ impl HookConfig {
 
         settings[EXOMONAD_MARKER] = json!(true);
 
+        // Enable Claude Code Agent Teams feature for native inter-agent messaging
+        if settings.get("env").is_none() {
+            settings["env"] = json!({});
+        }
+        if let Some(env_obj) = settings["env"].as_object_mut() {
+            env_obj.insert(
+                "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS".to_string(),
+                json!("1"),
+            );
+        }
+
         let content =
             serde_json::to_string_pretty(&settings).map_err(ExoMonadError::JsonSerialize)?;
         fs::write(&settings_path, &content).map_err(ExoMonadError::Io)?;

--- a/rust/exomonad-core/src/services/agent_control.rs
+++ b/rust/exomonad-core/src/services/agent_control.rs
@@ -1167,6 +1167,11 @@ impl AgentControlService {
             if let Some(port) = self.mcp_server_port {
                 env_vars.insert("EXOMONAD_SERVER_PORT".to_string(), port.to_string());
             }
+            // Enable Claude Code Agent Teams for native inter-agent messaging
+            env_vars.insert(
+                "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS".to_string(),
+                "1".to_string(),
+            );
 
             // Write .mcp.json in worktree root
             self.write_agent_mcp_config(effective_project_dir, &worktree_path, AgentType::Claude, "tl")

--- a/rust/exomonad-core/src/services/mod.rs
+++ b/rust/exomonad-core/src/services/mod.rs
@@ -20,6 +20,8 @@ pub mod popup;
 pub mod questions;
 pub mod repo;
 pub mod secrets;
+pub mod team_registry;
+pub mod teams_mailbox;
 pub mod zellij_events;
 
 pub use self::agent_control::{

--- a/rust/exomonad-core/src/services/team_registry.rs
+++ b/rust/exomonad-core/src/services/team_registry.rs
@@ -1,0 +1,57 @@
+//! In-memory registry mapping agent identity to Claude Teams info.
+//!
+//! Populated by the SessionStart hook (via `session.register_team` effect)
+//! when a Claude agent creates its isolated team on startup.
+//! Queried by `notify_parent` and GitHub poller to route messages via
+//! Teams inbox instead of Zellij STDIN injection.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use tracing::info;
+
+/// Info about an agent's Claude Teams membership.
+#[derive(Debug, Clone)]
+pub struct TeamInfo {
+    /// Team name this agent created (e.g., "exo-root").
+    pub team_name: String,
+    /// Agent's inbox name within its team (used as filename).
+    pub inbox_name: String,
+}
+
+/// Maps agent identity keys to Claude Teams info.
+pub struct TeamRegistry {
+    inner: Arc<Mutex<HashMap<String, TeamInfo>>>,
+}
+
+impl Default for TeamRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TeamRegistry {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Register a team for the given agent identity key.
+    pub async fn register(&self, key: &str, info: TeamInfo) {
+        info!(
+            key = %key,
+            team_name = %info.team_name,
+            inbox_name = %info.inbox_name,
+            "Registering Claude Teams info"
+        );
+        let mut map = self.inner.lock().await;
+        map.insert(key.to_string(), info);
+    }
+
+    /// Look up the team info for the given agent identity key.
+    pub async fn get(&self, key: &str) -> Option<TeamInfo> {
+        let map = self.inner.lock().await;
+        map.get(key).cloned()
+    }
+}

--- a/rust/exomonad-core/src/services/teams_mailbox.rs
+++ b/rust/exomonad-core/src/services/teams_mailbox.rs
@@ -1,0 +1,80 @@
+//! Claude Teams inbox writer.
+//!
+//! Writes messages to `~/.claude/teams/{team_name}/inboxes/{recipient}.json`.
+//! Claude Code's native file watcher picks up inbox writes and injects them
+//! as `<teammate-message>` into the LLM context.
+//!
+//! This replaces Zellij STDIN injection for Claude-to-Claude communication,
+//! eliminating the Ink paste timing hack.
+
+use serde::Serialize;
+use std::path::PathBuf;
+use tracing::{debug, info};
+
+/// Message format for Claude Teams inbox.
+#[derive(Debug, Serialize)]
+pub struct TeamsMessage {
+    #[serde(rename = "type")]
+    pub message_type: String,
+    pub recipient: String,
+    pub content: String,
+    pub summary: String,
+}
+
+/// Write a message to a Claude Teams inbox file.
+///
+/// Creates parent directories if needed. Writes atomically by writing to a
+/// temp file and renaming.
+pub fn write_to_inbox(
+    team_name: &str,
+    recipient: &str,
+    message: &TeamsMessage,
+) -> std::io::Result<()> {
+    let home = dirs::home_dir().ok_or_else(|| {
+        std::io::Error::new(std::io::ErrorKind::NotFound, "HOME directory not found")
+    })?;
+
+    let inbox_dir = home
+        .join(".claude")
+        .join("teams")
+        .join(team_name)
+        .join("inboxes");
+
+    std::fs::create_dir_all(&inbox_dir)?;
+
+    let inbox_file = inbox_dir.join(format!("{}.json", recipient));
+
+    info!(
+        team = %team_name,
+        recipient = %recipient,
+        file = %inbox_file.display(),
+        "Writing to Teams inbox"
+    );
+
+    let json = serde_json::to_string_pretty(message).map_err(|e| {
+        std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string())
+    })?;
+
+    // Atomic write: temp file + rename
+    let tmp_file = inbox_dir.join(format!(".{}.json.tmp", recipient));
+    std::fs::write(&tmp_file, &json)?;
+    std::fs::rename(&tmp_file, &inbox_file)?;
+
+    debug!(
+        bytes = json.len(),
+        "Teams inbox write complete"
+    );
+
+    Ok(())
+}
+
+/// Get the Teams inbox file path for a given team and recipient.
+pub fn inbox_path(team_name: &str, recipient: &str) -> Option<PathBuf> {
+    dirs::home_dir().map(|home| {
+        home.join(".claude")
+            .join("teams")
+            .join(team_name)
+            .join("inboxes")
+            .join(format!("{}.json", recipient))
+    })
+}

--- a/rust/exomonad-proto/proto/effects/session.proto
+++ b/rust/exomonad-proto/proto/effects/session.proto
@@ -9,6 +9,16 @@ message RegisterClaudeSessionResponse {
   bool success = 1;
 }
 
+message RegisterTeamRequest {
+  string team_name = 1;
+  string inbox_name = 2;
+}
+
+message RegisterTeamResponse {
+  bool success = 1;
+}
+
 service SessionEffects {
   rpc RegisterClaudeId(RegisterClaudeSessionRequest) returns (RegisterClaudeSessionResponse);
+  rpc RegisterTeam(RegisterTeamRequest) returns (RegisterTeamResponse);
 }

--- a/rust/exomonad/src/main.rs
+++ b/rust/exomonad/src/main.rs
@@ -967,6 +967,7 @@ async fn main() -> Result<()> {
                 event_log.clone(),
             ));
             builder = builder.with_handlers(exomonad_core::git_handlers(git, github, jj));
+            let team_registry = Arc::new(exomonad_core::services::team_registry::TeamRegistry::new());
             let (orch_handlers, question_registry) = exomonad_core::orchestration_handlers(
                 agent_control.clone(),
                 event_queue.clone(),
@@ -975,6 +976,7 @@ async fn main() -> Result<()> {
                 remote_port,
                 Some(event_session_id),
                 claude_session_registry,
+                team_registry.clone(),
             );
             builder = builder.with_handlers(orch_handlers);
             let rt = builder.build().await.context("Failed to build runtime")?;
@@ -1021,6 +1023,7 @@ async fn main() -> Result<()> {
             if let Some(ref el) = event_log {
                 poller = poller.with_event_log(el.clone());
             }
+            poller = poller.with_team_registry(team_registry);
             tokio::spawn(async move {
                 poller.run().await;
             });


### PR DESCRIPTION
## Summary

- Add `TeamRegistry` service + `teams_mailbox` inbox writer for Claude Code's experimental Agent Teams feature
- Extend `notify_parent` handler to deliver messages via Teams inbox (with Zellij injection fallback for Gemini agents)
- Add `RegisterTeam` proto effect + Haskell bindings so agents can register their team info on startup
- Enable `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` feature flag in hook config and spawned agent env vars
- GitHub poller also routes events via Teams inbox for Claude agents

## Details

Claude Code v2.1.19+ ships an experimental "Agent Teams" feature that provides filesystem-based inter-agent messaging via `~/.claude/teams/`. By having each Claude session register a team on startup, we can route events through the Teams mailbox — Claude Code natively picks up inbox writes and injects them as `<teammate-message>` into the LLM context. This eliminates the Ink paste timing hack for Claude-to-Claude communication.

**Scope**: Claude-to-Claude only. Gemini agents continue using Zellij STDIN injection (unchanged).

### New files
- `rust/exomonad-core/src/services/team_registry.rs` — In-memory registry mapping agent identity to TeamInfo
- `rust/exomonad-core/src/services/teams_mailbox.rs` — Atomic JSON writer for `~/.claude/teams/{team}/inboxes/{recipient}.json`

### Modified files
- Proto: Added `RegisterTeamRequest/Response` messages and `RegisterTeam` RPC
- Rust handlers: `SessionHandler.register_team()`, `EventHandler.notify_parent()` with Teams delivery, `GitHubPoller.emit_event()` with Teams delivery
- Hooks: Feature flag in `settings.local.json` env section
- Agent control: Feature flag env var for spawned Claude subtrees
- Main: Wire `TeamRegistry` through to handlers and poller
- Haskell: Proto bindings + `SessionRegisterTeam` effect type

## Test plan
- [x] `cargo build --workspace` — clean
- [x] `cargo test --workspace --lib` — 275 tests pass
- [ ] Manual: start exomonad, verify Claude creates team, spawn subtree, verify child notifies parent via Teams inbox
- [ ] Manual: verify Gemini agents still work via Zellij injection (regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)