### PR TITLE
fix(core): update Claude Teams inbox format to JSON array and enable atomic append

### DIFF
--- a/rust/exomonad-core/src/services/github_poller.rs
+++ b/rust/exomonad-core/src/services/github_poller.rs
@@ -3,6 +3,8 @@ use crate::services::agent_control::AgentType;
 use crate::services::event_log::EventLog;
 use crate::services::event_queue::EventQueue;
 use crate::services::repo;
+use crate::services::team_registry::TeamRegistry;
+use crate::services::teams_mailbox;
 use crate::services::zellij_events;
 use anyhow::{Context, Result};
 use exomonad_proto::effects::events::{event::EventType, Event, WorkerComplete};
@@ -22,6 +24,7 @@ pub struct GitHubPoller {
     poll_interval: Duration,
     state: Arc<Mutex<HashMap<PRNumber, PRState>>>,
     repo_info: Arc<Mutex<Option<(String, String)>>>, // (owner, name)
+    team_registry: Option<Arc<TeamRegistry>>,
 }
 
 /// A Copilot review comment with optional file context.
@@ -54,7 +57,13 @@ impl GitHubPoller {
             poll_interval: Duration::from_secs(60),
             state: Arc::new(Mutex::new(HashMap::new())),
             repo_info: Arc::new(Mutex::new(None)),
+            team_registry: None,
         }
+    }
+
+    pub fn with_team_registry(mut self, registry: Arc<TeamRegistry>) -> Self {
+        self.team_registry = Some(registry);
+        self
     }
 
     pub fn with_event_log(mut self, event_log: Arc<EventLog>) -> Self {
@@ -486,9 +495,45 @@ impl GitHubPoller {
         };
 
         if let Some(agent_message) = agent_message {
-            let slug = branch.rsplit_once('.').map(|(_, s)| s).unwrap_or(branch);
-            let tab_name = agent_type.tab_display_name(slug);
-            zellij_events::inject_input(&tab_name, &agent_message);
+            let mut delivered_via_teams = false;
+
+            // For Claude agents, try Teams inbox delivery first
+            if agent_type == AgentType::Claude {
+                if let Some(ref registry) = self.team_registry {
+                    if let Some(team_info) = registry.get(branch).await {
+                        match teams_mailbox::write_to_inbox(
+                            &team_info.team_name,
+                            &team_info.inbox_name,
+                            "github",
+                            &agent_message,
+                            &format!("GitHub event: {} on {}", status, branch),
+                            "blue",
+                        ) {
+                            Ok(()) => {
+                                info!(
+                                    branch = %branch,
+                                    team = %team_info.team_name,
+                                    "Delivered poller event via Teams inbox"
+                                );
+                                delivered_via_teams = true;
+                            }
+                            Err(e) => {
+                                warn!(
+                                    branch = %branch,
+                                    error = %e,
+                                    "Teams inbox write failed, falling back to Zellij"
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+
+            if !delivered_via_teams {
+                let slug = branch.rsplit_once('.').map(|(_, s)| s).unwrap_or(branch);
+                let tab_name = agent_type.tab_display_name(slug);
+                zellij_events::inject_input(&tab_name, &agent_message);
+            }
         }
     }
 }

--- a/rust/exomonad-core/src/services/mod.rs
+++ b/rust/exomonad-core/src/services/mod.rs
@@ -20,6 +20,8 @@ pub mod popup;
 pub mod questions;
 pub mod repo;
 pub mod secrets;
+pub mod team_registry;
+pub mod teams_mailbox;
 pub mod zellij_events;
 
 pub use self::agent_control::{

--- a/rust/exomonad-core/src/services/team_registry.rs
+++ b/rust/exomonad-core/src/services/team_registry.rs
@@ -1,0 +1,57 @@
+//! In-memory registry mapping agent identity to Claude Teams info.
+//!
+//! Populated by the SessionStart hook (via `session.register_team` effect)
+//! when a Claude agent creates its isolated team on startup.
+//! Queried by `notify_parent` and GitHub poller to route messages via
+//! Teams inbox instead of Zellij STDIN injection.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use tracing::info;
+
+/// Info about an agent's Claude Teams membership.
+#[derive(Debug, Clone)]
+pub struct TeamInfo {
+    /// Team name this agent created (e.g., "exo-root").
+    pub team_name: String,
+    /// Agent's inbox name within its team (used as filename).
+    pub inbox_name: String,
+}
+
+/// Maps agent identity keys to Claude Teams info.
+pub struct TeamRegistry {
+    inner: Arc<Mutex<HashMap<String, TeamInfo>>>,
+}
+
+impl Default for TeamRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TeamRegistry {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Register a team for the given agent identity key.
+    pub async fn register(&self, key: &str, info: TeamInfo) {
+        info!(
+            key = %key,
+            team_name = %info.team_name,
+            inbox_name = %info.inbox_name,
+            "Registering Claude Teams info"
+        );
+        let mut map = self.inner.lock().await;
+        map.insert(key.to_string(), info);
+    }
+
+    /// Look up the team info for the given agent identity key.
+    pub async fn get(&self, key: &str) -> Option<TeamInfo> {
+        let map = self.inner.lock().await;
+        map.get(key).cloned()
+    }
+}

--- a/rust/exomonad-core/src/services/teams_mailbox.rs
+++ b/rust/exomonad-core/src/services/teams_mailbox.rs
@@ -1,0 +1,185 @@
+//! Claude Teams inbox writer.
+//!
+//! Writes messages to `~/.claude/teams/{team_name}/inboxes/{recipient}.json`.
+//! Claude Code's native file watcher picks up inbox writes and injects them
+//! as `<teammate-message>` into the LLM context.
+//!
+//! This replaces Zellij STDIN injection for Claude-to-Claude communication,
+//! eliminating the Ink paste timing hack.
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use tracing::{debug, info};
+
+/// Message format for Claude Teams inbox.
+/// Full file is a JSON array of these messages: `[ {msg1}, {msg2}, ... ]`.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct TeamsMessage {
+    pub from: String,
+    pub text: String,
+    pub summary: String,
+    pub timestamp: String,
+    pub color: String,
+    pub read: bool,
+}
+
+/// Write a message to a Claude Teams inbox file.
+///
+/// Appends to the existing JSON array if the file exists, or creates a new array.
+/// Writes atomically by writing to a temp file and renaming.
+pub fn write_to_inbox(
+    team_name: &str,
+    recipient: &str,
+    from: &str,
+    text: &str,
+    summary: &str,
+    color: &str,
+) -> std::io::Result<()> {
+    let home = dirs::home_dir().ok_or_else(|| {
+        std::io::Error::new(std::io::ErrorKind::NotFound, "HOME directory not found")
+    })?;
+
+    write_to_inbox_at_base(&home, team_name, recipient, from, text, summary, color)
+}
+
+/// Write a message to a Claude Teams inbox file at a specific base path.
+/// Internal helper for testing.
+fn write_to_inbox_at_base(
+    base: &Path,
+    team_name: &str,
+    recipient: &str,
+    from: &str,
+    text: &str,
+    summary: &str,
+    color: &str,
+) -> std::io::Result<()> {
+    let inbox_dir = base
+        .join(".claude")
+        .join("teams")
+        .join(team_name)
+        .join("inboxes");
+
+    std::fs::create_dir_all(&inbox_dir)?;
+
+    let inbox_file = inbox_dir.join(format!("{}.json", recipient));
+
+    // 1. Read existing inbox if it exists
+    let mut messages: Vec<TeamsMessage> = if inbox_file.exists() {
+        let content = std::fs::read_to_string(&inbox_file)?;
+        serde_json::from_str(&content).unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+
+    // 2. Append new message
+    let timestamp = Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+    let new_message = TeamsMessage {
+        from: from.to_string(),
+        text: text.to_string(),
+        summary: summary.to_string(),
+        timestamp,
+        color: color.to_string(),
+        read: false,
+    };
+    messages.push(new_message);
+
+    info!(
+        team = %team_name,
+        recipient = %recipient,
+        file = %inbox_file.display(),
+        count = messages.len(),
+        "Writing to Teams inbox"
+    );
+
+    let json = serde_json::to_string_pretty(&messages).map_err(|e| {
+        std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string())
+    })?;
+
+    // Atomic write: temp file + rename
+    let tmp_file = inbox_dir.join(format!(".{}.json.tmp", recipient));
+    std::fs::write(&tmp_file, &json)?;
+    std::fs::rename(&tmp_file, &inbox_file)?;
+
+    debug!(
+        bytes = json.len(),
+        "Teams inbox write complete"
+    );
+
+    Ok(())
+}
+
+/// Get the Teams inbox file path for a given team and recipient.
+pub fn inbox_path(team_name: &str, recipient: &str) -> Option<PathBuf> {
+    dirs::home_dir().map(|home| {
+        home.join(".claude")
+            .join("teams")
+            .join(team_name)
+            .join("inboxes")
+            .join(format!("{}.json", recipient))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_teams_mailbox_append() -> std::io::Result<()> {
+        let tmp = tempdir()?;
+        let base = tmp.path();
+        let team_name = "test-team";
+        let recipient = "test-recipient";
+        
+        // Write first message
+        write_to_inbox_at_base(
+            base,
+            team_name,
+            recipient,
+            "agent1",
+            "Hello from agent1",
+            "Message 1",
+            "blue"
+        )?;
+
+        // Write second message
+        write_to_inbox_at_base(
+            base,
+            team_name,
+            recipient,
+            "agent2",
+            "Hello from agent2",
+            "Message 2",
+            "green"
+        )?;
+
+        // Read back
+        let inbox_file = base.join(".claude")
+            .join("teams")
+            .join(team_name)
+            .join("inboxes")
+            .join(format!("{}.json", recipient));
+        
+        let content = std::fs::read_to_string(&inbox_file)?;
+        let messages: Vec<TeamsMessage> = serde_json::from_str(&content).unwrap();
+
+        assert_eq!(messages.len(), 2);
+        
+        assert_eq!(messages[0].from, "agent1");
+        assert_eq!(messages[0].text, "Hello from agent1");
+        assert_eq!(messages[0].summary, "Message 1");
+        assert_eq!(messages[0].color, "blue");
+        assert_eq!(messages[0].read, false);
+        assert!(!messages[0].timestamp.is_empty());
+
+        assert_eq!(messages[1].from, "agent2");
+        assert_eq!(messages[1].text, "Hello from agent2");
+        assert_eq!(messages[1].summary, "Message 2");
+        assert_eq!(messages[1].color, "green");
+        assert_eq!(messages[1].read, false);
+        assert!(!messages[1].timestamp.is_empty());
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Claude Teams inbox writer updated to use the correct Claude Teams inbox array format.

Key changes:
- TeamsMessage struct updated with from, text, summary, timestamp, color, and read fields.
- write_to_inbox refactored to support atomic JSON array append (read existing, append, write to tmp, rename).
- TeamRegistry service added to track agent identities and their corresponding Teams info.
- Integrated TeamRegistry and write_to_inbox into EventHandler::notify_parent and GitHubPoller for native Teams-based delivery.
- Unit test in teams_mailbox.rs verifying the append logic.
- Builds and tests pass.