### PR TITLE
fix: spawn workers in caller's Zellij tab and worktree

### DIFF
--- a/rust/exomonad-core/src/handlers/agent.rs
+++ b/rust/exomonad-core/src/handlers/agent.rs
@@ -181,7 +181,7 @@ impl AgentEffects for AgentHandler {
 
         let result = self
             .service
-            .spawn_worker(&options, &ctx.birth_branch)
+            .spawn_worker(&options, ctx)
             .await
             .effect_err("agent")?;
 


### PR DESCRIPTION
## Bug Fix: Workers Spawning in Root Tab

Fixes a bug where `spawn_workers` would always create Gemini worker panes in the root **TL** Zellij tab, regardless of which agent called it. This caused workers to run in the wrong directory (project root) when called from a subtree agent.

### Changes:
- **`AgentControlService::spawn_worker`**: Now takes the full `EffectContext` of the caller.
- **`AgentControlService::new_zellij_pane`**: Added `tab_name` parameter. If provided, it runs `zellij action go-to-tab-name` before spawning the pane.
- **Context Resolution**: Uses `resolve_own_tab_name(ctx)` and `resolve_agent_working_dir(ctx)` to determine the correct tab and `cwd` for the new worker pane.
- **`resolve_own_tab_name`**: Improved to correctly identify Gemini vs Claude tab emojis based on the agent name.

### Verification:
- `cargo check --workspace` passes.
- Changes manually reviewed for correctness in tab/directory resolution logic.
