### PR TITLE
docs: rewrite README.md for public launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,119 +1,80 @@
 # ExoMonad
 
-> Type-safe LLM agent framework with structured state and templates
+Orchestrate heterogeneous LLM agent teams from your CLI.
 
-## What Is This?
+ExoMonad lets you spawn and manage teams of LLM agents (Claude + Gemini) directly from a single CLI session. Each agent operates in its own isolated git worktree, performing tasks, filing PRs, and notifying you when they finish—all integrated into your native Claude Code or Gemini CLI conversation.
 
-A library for building LLM agents using **polysemy** for sandboxed effects, **ginger** (Jinja) templates validated at compile time, and **structured output** for LLM → state mutations.
+## Key Features
+- **Heterogeneous Agents**: Deploy Claude (Opus/3.5 Sonnet) for high-level architecture and Gemini (1.5 Flash/Pro) for fast, focused implementation.
+- **Git Worktree Isolation**: Every agent gets its own directory and branch. No merge conflicts while work is in progress.
+- **Push Notifications**: Agents notify you via the Claude Teams inbox when they complete. No polling or context switching required.
+- **Haskell WASM DSL**: Agent logic and tool definitions are written in Haskell and compiled to WASM. Hot reload by editing a tool and running your next command.
+- **Template System**: Reuse verified patterns and anti-patterns across worker specs to save up to 89% on orchestration tokens.
 
-The key insight: LLMs don't need raw IO access. They need:
-1. **Typed state** they can read (via templates)
-2. **Typed mutations** they can express (via structured output)
-3. **Typed tools** for mid-turn capabilities
+## Quick Demo
 
-The Haskell code controls what's possible. The LLM controls what happens.
+Spawn multiple Gemini workers to implement features in parallel from your Claude session:
+
+```bash
+# In your Claude session:
+spawn_workers agents=[
+  { name: "rust-impl", role: "dev", task: "Implement the Rust effect handlers" },
+  { name: "haskell-sdk", role: "dev", task: "Add corresponding Haskell effect types" }
+]
+```
+
+**What happens:**
+1. Two new Zellij panes open immediately.
+2. Each worker starts implementing its assigned task in isolation.
+3. You continue working in your main tab.
+4. When a worker finishes, it files a PR and notifies you directly in your Claude conversation via the Teams inbox.
+
+## Install
+
+### For Users
+*Public release coming soon. Once published:*
+```bash
+cargo install exomonad
+# Download pre-built WASM binaries to ~/.exo/wasm/
+```
+
+### For Developers
+Requires [Nix](https://nixos.org/) for the Haskell WASM build.
+```bash
+git clone https://github.com/inanna-malick/exomonad
+cd exomonad
+just install-all-dev  # Builds WASM via Nix and installs the Rust binary to ~/.cargo/bin/
+```
+
+## Getting Started
+
+1. **Initialize**: Run `exomonad init` in your project root. This starts the background server and sets up your environment.
+2. **Register MCP** (one-time):
+   ```bash
+   claude mcp add --transport http exomonad http://localhost:7432/agents/tl/root/mcp
+   ```
+3. **Launch Agent**: Open the Tech Lead tab in your Zellij session and run `claude`.
+4. **Orchestrate**: Delegate tasks using tools like `spawn_workers` or `spawn_subtree`.
 
 ## Architecture
 
-```
-┌─────────────────────────────────────────────────────────────┐
-│                      Agent Turn Loop                         │
-│                                                             │
-│  1. Build context (Haskell: State → Context)                │
-│  2. Render template (Jinja: Context → prompt)               │
-│  3. Call LLM (runTurn: prompt + schema + tools → result)    │
-│  4. Apply structured output (Output → State')               │
-│  5. Handle user input (RequestInput for choices)            │
-│  6. Return response                                         │
-└─────────────────────────────────────────────────────────────┘
-```
+ExoMonad uses a split architecture for safety and performance:
+- **Haskell WASM**: Defines all tool logic, schemas, and agent decision trees. Agents are IO-blind state machines.
+- **Rust Runtime**: Hosts the WASM plugin and executes all side effects (Git, GitHub API, Filesystem, Zellij).
+- **Zellij**: Provides process isolation and multiplexing for agent tabs and panes.
 
-### Effects (what agents can do)
+See [CLAUDE.md](CLAUDE.md) for a deep dive into the system architecture.
 
-```haskell
-type AgentEffects s event =
-  '[ State s          -- read/write agent state
-   , Random           -- dice rolls, weighted choices
-   , LLM              -- template-based LLM calls
-   , Emit event       -- observable events
-   , RequestInput     -- user input
-   ]
+## Available Tools
 
--- Notably absent: IO, Network, FileSystem
--- The interpreter handles all real-world interaction
-```
+| Tool | Role | Description |
+|------|------|-------------|
+| `spawn_subtree` | tl | Fork a Claude agent into a new worktree and Zellij tab. |
+| `spawn_leaf_subtree` | tl | Fork a Gemini agent into a new worktree and Zellij tab. |
+| `spawn_workers` | tl | Spawn Gemini agents as Zellij panes in the current directory. |
+| `file_pr` | tl, dev | Create or update a pull request for the current branch. |
+| `merge_pr` | tl | Merge a child agent's PR and fetch the changes. |
+| `notify_parent` | all | Signal completion to the parent agent via the Teams inbox. |
 
-### Templates (what the LLM sees)
-
-Ginger (Jinja) templates validated at compile time:
-
-```haskell
-$(typedTemplateFile ''MyContext "templates/turn.jinja")
--- Compile error if template references nonexistent fields
-```
-
-### Structured Output (what the LLM can express)
-
-Every mutation includes `because` for training data:
-
-```haskell
-data StateDelta = StateDelta
-  { deltaValue :: Int
-  , deltaBecause :: Text  -- "User requested change"
-  }
-```
-
-## Quick Start
-
-```bash
-# Build all packages
-cabal build all
-
-# Run pre-build for Docker (generates SSH keys)
-./scripts/docker-prebuild.sh
-
-# Run native server with SimpleAgent example
-just native  # Starts at localhost:8080
-```
-
-## Project Structure
-
-```
-haskell/dsl/core/        # Core library (effects, templates)
-haskell/effects/         # Native effect interpreters
-haskell/protocol/        # Wire types and FFI
-```
-
-For detailed documentation, see `CLAUDE.md`.
-
-## Example Agents
-
-Agents live in separate repos to keep the library clean:
-- `~/exomonad-labs/anemone` - DM agent, Tidying agent, etc.
-
-## See Also
-
-- [polysemy](https://hackage.haskell.org/package/polysemy) - Higher-power, low-boilerplate effect system
-- [ginger](https://github.com/inanna-malick/ginger) - Jinja template engine for Haskell (typed fork)
-- [Anthropic Tool Use](https://docs.anthropic.com/en/docs/tool-use) - LLM tool calling
-
-## Testing
-
-### FFI Property Tests
-
-We use property-based testing to verify JSON serialization across the WASM FFI boundary.
-
-**Rust:**
-```bash
-cd rust && cargo test --test proptest_ffi
-```
-
-**Haskell:**
-```bash
-cd haskell/wasm-guest && cabal test ffi-serialization-tests
-```
-
-**Integration (Round-trip):**
-```bash
-cd rust && cargo test --test integration_ffi
-```
+## License
+ExoMonad is released under the [BSD 3-Clause License](LICENSE).


### PR DESCRIPTION
This PR rewrites the README.md to prepare for a public launch. It focuses on ExoMonad as an orchestration tool for heterogeneous LLM agent teams (Claude + Gemini).

Key changes:
- Focused pitch on agent orchestration and isolation.
- Clearer install instructions (Users vs Developers).
- Quick demo of `spawn_workers`.
- Table of available MCP tools.
- Simplified architecture section.

The content is based on the source of truth in `CLAUDE.md` and current project capabilities.