### PR TITLE
docs: add missing CLAUDE.md files for effect interpreters

### DIFF
--- a/haskell/effects/env-interpreter/CLAUDE.md
+++ b/haskell/effects/env-interpreter/CLAUDE.md
@@ -1,0 +1,37 @@
+# Env Interpreter — Environment Variable Access
+
+Interprets the `Env` effect for reading environment variables using standard Haskell `System.Environment` operations.
+
+## When to Read This
+
+Read this if you're:
+- Debugging environment variable lookup logic
+- Adding support for system-wide environment queries to agents
+
+## Architecture
+
+The `env-interpreter` is a direct I/O implementation that lifts `System.Environment` functions (like `lookupEnv` and `getEnvironment`) into the Polysemy effect stack.
+
+## Usage
+
+```haskell
+import ExoMonad.Env.Interpreter (runEnvIO)
+import ExoMonad.Effects.Env
+
+main :: IO ()
+main = runM . runEnvIO $ do
+  mToken <- getEnv "GITHUB_TOKEN"
+  envPairs <- getEnvironment
+  pure (mToken, envPairs)
+```
+
+## Key Modules
+
+| Module | Purpose |
+|--------|---------|
+| `ExoMonad.Env.Interpreter` | Implementation using `System.Environment` |
+
+## Related Documentation
+
+- [dsl/core/CLAUDE.md](../../dsl/core/CLAUDE.md) - Env effect type
+- [effects/CLAUDE.md](../CLAUDE.md) - Effect interpreter listing

--- a/haskell/effects/filesystem-interpreter/CLAUDE.md
+++ b/haskell/effects/filesystem-interpreter/CLAUDE.md
@@ -1,0 +1,39 @@
+# FileSystem Interpreter — Direct File I/O
+
+Interprets the `FileSystem` effect using standard Haskell `System.Directory` and `System.IO` operations.
+
+## When to Read This
+
+Read this if you're:
+- Debugging file system operations (creation, writing, copying)
+- Understanding how file paths are handled in the interpreter
+- Adding new file manipulation capabilities to the agent environment
+
+## Architecture
+
+This interpreter uses the `Polysemy.Embed` effect to perform direct side-effecting I/O operations on the local filesystem. It ensures that parent directories exist before writing or copying files.
+
+## Usage
+
+```haskell
+import ExoMonad.FileSystem.Interpreter (runFileSystemIO)
+import ExoMonad.Effects.FileSystem
+
+main :: IO ()
+main = runM . runFileSystemIO $ do
+  createDirectory someDirPath
+  writeTextFile someFilePath "Hello ExoMonad"
+  exists <- fileExists someFilePath
+  pure exists
+```
+
+## Key Modules
+
+| Module | Purpose |
+|--------|---------|
+| `ExoMonad.FileSystem.Interpreter` | I/O implementation of file system operations |
+
+## Related Documentation
+
+- [dsl/core/CLAUDE.md](../../dsl/core/CLAUDE.md) - FileSystem effect type
+- [effects/CLAUDE.md](../CLAUDE.md) - Effect interpreter listing

--- a/haskell/effects/git-interpreter/CLAUDE.md
+++ b/haskell/effects/git-interpreter/CLAUDE.md
@@ -1,0 +1,44 @@
+# Git Interpreter — Git Effect Handler (Pure)
+
+Interprets the `Git` effect by injecting pure handlers for repository queries and operations. This is primarily used for testing or when delegating to host environments that provide their own git implementation.
+
+## When to Read This
+
+Read this if you're:
+- Injecting mock git behavior for integration tests
+- Understanding how the `Git` effect is handled in pure contexts
+- Extracting worktree names from filesystem paths
+
+## Architecture
+
+The `git-interpreter` provides a pure handler that allows the caller to specify the logic for each git operation. The previous subprocess-based implementation has been replaced by remote execution via the control socket in production environments.
+
+## Usage
+
+```haskell
+import ExoMonad.Git.Interpreter (runGit)
+import ExoMonad.Effects.Git (Git, getWorktreeInfo)
+
+main :: IO ()
+main = runM $ runGit
+  (pure Nothing)       -- GetWorktreeInfo
+  (pure [])            -- GetDirtyFiles
+  (\_ -> pure [])      -- GetRecentCommits
+  (pure "main")        -- GetCurrentBranch
+  (\_ -> pure 0)       -- GetCommitsAhead
+  (\_ _ -> pure ())    -- FetchRemote
+  $ do
+    info <- getWorktreeInfo
+    -- Handle info
+```
+
+## Key Modules
+
+| Module | Purpose |
+|--------|---------|
+| `ExoMonad.Git.Interpreter` | Pure effect interpreter and path utility functions |
+
+## Related Documentation
+
+- [dsl/core/CLAUDE.md](../../dsl/core/CLAUDE.md) - Git effect type definition
+- [effects/CLAUDE.md](../CLAUDE.md) - Effect interpreter listing

--- a/haskell/effects/socket-client/CLAUDE.md
+++ b/haskell/effects/socket-client/CLAUDE.md
@@ -1,0 +1,62 @@
+# Socket Client — Shared Unix Domain Socket Protocol
+
+Shared library for NDJSON-based communication over Unix Domain Sockets. This is the primary transport layer for interpreters that communicate with the Rust backend services (e.g., LLM, GitHub, and Observability).
+
+## When to Read This
+
+Read this if you're:
+- Modifying the wire protocol between Haskell and Rust
+- Adding new service request or response variants to the protocol
+- Debugging low-level socket connection or JSON decoding issues
+
+## Architecture
+
+```
+┌──────────────────────────┐         ┌──────────────────────────┐
+│ Haskell Interpreter      │         │ Rust Backend Service     │
+│ (LLM, GitHub, etc.)      │         │ (exomonad-core)          │
+└────────────┬─────────────┘         └────────────┬─────────────┘
+             │                                    │
+             │  ServiceRequest (JSON)             │
+             ├───────────────────────────────────▶│
+             │  Unix Socket (NDJSON)              │
+             │                                    │
+             │  ServiceResponse (JSON)            │
+             │◀───────────────────────────────────┤
+             │                                    │
+```
+
+## Usage
+
+The library is typically used by other interpreters via `sendRequest`:
+
+```haskell
+import ExoMonad.Effects.SocketClient (sendRequest, SocketConfig(..), ServiceRequest(..))
+
+config = SocketConfig ".exo/sockets/service.sock" 5000
+req = GitHubCheckAuth
+
+main = do
+  result <- sendRequest config req
+  -- result is Either ServiceError ServiceResponse
+```
+
+## Protocol Types
+
+### ServiceRequest
+Mirror of Rust protocol types including `AnthropicChat`, `GitHubGetIssue`, `OllamaGenerate`, `OtelSpan`, etc.
+
+### ServiceResponse
+Mirror of Rust protocol types including `AnthropicChatResponse`, `GitHubIssueResponse`, `OtelAckResponse`, `ErrorResponse`, etc.
+
+## Key Modules
+
+| Module | Purpose |
+|--------|---------|
+| `ExoMonad.Effects.SocketClient` | Shared protocol types and socket I/O logic |
+
+## Related Documentation
+
+- [effects/llm-interpreter/CLAUDE.md](../llm-interpreter/CLAUDE.md) - LLM interpreter
+- [effects/github-interpreter/CLAUDE.md](../github-interpreter/CLAUDE.md) - GitHub interpreter
+- [effects/CLAUDE.md](../CLAUDE.md) - Effect interpreter listing


### PR DESCRIPTION
Created 4 missing Haskell CLAUDE.md files for effect interpreter packages:
- `haskell/effects/git-interpreter/CLAUDE.md`
- `haskell/effects/filesystem-interpreter/CLAUDE.md`
- `haskell/effects/env-interpreter/CLAUDE.md`
- `haskell/effects/socket-client/CLAUDE.md`

Each file follows the established format and includes usage examples, key modules, and architectural overviews based on the actual source code.