### PR TITLE
docs: exomonad-core documentation and root tree update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,18 +299,23 @@ CLAUDE.md  ← YOU ARE HERE (project overview)
 ├── haskell/CLAUDE.md  ← Haskell package organization
 │   ├── dsl/core/CLAUDE.md      ← Graph DSL reference (START HERE for handlers)
 │   ├── effects/CLAUDE.md       ← Effect interpreters
-│   │   ├── llm-interpreter/     ← Anthropic/OpenAI API
-│   │   ├── worktree-interpreter/ ← Git worktree management
-│   │   ├── github-interpreter/  ← GitHub API integration
-│   │   ├── git-interpreter/      ← Native git operations
-│   │   └── filesystem-interpreter/ ← Local filesystem access
+│   │   ├── env-interpreter/
+│   │   ├── filesystem-interpreter/
+│   │   ├── git-interpreter/
+│   │   ├── github-interpreter/
+│   │   ├── justfile-interpreter/
+│   │   ├── llm-interpreter/
+│   │   ├── observability-interpreter/
+│   │   ├── socket-client/
+│   │   ├── worktree-interpreter/
+│   │   └── zellij-interpreter/
 │   ├── proto/CLAUDE.md         ← Generated Haskell types for proto
 │   ├── protocol/CLAUDE.md      ← Wire formats
 │   ├── tools/CLAUDE.md         ← Dev tools
 │   └── wasm-guest/CLAUDE.md    ← MCP tool definitions (WASM guest logic)
 ├── rust/CLAUDE.md             ← Rust workspace overview (3 crates)
 │   ├── exomonad/CLAUDE.md  ← MCP server + hook handler (binary)
-│   ├── exomonad-core/      ← Unified library: framework, handlers, services, protocol, UI types
+│   ├── exomonad-core/CLAUDE.md ← Unified library: framework, handlers, services, protocol, UI types
 │   ├── exomonad-proto/     ← Proto-generated types (prost) for FFI + effects
 │   └── exomonad-plugin/CLAUDE.md   ← Zellij WASM plugin (status + popups)
 ├── docs/decisions/            ← Architecture decision records (living docs)
@@ -321,6 +326,7 @@ CLAUDE.md  ← YOU ARE HERE (project overview)
 |--------------|-----------|
 | Add FFI boundary types | `proto/CLAUDE.md` |
 | Understand MCP tool architecture | `rust/exomonad/CLAUDE.md` |
+| Work on exomonad-core framework | `rust/exomonad-core/CLAUDE.md` |
 | Work on effect handlers or services | `rust/exomonad-core/` (handlers/, services/) |
 | Extend the effect framework | `rust/exomonad-core/` (effects/) |
 | Understand shared protocol types | `rust/exomonad-core/` (protocol/) |

--- a/rust/exomonad-core/CLAUDE.md
+++ b/rust/exomonad-core/CLAUDE.md
@@ -1,0 +1,39 @@
+# exomonad-core — Unified Library
+
+ExoMonad core is the unified library providing the effect system framework, WASM hosting via Extism, an MCP server implementation, and built-in effect handlers and services for git, GitHub, agent orchestration, and more. It defines the FFI boundary using protobuf and provides a lightweight UI protocol for frontend plugins.
+
+## Module Structure
+
+| Directory | Purpose |
+|-----------|---------|
+| `effects/` | EffectHandler trait, EffectRegistry, dispatch, error helpers |
+| `handlers/` | Effect handler implementations (git, github, log, agent, fs, etc.) |
+| `services/` | Business logic services (git, github, agent_control, event_queue, etc.) |
+| `services/external/` | External API clients (anthropic, github/octocrab, ollama, otel) |
+| `mcp/` | MCP server implementation (tools, server, state) |
+| `protocol/` | Wire format types (hook, mcp, service) |
+
+## Feature Flags
+
+| Feature | Default | Description |
+|---------|---------|-------------|
+| `runtime` | Yes | Full runtime: WASM hosting, effect handlers, MCP server, services |
+
+Without `runtime`: only `ui_protocol` module available. Used by `exomonad-plugin` which targets wasm32-wasi.
+
+## Key Types
+
+| Type | Purpose |
+|------|---------|
+| `EffectHandler` | Trait for implementing namespace-based effect handlers |
+| `EffectRegistry` | Registry for dispatching effects by namespace |
+| `EffectContext` | Identity context (agent name, birth branch) passed to all handlers |
+| `EffectError` | Common error type for all effects with protobuf mapping |
+| `PluginManager` | Manages WASM guest calls and host function dispatch via Extism |
+| `RuntimeBuilder` | Fluent API for assembling handlers and loading WASM |
+
+## Related Documentation
+
+- [Root CLAUDE.md](../../CLAUDE.md)
+- [Handlers CLAUDE.md](src/handlers/CLAUDE.md)
+- [Haskell effects](../../haskell/effects/CLAUDE.md)


### PR DESCRIPTION
Create `rust/exomonad-core/CLAUDE.md` to document the unified library structure and update the root `CLAUDE.md` documentation tree to include all 10 Haskell effect interpreters and link the new core documentation.

Changes:
- Created `rust/exomonad-core/CLAUDE.md` with module overview, feature flags, and key types.
- Updated root `CLAUDE.md` Documentation Tree to list all interpreters and `exomonad-core/CLAUDE.md`.
- Added `exomonad-core` framework entry to the "I want to..." table in root `CLAUDE.md`.