### PR TITLE
feat: add unit tests for handlers (file_pr, merge_pr, agent, github)

### DIFF
--- a/rust/exomonad-core/src/handlers/agent.rs
+++ b/rust/exomonad-core/src/handlers/agent.rs
@@ -332,6 +332,52 @@ impl AgentEffects for AgentHandler {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{AgentName, BirthBranch};
+    use crate::effects::EffectContext;
+    use crate::services::git_worktree::GitWorktreeService;
+    use std::path::PathBuf;
+
+    fn test_ctx() -> EffectContext {
+        EffectContext {
+            agent_name: AgentName::from("test"),
+            birth_branch: BirthBranch::from("main"),
+        }
+    }
+
+    fn test_handler() -> AgentHandler {
+        let dir = PathBuf::from(".");
+        let git_wt = Arc::new(GitWorktreeService::new(dir.clone()));
+        let service = Arc::new(AgentControlService::new(dir, None, git_wt));
+        AgentHandler::new(service)
+    }
+
+    #[test]
+    fn test_namespace() {
+        let _ctx = test_ctx();
+        let handler = test_handler();
+        assert_eq!(handler.namespace(), "agent");
+    }
+
+    #[test]
+    fn test_convert_agent_type() {
+        assert_eq!(
+            convert_agent_type(AgentType::Claude),
+            ServiceAgentType::Claude
+        );
+        assert_eq!(
+            convert_agent_type(AgentType::Gemini),
+            ServiceAgentType::Gemini
+        );
+        assert_eq!(
+            convert_agent_type(AgentType::Unspecified),
+            ServiceAgentType::Gemini
+        );
+    }
+}
+
 fn spawn_result_to_proto(
     issue: &str,
     result: &crate::services::agent_control::SpawnResult,

--- a/rust/exomonad-core/src/handlers/file_pr.rs
+++ b/rust/exomonad-core/src/handlers/file_pr.rs
@@ -79,3 +79,39 @@ impl FilePrEffects for FilePRHandler {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{AgentName, BirthBranch};
+    use crate::effects::EffectContext;
+    use std::path::PathBuf;
+
+    fn test_ctx(branch: &str) -> EffectContext {
+        EffectContext {
+            agent_name: AgentName::from("test"),
+            birth_branch: BirthBranch::from(branch),
+        }
+    }
+
+    #[test]
+    fn test_namespace() {
+        let git_wt = Arc::new(GitWorktreeService::new(PathBuf::from(".")));
+        let handler = FilePRHandler::new(git_wt);
+        assert_eq!(handler.namespace(), "file_pr");
+    }
+
+    #[test]
+    fn test_resolve_working_dir_root() {
+        let ctx = test_ctx("main");
+        let working_dir = crate::services::agent_control::resolve_agent_working_dir(&ctx);
+        assert_eq!(working_dir, PathBuf::from("."));
+    }
+
+    #[test]
+    fn test_resolve_working_dir_spawned() {
+        let ctx = test_ctx("main.feature");
+        let working_dir = crate::services::agent_control::resolve_agent_working_dir(&ctx);
+        assert_eq!(working_dir, PathBuf::from(".exo/worktrees/feature/"));
+    }
+}

--- a/rust/exomonad-core/src/handlers/github.rs
+++ b/rust/exomonad-core/src/handlers/github.rs
@@ -308,3 +308,49 @@ fn convert_pr(pr: crate::services::github::PullRequest) -> PullRequest {
         updated_at: 0,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{AgentName, BirthBranch, FilterState};
+    use crate::effects::EffectContext;
+
+    fn test_ctx() -> EffectContext {
+        EffectContext {
+            agent_name: AgentName::from("test"),
+            birth_branch: BirthBranch::from("main"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_namespace() {
+        let _ctx = test_ctx();
+        let service = GitHubService::new("token".to_string()).unwrap();
+        let handler = GitHubHandler::new(service);
+        assert_eq!(handler.namespace(), "github");
+    }
+
+    #[test]
+    fn test_make_repo() {
+        let repo = make_repo("owner", "repo");
+        assert_eq!(repo.owner.as_str(), "owner");
+        assert_eq!(repo.name.as_str(), "repo");
+    }
+
+    #[test]
+    fn test_issue_state_to_filter() {
+        assert_eq!(
+            issue_state_to_filter(IssueState::Open),
+            Some(FilterState::Open)
+        );
+        assert_eq!(
+            issue_state_to_filter(IssueState::Closed),
+            Some(FilterState::Closed)
+        );
+        assert_eq!(
+            issue_state_to_filter(IssueState::All),
+            Some(FilterState::All)
+        );
+        assert_eq!(issue_state_to_filter(IssueState::Unspecified), None);
+    }
+}

--- a/rust/exomonad-core/src/handlers/merge_pr.rs
+++ b/rust/exomonad-core/src/handlers/merge_pr.rs
@@ -46,3 +46,40 @@ impl MergePrEffects for MergePRHandler {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{AgentName, BirthBranch, PRNumber};
+    use crate::effects::{EffectContext, EffectHandler};
+    use std::path::PathBuf;
+
+    fn test_ctx() -> EffectContext {
+        EffectContext {
+            agent_name: AgentName::from("test"),
+            birth_branch: BirthBranch::from("main"),
+        }
+    }
+
+    #[test]
+    fn test_namespace() {
+        let _ctx = test_ctx();
+        let git_wt = Arc::new(GitWorktreeService::new(PathBuf::from(".")));
+        let handler = MergePRHandler::new(git_wt);
+        assert_eq!(handler.namespace(), "merge_pr");
+    }
+
+    #[test]
+    fn test_pr_number_conversion() {
+        let proto_pr_number: i64 = 123;
+        let pr_number = PRNumber::new(proto_pr_number as u64);
+        assert_eq!(pr_number.as_u64(), 123);
+    }
+
+    #[test]
+    fn test_pr_number_round_trip() {
+        let original: u64 = 456;
+        let pr_number = PRNumber::new(original);
+        assert_eq!(pr_number.as_u64(), original);
+    }
+}


### PR DESCRIPTION
This PR adds unit tests for 4 Rust handler files with thin dispatch logic in `exomonad-core`:
- `rust/exomonad-core/src/handlers/file_pr.rs`
- `rust/exomonad-core/src/handlers/merge_pr.rs`
- `rust/exomonad-core/src/handlers/agent.rs`
- `rust/exomonad-core/src/handlers/github.rs`

The tests follow the pattern from `kv.rs` and cover namespace, conversion logic, and internal helper functions.
All 11 new tests pass.