### PR TITLE
feat: add unit tests for EffectRegistry and PopupHandler

### DIFF
--- a/rust/exomonad-core/src/handlers/popup.rs
+++ b/rust/exomonad-core/src/handlers/popup.rs
@@ -63,3 +63,27 @@ impl PopupEffects for PopupHandler {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::effects::EffectHandler;
+
+    #[test]
+    fn test_namespace() {
+        let handler = PopupHandler::new(None);
+        assert_eq!(handler.namespace(), "popup");
+    }
+
+    #[test]
+    fn test_construction_no_session() {
+        let handler = PopupHandler::new(None);
+        assert_eq!(handler.namespace(), "popup");
+    }
+
+    #[test]
+    fn test_construction_with_session() {
+        let handler = PopupHandler::new(Some("my-session".to_string()));
+        assert_eq!(handler.namespace(), "popup");
+    }
+}


### PR DESCRIPTION
This PR adds unit tests for `EffectRegistry` and `PopupHandler` to ensure correct dispatch logic and construction.

Tests added:
- `PopupHandler::new(None)` construction
- `PopupHandler::new(Some(...))` construction
- `PopupHandler::namespace()` check
- `EffectRegistry::dispatch` for empty registry (fails)
- `EffectRegistry::dispatch` routing by namespace
- `EffectRegistry::namespaces()` list check