### PR TITLE
test: unit tests for protocol types and log service

### DIFF
--- a/rust/exomonad-core/src/protocol/mod.rs
+++ b/rust/exomonad-core/src/protocol/mod.rs
@@ -87,3 +87,60 @@ pub enum HookEventType {
     /// Custom: Worker agent exit (sends completion note to parent)
     WorkerExit,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_runtime_default() {
+        assert_eq!(Runtime::default(), Runtime::Claude);
+    }
+
+    #[test]
+    fn test_runtime_claude_serialization() {
+        let val = Runtime::Claude;
+        let json = serde_json::to_string(&val).unwrap();
+        assert_eq!(json, "\"claude\"");
+    }
+
+    #[test]
+    fn test_runtime_gemini_serialization() {
+        let val = Runtime::Gemini;
+        let json = serde_json::to_string(&val).unwrap();
+        assert_eq!(json, "\"gemini\"");
+    }
+
+    #[test]
+    fn test_runtime_roundtrip() {
+        let val = Runtime::Gemini;
+        let json = serde_json::to_string(&val).unwrap();
+        let back: Runtime = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, val);
+    }
+
+    #[test]
+    fn test_runtime_display() {
+        assert_eq!(Runtime::Claude.to_string(), "claude");
+        assert_eq!(Runtime::Gemini.to_string(), "gemini");
+    }
+
+    #[test]
+    fn test_hook_event_type_pre_tool_use_serialization() {
+        let val = HookEventType::PreToolUse;
+        let json = serde_json::to_string(&val).unwrap();
+        assert_eq!(json, "\"pre-tool-use\"");
+    }
+
+    #[test]
+    fn test_hook_event_type_session_start_serialization() {
+        let val = HookEventType::SessionStart;
+        let json = serde_json::to_string(&val).unwrap();
+        assert_eq!(json, "\"session-start\"");
+    }
+
+    #[test]
+    fn test_hook_event_type_display() {
+        assert_eq!(HookEventType::PreToolUse.to_string(), "pre-tool-use");
+    }
+}

--- a/rust/exomonad-core/src/services/log.rs
+++ b/rust/exomonad-core/src/services/log.rs
@@ -38,3 +38,55 @@ pub struct LogPayload {
 pub trait HasLogService {
     fn log_service(&self) -> &LogService;
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_log_level_info_serialization() {
+        let val = LogLevel::Info;
+        let json = serde_json::to_string(&val).unwrap();
+        assert_eq!(json, "\"info\"");
+    }
+
+    #[test]
+    fn test_log_level_error_serialization() {
+        let val = LogLevel::Error;
+        let json = serde_json::to_string(&val).unwrap();
+        assert_eq!(json, "\"error\"");
+    }
+
+    #[test]
+    fn test_log_level_roundtrip() {
+        let val = LogLevel::Warn;
+        let json = serde_json::to_string(&val).unwrap();
+        let back: LogLevel = serde_json::from_str(&json).unwrap();
+        assert!(matches!(back, LogLevel::Warn));
+    }
+
+    #[test]
+    fn test_log_payload_roundtrip_with_fields() {
+        let mut fields = HashMap::new();
+        fields.insert("key".to_string(), "value".to_string());
+        let val = LogPayload {
+            message: "test message".to_string(),
+            fields: Some(fields),
+        };
+        let json = serde_json::to_string(&val).unwrap();
+        let back: LogPayload = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, val);
+    }
+
+    #[test]
+    fn test_log_payload_roundtrip_without_fields() {
+        let val = LogPayload {
+            message: "test message".to_string(),
+            fields: None,
+        };
+        let json = serde_json::to_string(&val).unwrap();
+        let back: LogPayload = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, val);
+    }
+}


### PR DESCRIPTION
This PR adds unit tests for protocol types (`Runtime`, `HookEventType`) and the log service (`LogLevel`, `LogPayload`) in `exomonad-core`.

Tests cover:
- Serialization/deserialization for all enums and structs.
- Default values for `Runtime`.
- `Display` implementation for `Runtime` and `HookEventType` (strum).
- Roundtrip verification for `LogPayload` with and without optional fields.

Verified with `cargo test -p exomonad-core`.