### PR TITLE
feat: harden external services by replacing panics with error returns

### DIFF
--- a/rust/exomonad-core/src/services/external/anthropic.rs
+++ b/rust/exomonad-core/src/services/external/anthropic.rs
@@ -94,7 +94,12 @@ impl ExternalService for AnthropicService {
                 system,
                 thinking,
             } => (model, messages, max_tokens, tools, system, thinking),
-            _ => panic!("Invalid request type for AnthropicService"),
+            _ => {
+                return Err(ServiceError::Api {
+                    code: 400,
+                    message: "Invalid request type for AnthropicService".to_string(),
+                })
+            }
         };
 
         let payload = AnthropicRequestPayload {
@@ -105,7 +110,10 @@ impl ExternalService for AnthropicService {
             system,
             thinking,
         };
-        let url = self.base_url.join("/v1/messages").unwrap();
+        let url = self.base_url.join("/v1/messages").map_err(|e| ServiceError::Api {
+            code: 500,
+            message: format!("URL join failed: {}", e),
+        })?;
         let mut attempts = 0;
         let max_attempts = 3;
         let mut backoff = Duration::from_millis(500);

--- a/rust/exomonad-core/src/services/external/github.rs
+++ b/rust/exomonad-core/src/services/external/github.rs
@@ -761,7 +761,10 @@ impl ExternalService for GitHubService {
                     reviews,
                 })
             }
-            _ => panic!("Invalid request type for GitHubService"),
+            _ => Err(ServiceError::Api {
+                code: 400,
+                message: "Invalid request type for GitHubService".to_string(),
+            }),
         }
     }
 }

--- a/rust/exomonad-core/src/services/external/ollama.rs
+++ b/rust/exomonad-core/src/services/external/ollama.rs
@@ -21,7 +21,7 @@ impl OllamaService {
     pub fn new(endpoint: Option<Url>) -> Self {
         match endpoint {
             Some(url) => {
-                let host = url.scheme().to_string() + "://" + url.host_str().unwrap();
+                let host = url.scheme().to_string() + "://" + url.host_str().unwrap_or("localhost");
                 let port = url.port().unwrap_or(11434);
                 Self {
                     client: Ollama::new(host, port),
@@ -73,7 +73,10 @@ impl ExternalService for OllamaService {
                     done: response.done,
                 })
             }
-            _ => panic!("Invalid request type for OllamaService"),
+            _ => Err(ServiceError::Api {
+                code: 400,
+                message: "Invalid request type for OllamaService".to_string(),
+            }),
         }
     }
 }

--- a/rust/exomonad-core/src/services/external/otel.rs
+++ b/rust/exomonad-core/src/services/external/otel.rs
@@ -299,7 +299,10 @@ impl ExternalService for OtelService {
 
                 Ok(ServiceResponse::Ack)
             }
-            _ => panic!("Invalid request type for OtelService"),
+            _ => Err(ServiceError::Api {
+                code: 400,
+                message: "Invalid request type for OtelService".to_string(),
+            }),
         }
     }
 }


### PR DESCRIPTION
This PR replaces `panic!()` and `.unwrap()` calls in the external service implementations (`anthropic.rs`, `github.rs`, `ollama.rs`, and `otel.rs`) with proper `ServiceError` returns.

### Changes:
- Replaced `panic!("Invalid request type for XService")` with `Err(ServiceError::Api { code: 400, message: ... })` in all 4 files.
- Replaced `.unwrap()` on URL join in `anthropic.rs` with `map_err(|e| ServiceError::Api { ... })?`.
- Replaced `.host_str().unwrap()` in `ollama.rs` with `.host_str().unwrap_or("localhost")`.

Verified with:
- `cargo test -p exomonad-core -- services::external`
- `cargo build --workspace`
- Grep for panics in production code.