### PR TITLE
feat: add standard crate metadata to exomonad-plugin

### DIFF
--- a/rust/exomonad-plugin/Cargo.toml
+++ b/rust/exomonad-plugin/Cargo.toml
@@ -2,6 +2,12 @@
 name = "exomonad-plugin"
 version = "0.1.0"
 edition = "2021"
+description = "Zellij WASM plugin for ExoMonad agent status and popup UI"
+license = "BSD-3-Clause"
+repository = "https://github.com/tidepool-heavy-industries/exomonad"
+homepage = "https://github.com/tidepool-heavy-industries/exomonad"
+keywords = ["agent", "zellij", "plugin", "wasm"]
+categories = ["development-tools"]
 
 [workspace]
 


### PR DESCRIPTION
This PR adds standard crate metadata (description, license, repository, homepage, keywords, and categories) to `rust/exomonad-plugin/Cargo.toml` to match the other crates in the workspace.

Verification:
`cargo metadata` confirms the fields are correctly recognized.