### PR TITLE
Release Docs Cleanup: Update README, add CHANGELOG, delete stale files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [0.1.0] - 2026-02-24
+
+### Added
+- Agent orchestration: `spawn_subtree` (Claude), `spawn_leaf_subtree` (Gemini), `spawn_workers` (Gemini panes)
+- PR workflow: `file_pr`, `merge_pr`, `notify_parent`
+- Haskell WASM effect system with typed effects and Rust host handlers
+- Hot reload for WASM tools in HTTP serve mode
+- Push-based agent coordination via Zellij stdin injection
+- Zellij plugin for agent status display and interactive popup UI
+- Event logging (JSONL) and GitHub poller for CI/review status
+- Role system: TL, Dev, Worker roles with permission cascades
+- `exomonad init` for session bootstrap (server tab + TL tab)

--- a/README.md
+++ b/README.md
@@ -32,16 +32,17 @@ spawn_workers agents=[
 ## Install
 
 ### For Users
-*Public release coming soon. Once published:*
+Requires [Nix](https://nixos.org/) (for Haskell WASM compilation) and [Zellij](https://zellij.dev/).
 ```bash
-cargo install exomonad
-# Download pre-built WASM binaries to ~/.exo/wasm/
+git clone https://github.com/tidepool-heavy-industries/exomonad
+cd exomonad
+just install-all  # Builds WASM via Nix, compiles Rust, installs to ~/.cargo/bin/
 ```
 
 ### For Developers
 Requires [Nix](https://nixos.org/) for the Haskell WASM build.
 ```bash
-git clone https://github.com/inanna-malick/exomonad
+git clone https://github.com/tidepool-heavy-industries/exomonad
 cd exomonad
 just install-all-dev  # Builds WASM via Nix and installs the Rust binary to ~/.cargo/bin/
 ```


### PR DESCRIPTION
This PR updates the README.md with actual installation steps and points to the new organization. It also adds a CHANGELOG.md for the v0.1.0 release and deletes stale untracked files.