### PR TITLE
chore: standardize Haskell cabal metadata (license/author)

### DIFF
--- a/haskell/dsl/core/exomonad-core.cabal
+++ b/haskell/dsl/core/exomonad-core.cabal
@@ -2,8 +2,8 @@ cabal-version:      3.0
 name:               exomonad-core
 version:            0.1.0.0
 synopsis:           Type-safe LLM agent loops with structured state and templates
-license:            MIT
-author:             Inanna
+license:            BSD-3-Clause
+author:             Inanna Malick
 build-type:         Simple
 
 common warnings

--- a/haskell/effects/env-interpreter/exomonad-env-interpreter.cabal
+++ b/haskell/effects/env-interpreter/exomonad-env-interpreter.cabal
@@ -2,9 +2,8 @@ cabal-version:      3.0
 name:               exomonad-env-interpreter
 version:            0.1.0.0
 synopsis:           Env effect interpreter for ExoMonad
-license:            MIT
+license:            BSD-3-Clause
 author:             Inanna Malick
-maintainer:         inanna@malick.com
 category:           Control
 build-type:         Simple
 

--- a/haskell/effects/filesystem-interpreter/exomonad-filesystem-interpreter.cabal
+++ b/haskell/effects/filesystem-interpreter/exomonad-filesystem-interpreter.cabal
@@ -7,8 +7,8 @@ description:
     .
     Enables graphs to perform file system operations (create directories,
     write files, copy files, create symlinks) in a testable, IO-blind way.
-license:            MIT
-author:             Inanna
+license:            BSD-3-Clause
+author:             Inanna Malick
 build-type:         Simple
 
 common warnings

--- a/haskell/effects/git-interpreter/exomonad-git-interpreter.cabal
+++ b/haskell/effects/git-interpreter/exomonad-git-interpreter.cabal
@@ -3,8 +3,8 @@ name:               exomonad-git-interpreter
 version:            0.1.0.0
 synopsis:           Git effect interpreter - CLI client
 description:        Implements Git effect by calling git CLI commands.
-license:            MIT
-author:             Inanna
+license:            BSD-3-Clause
+author:             Inanna Malick
 build-type:         Simple
 
 common warnings

--- a/haskell/effects/github-interpreter/exomonad-github-interpreter.cabal
+++ b/haskell/effects/github-interpreter/exomonad-github-interpreter.cabal
@@ -7,8 +7,8 @@ description:
     .
     Enables graphs to query GitHub issues, pull requests, comments, and reviews
     for context construction in agent templates.
-license:            MIT
-author:             Inanna
+license:            BSD-3-Clause
+author:             Inanna Malick
 build-type:         Simple
 
 common warnings

--- a/haskell/effects/justfile-interpreter/exomonad-justfile-interpreter.cabal
+++ b/haskell/effects/justfile-interpreter/exomonad-justfile-interpreter.cabal
@@ -4,8 +4,8 @@ version:            0.1.0.0
 synopsis:           Justfile effect interpreter - just CLI client
 description:
     Implements Justfile effect by calling the just CLI tool.
-license:            MIT
-author:             Inanna
+license:            BSD-3-Clause
+author:             Inanna Malick
 build-type:         Simple
 
 common warnings

--- a/haskell/effects/llm-interpreter/exomonad-llm-interpreter.cabal
+++ b/haskell/effects/llm-interpreter/exomonad-llm-interpreter.cabal
@@ -4,8 +4,8 @@ version:            0.1.0.0
 synopsis:           LLM effect interpreter - Anthropic client
 description:        Socket-based implementation of LLMComplete effect for Anthropic.
                     Supports Anthropic with type-level provider switch.
-license:            MIT
-author:             Inanna
+license:            BSD-3-Clause
+author:             Inanna Malick
 build-type:         Simple
 
 common defaults

--- a/haskell/effects/observability-interpreter/exomonad-observability-interpreter.cabal
+++ b/haskell/effects/observability-interpreter/exomonad-observability-interpreter.cabal
@@ -2,8 +2,8 @@ cabal-version:      3.0
 name:               exomonad-observability-interpreter
 version:            0.1.0.0
 synopsis:           Observability effect interpreter - Loki push client
-license:            MIT
-author:             Inanna
+license:            BSD-3-Clause
+author:             Inanna Malick
 build-type:         Simple
 
 common warnings

--- a/haskell/effects/socket-client/exomonad-socket-client.cabal
+++ b/haskell/effects/socket-client/exomonad-socket-client.cabal
@@ -2,9 +2,8 @@ cabal-version:      3.0
 name:               exomonad-socket-client
 version:            0.1.0.0
 synopsis:           Unix socket client for ExoMonad effects
-license:            MIT
-author:             Tidepool Heavy Industries
-maintainer:         engineering@exomonad.io
+license:            BSD-3-Clause
+author:             Inanna Malick
 category:           Network
 build-type:         Simple
 

--- a/haskell/effects/worktree-interpreter/exomonad-worktree-interpreter.cabal
+++ b/haskell/effects/worktree-interpreter/exomonad-worktree-interpreter.cabal
@@ -8,8 +8,8 @@ description:
     Enables graphs to manage isolated git worktrees for parallel agent execution.
     Each worktree gets its own branch and working directory, allowing multiple
     Claude Code sessions to work in parallel without conflicts.
-license:            MIT
-author:             Inanna
+license:            BSD-3-Clause
+author:             Inanna Malick
 build-type:         Simple
 
 common warnings

--- a/haskell/effects/zellij-interpreter/exomonad-zellij-interpreter.cabal
+++ b/haskell/effects/zellij-interpreter/exomonad-zellij-interpreter.cabal
@@ -7,8 +7,8 @@ description:
     .
     Enables graphs to create tabs and interact with Zellij sessions
     for parallel agent orchestration.
-license:            MIT
-author:             Inanna
+license:            BSD-3-Clause
+author:             Inanna Malick
 build-type:         Simple
 
 common warnings

--- a/haskell/protocol/wire-types/exomonad-wire-types.cabal
+++ b/haskell/protocol/wire-types/exomonad-wire-types.cabal
@@ -2,8 +2,8 @@ cabal-version:      3.0
 name:               exomonad-wire-types
 version:            0.1.0.0
 synopsis:           Wire format types for exomonad native GUI (UIState, UserAction)
-license:            MIT
-author:             Inanna
+license:            BSD-3-Clause
+author:             Inanna Malick
 build-type:         Simple
 
 common warnings

--- a/haskell/tools/training-generator/exomonad-training-generator.cabal
+++ b/haskell/tools/training-generator/exomonad-training-generator.cabal
@@ -8,9 +8,8 @@ description:
   Arbitrary instances to generate synthetic edge contexts and heuristic
   scoring to produce ground-truth rubrics.
 
-license:       MIT
-author:        ExoMonad Authors
-maintainer:    dev@exomonad.so
+license:       BSD-3-Clause
+author:        Inanna Malick
 category:      Development
 build-type:    Simple
 

--- a/haskell/wasm-guest/wasm-guest.cabal
+++ b/haskell/wasm-guest/wasm-guest.cabal
@@ -2,9 +2,8 @@ cabal-version:      3.4
 name:               wasm-guest
 version:            0.1.0.0
 synopsis:           Haskell WASM Guest for ExoMonad
-license:            MIT
-author:             ExoMonad Team
-maintainer:         maintainers@exomonad.io
+license:            BSD-3-Clause
+author:             Inanna Malick
 build-type:         Simple
 
 common shared


### PR DESCRIPTION
Standardizes license and author fields across 14 Haskell `.cabal` files to use `BSD-3-Clause` and `Inanna Malick`. Also removes any fake maintainer emails.

- Changed `license: MIT` to `license: BSD-3-Clause`
- Changed `author:` to `Inanna Malick`
- Removed `maintainer:` fields with `exomonad.so`, `exomonad.io`, or `malick.com` emails.

Verification:
- Grepped for any remaining `license: MIT` in `haskell/` (excluding `vendor/`) -> none.
- Grepped for any authors other than `Inanna Malick` in `haskell/` (excluding `vendor/` and `proto/` which have none) -> none.
- Grepped for any `maintainer:` with `exomonad` in `haskell/` (excluding `vendor/`) -> none.