### PR TITLE
feat: implement ACP client and registry

### DIFF
--- a/rust/exomonad-core/src/services/acp_registry.rs
+++ b/rust/exomonad-core/src/services/acp_registry.rs
@@ -7,6 +7,14 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
+use anyhow::Context;
+use agent_client_protocol::{
+    Agent, ClientSideConnection, InitializeRequest, NewSessionRequest, PromptRequest,
+    Implementation, ProtocolVersion,
+};
+use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
+use std::process::Stdio;
+use tokio::process::Command;
 
 /// Metadata for an active ACP connection.
 #[derive(Debug)]
@@ -32,15 +40,108 @@ impl AcpRegistry {
         }
     }
 
-    pub async fn register(&self, _agent_id: String, _conn: AcpConnection) {
-        todo!("Insert connection into registry")
+    pub async fn register(&self, agent_id: String, conn: AcpConnection) {
+        let mut connections = self.connections.write().await;
+        tracing::info!(agent = %agent_id, "Registering ACP connection");
+        connections.insert(agent_id, Arc::new(conn));
     }
 
-    pub async fn get(&self, _agent_id: &str) -> Option<Arc<AcpConnection>> {
-        todo!("Look up connection by agent ID")
+    pub async fn get(&self, agent_id: &str) -> Option<Arc<AcpConnection>> {
+        self.connections.read().await.get(agent_id).cloned()
     }
 
-    pub async fn remove(&self, _agent_id: &str) -> Option<Arc<AcpConnection>> {
-        todo!("Remove and return connection")
+    pub async fn remove(&self, agent_id: &str) -> Option<Arc<AcpConnection>> {
+        let mut connections = self.connections.write().await;
+        let removed = connections.remove(agent_id);
+        if removed.is_some() {
+            tracing::info!(agent = %agent_id, "Removed ACP connection");
+        }
+        removed
     }
+}
+
+/// Spawn a Gemini CLI subprocess with ACP and send the initial prompt.
+///
+/// Returns the AcpConnection (with session_id and connection) for registry storage.
+/// The caller is responsible for registering it in the AcpRegistry.
+pub async fn connect_and_prompt(
+    agent_id: String,
+    gemini_command: &str,
+    working_dir: &std::path::Path,
+    initial_prompt: &str,
+    env_vars: Vec<(String, String)>,
+) -> anyhow::Result<AcpConnection> {
+    tracing::info!(agent = %agent_id, cwd = %working_dir.display(), "Spawning ACP subprocess");
+
+    let mut child = Command::new(gemini_command)
+        .arg("--experimental-acp")
+        .current_dir(working_dir)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .envs(env_vars)
+        .spawn()
+        .context("Failed to spawn gemini with --experimental-acp")?;
+
+    let stdin = child.stdin.take().context("No stdin on child")?;
+    let stdout = child.stdout.take().context("No stdout on child")?;
+
+    // Convert tokio AsyncRead/Write to futures AsyncRead/Write
+    let outgoing = stdin.compat_write();
+    let incoming = stdout.compat();
+
+    let client = super::acp_client::ExoMonadAcpClient {
+        agent_id: agent_id.clone(),
+    };
+
+    let (conn, io_task) = ClientSideConnection::new(
+        client,
+        outgoing,
+        incoming,
+        |fut| {
+            tokio::spawn(fut);
+        },
+    );
+
+    // Spawn the I/O task
+    tokio::spawn(async move {
+        if let Err(e) = io_task.await {
+            tracing::warn!(error = %e, "ACP I/O task ended with error");
+        }
+    });
+
+    // Initialize
+    tracing::info!(agent = %agent_id, "Initializing ACP connection");
+    conn.initialize(
+        InitializeRequest::new(ProtocolVersion::V1)
+            .client_info(Implementation::new("exomonad", env!("CARGO_PKG_VERSION"))),
+    )
+    .await
+    .map_err(|e| anyhow::anyhow!("ACP initialize failed: {:?}", e))?;
+
+    // Create session
+    tracing::info!(agent = %agent_id, "Creating ACP session");
+    let session = conn.new_session(NewSessionRequest::new(working_dir.to_path_buf()))
+        .await
+        .map_err(|e| anyhow::anyhow!("ACP new_session failed: {:?}", e))?;
+
+    let session_id = session.session_id.clone();
+    tracing::info!(agent = %agent_id, session_id = %session_id, "ACP session created");
+
+    // Send initial prompt
+    tracing::info!(agent = %agent_id, "Sending initial ACP prompt");
+    conn.prompt(PromptRequest::new(
+        session_id.clone(),
+        vec![initial_prompt.into()],
+    ))
+    .await
+    .map_err(|e| anyhow::anyhow!("ACP prompt failed: {:?}", e))?;
+
+    tracing::info!(agent = %agent_id, "Initial ACP prompt completed");
+
+    Ok(AcpConnection {
+        agent_id,
+        session_id,
+        conn,
+    })
 }


### PR DESCRIPTION
This PR implements the ACP (Agent Client Protocol) Client and Registry in `exomonad-core`.

Key changes:
- Implemented `AcpRegistry` methods: `register`, `get`, and `remove`.
- Added `connect_and_prompt` function to `acp_registry.rs` which handles the full ACP handshake (spawn, initialize, new_session, prompt).
- Implemented `ExoMonadAcpClient` in `acp_client.rs` with auto-approval for permissions and logging for session notifications.
- Used strict `::new()` constructors for ACP structs to comply with non-exhaustive definitions.

Verified with `cargo check -p exomonad-core`.