### PR TITLE
feat: add spawn_acp Rust handler with ACP integration

### DIFF
--- a/proto/effects/agent.proto
+++ b/proto/effects/agent.proto
@@ -278,6 +278,21 @@ message SpawnLeafSubtreeResponse {
 }
 
 // ============================================================================
+// SpawnAcp - Spawn a Gemini agent via ACP (headless, no Zellij)
+// ============================================================================
+
+message SpawnAcpRequest {
+  // Human-readable name for the agent.
+  string name = 1;
+  // Initial prompt/instructions for the agent.
+  string prompt = 2;
+}
+
+message SpawnAcpResponse {
+  AgentInfo agent = 1;
+}
+
+// ============================================================================
 // Service definition
 // ============================================================================
 
@@ -288,6 +303,7 @@ service AgentEffects {
   rpc SpawnWorker(SpawnWorkerRequest) returns (SpawnWorkerResponse);
   rpc SpawnSubtree(SpawnSubtreeRequest) returns (SpawnSubtreeResponse);
   rpc SpawnLeafSubtree(SpawnLeafSubtreeRequest) returns (SpawnLeafSubtreeResponse);
+  rpc SpawnAcp(SpawnAcpRequest) returns (SpawnAcpResponse);
   rpc Cleanup(CleanupRequest) returns (CleanupResponse);
   rpc CleanupBatch(CleanupBatchRequest) returns (CleanupBatchResponse);
   rpc CleanupMerged(CleanupMergedRequest) returns (CleanupMergedResponse);

--- a/rust/exomonad-core/src/handlers/groups.rs
+++ b/rust/exomonad-core/src/handlers/groups.rs
@@ -77,7 +77,8 @@ pub fn orchestration_handlers(
     vec![
         Box::new(
             AgentHandler::new(agent_control)
-                .with_claude_session_registry(claude_session_registry.clone()),
+                .with_claude_session_registry(claude_session_registry.clone())
+                .with_acp_registry(acp_registry.clone()),
         ),
         Box::new(PopupHandler::new(zellij_session)),
         Box::new(

--- a/rust/exomonad-core/src/services/agent_control.rs
+++ b/rust/exomonad-core/src/services/agent_control.rs
@@ -464,6 +464,11 @@ impl AgentControlService {
         self
     }
 
+    /// Get the MCP server port.
+    pub fn mcp_server_port(&self) -> Option<u16> {
+        self.mcp_server_port
+    }
+
     /// Create from environment (loads secrets from ~/.exo/secrets).
     pub fn from_env() -> Result<Self> {
         let project_dir = std::env::current_dir().context("Failed to get current directory")?;

--- a/rust/exomonad-proto/proto/effects/agent.proto
+++ b/rust/exomonad-proto/proto/effects/agent.proto
@@ -278,6 +278,21 @@ message SpawnLeafSubtreeResponse {
 }
 
 // ============================================================================
+// SpawnAcp - Spawn a Gemini agent via ACP (headless, no Zellij)
+// ============================================================================
+
+message SpawnAcpRequest {
+  // Human-readable name for the agent.
+  string name = 1;
+  // Initial prompt/instructions for the agent.
+  string prompt = 2;
+}
+
+message SpawnAcpResponse {
+  AgentInfo agent = 1;
+}
+
+// ============================================================================
 // Service definition
 // ============================================================================
 
@@ -288,6 +303,7 @@ service AgentEffects {
   rpc SpawnWorker(SpawnWorkerRequest) returns (SpawnWorkerResponse);
   rpc SpawnSubtree(SpawnSubtreeRequest) returns (SpawnSubtreeResponse);
   rpc SpawnLeafSubtree(SpawnLeafSubtreeRequest) returns (SpawnLeafSubtreeResponse);
+  rpc SpawnAcp(SpawnAcpRequest) returns (SpawnAcpResponse);
   rpc Cleanup(CleanupRequest) returns (CleanupResponse);
   rpc CleanupBatch(CleanupBatchRequest) returns (CleanupBatchResponse);
   rpc CleanupMerged(CleanupMergedRequest) returns (CleanupMergedResponse);


### PR DESCRIPTION
This PR implements the Rust side of the `spawn_acp` effect handler.

Key changes:
- Added `SpawnAcpRequest`, `SpawnAcpResponse`, and `SpawnAcp` RPC to `proto/effects/agent.proto` and `rust/exomonad-proto/proto/effects/agent.proto`.
- Added `acp_registry` field and `with_acp_registry` builder method to `AgentHandler` in `rust/exomonad-core/src/handlers/agent.rs`.
- Implemented `spawn_acp` in `AgentHandler` to spawn a Gemini agent via ACP, write settings, and register the connection.
- Added public accessor `mcp_server_port` to `AgentControlService`.
- Wired `AcpRegistry` into `AgentHandler` in `rust/exomonad-core/src/handlers/groups.rs`.

Verified with `cargo test --workspace` and WASM integration tests.