### PR TITLE
feat: add spawn_acp proto + Haskell WASM tool

### DIFF
--- a/haskell/proto/src/Effects/Agent.hs
+++ b/haskell/proto/src/Effects/Agent.hs
@@ -2365,3 +2365,131 @@ instance (HsJSONPB.ToJSON SpawnLeafSubtreeResponse) where
   toEncoding = HsJSONPB.toAesonEncoding
 instance (HsJSONPB.FromJSON SpawnLeafSubtreeResponse) where
   parseJSON = HsJSONPB.parseJSONPB
+data SpawnAcpRequest
+  = SpawnAcpRequest {spawnAcpRequestName :: Hs.Text,
+                     spawnAcpRequestPrompt :: Hs.Text}
+  deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)
+instance (Hs.NFData SpawnAcpRequest)
+instance (HsProtobuf.Named SpawnAcpRequest) where
+  nameOf _ = Hs.fromString "SpawnAcpRequest"
+instance (HsProtobuf.HasDefault SpawnAcpRequest)
+instance (HsProtobuf.Message SpawnAcpRequest) where
+  encodeMessage
+    _
+    SpawnAcpRequest {spawnAcpRequestName, spawnAcpRequestPrompt}
+    = Hs.mappend
+        (HsProtobuf.encodeMessageField
+           (HsProtobuf.FieldNumber 1)
+           ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
+              spawnAcpRequestName))
+        (HsProtobuf.encodeMessageField
+           (HsProtobuf.FieldNumber 2)
+           ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
+              spawnAcpRequestPrompt))
+  decodeMessage _
+    = Hs.pure SpawnAcpRequest
+        <*>
+          ((HsProtobuf.coerceOver @(HsProtobuf.String Hs.Text) @Hs.Text)
+             (HsProtobuf.at
+                HsProtobuf.decodeMessageField (HsProtobuf.FieldNumber 1)))
+        <*>
+          ((HsProtobuf.coerceOver @(HsProtobuf.String Hs.Text) @Hs.Text)
+             (HsProtobuf.at
+                HsProtobuf.decodeMessageField (HsProtobuf.FieldNumber 2)))
+  dotProto _
+    = [HsProtobufAST.DotProtoField
+         (HsProtobuf.FieldNumber 1)
+         (HsProtobufAST.Prim HsProtobufAST.String)
+         (HsProtobufAST.Single "name") [] "",
+       HsProtobufAST.DotProtoField
+         (HsProtobuf.FieldNumber 2)
+         (HsProtobufAST.Prim HsProtobufAST.String)
+         (HsProtobufAST.Single "prompt") [] ""]
+instance (HsJSONPB.ToJSONPB SpawnAcpRequest) where
+  toJSONPB (SpawnAcpRequest f1 f2)
+    = HsJSONPB.object
+        ["name" .= ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text)) f1),
+         "prompt" .= ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text)) f2)]
+  toEncodingPB (SpawnAcpRequest f1 f2)
+    = HsJSONPB.pairs
+        ["name" .= ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text)) f1),
+         "prompt" .= ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text)) f2)]
+instance (HsJSONPB.FromJSONPB SpawnAcpRequest) where
+  parseJSONPB
+    = HsJSONPB.withObject
+        "SpawnAcpRequest"
+        (\ obj
+           -> Hs.pure SpawnAcpRequest
+                <*>
+                  ((HsProtobuf.coerceOver @(HsProtobuf.String Hs.Text) @Hs.Text)
+                     (obj .: "name"))
+                <*>
+                  ((HsProtobuf.coerceOver @(HsProtobuf.String Hs.Text) @Hs.Text)
+                     (obj .: "prompt")))
+instance (HsJSONPB.ToJSON SpawnAcpRequest) where
+  toJSON = HsJSONPB.toAesonValue
+  toEncoding = HsJSONPB.toAesonEncoding
+instance (HsJSONPB.FromJSON SpawnAcpRequest) where
+  parseJSON = HsJSONPB.parseJSONPB
+newtype SpawnAcpResponse
+  = SpawnAcpResponse {spawnAcpResponseAgent :: (Hs.Maybe Effects.Agent.AgentInfo)}
+  deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)
+instance (Hs.NFData SpawnAcpResponse)
+instance (HsProtobuf.Named SpawnAcpResponse) where
+  nameOf _ = Hs.fromString "SpawnAcpResponse"
+instance (HsProtobuf.HasDefault SpawnAcpResponse)
+instance (HsProtobuf.Message SpawnAcpResponse) where
+  encodeMessage _ SpawnAcpResponse {spawnAcpResponseAgent}
+    = (HsProtobuf.encodeMessageField
+         (HsProtobuf.FieldNumber 1)
+         ((Hs.coerce
+             @(Hs.Maybe Effects.Agent.AgentInfo)
+             @(HsProtobuf.Nested Effects.Agent.AgentInfo))
+            spawnAcpResponseAgent))
+  decodeMessage _
+    = Hs.pure SpawnAcpResponse
+        <*>
+          ((HsProtobuf.coerceOver
+              @(HsProtobuf.Nested Effects.Agent.AgentInfo)
+              @(Hs.Maybe Effects.Agent.AgentInfo))
+             (HsProtobuf.at
+                HsProtobuf.decodeMessageField (HsProtobuf.FieldNumber 1)))
+  dotProto _
+    = [HsProtobufAST.DotProtoField
+         (HsProtobuf.FieldNumber 1)
+         (HsProtobufAST.Prim
+            (HsProtobufAST.Named (HsProtobufAST.Single "AgentInfo")))
+         (HsProtobufAST.Single "agent") [] ""]
+instance (HsJSONPB.ToJSONPB SpawnAcpResponse) where
+  toJSONPB (SpawnAcpResponse f1)
+    = HsJSONPB.object
+        ["agent"
+           .=
+             ((Hs.coerce
+                 @(Hs.Maybe Effects.Agent.AgentInfo)
+                 @(HsProtobuf.Nested Effects.Agent.AgentInfo))
+                f1)]
+  toEncodingPB (SpawnAcpResponse f1)
+    = HsJSONPB.pairs
+        ["agent"
+           .=
+             ((Hs.coerce
+                 @(Hs.Maybe Effects.Agent.AgentInfo)
+                 @(HsProtobuf.Nested Effects.Agent.AgentInfo))
+                f1)]
+instance (HsJSONPB.FromJSONPB SpawnAcpResponse) where
+  parseJSONPB
+    = HsJSONPB.withObject
+        "SpawnAcpResponse"
+        (\ obj
+           -> Hs.pure SpawnAcpResponse
+                <*>
+                  ((HsProtobuf.coerceOver
+                      @(HsProtobuf.Nested Effects.Agent.AgentInfo)
+                      @(Hs.Maybe Effects.Agent.AgentInfo))
+                     (obj .: "agent")))
+instance (HsJSONPB.ToJSON SpawnAcpResponse) where
+  toJSON = HsJSONPB.toAesonValue
+  toEncoding = HsJSONPB.toAesonEncoding
+instance (HsJSONPB.FromJSON SpawnAcpResponse) where
+  parseJSON = HsJSONPB.parseJSONPB

--- a/haskell/wasm-guest/src/ExoMonad/Effects/Agent.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Effects/Agent.hs
@@ -13,6 +13,7 @@ module ExoMonad.Effects.Agent
     AgentSpawnWorker,
     AgentSpawnSubtree,
     AgentSpawnLeafSubtree,
+    AgentSpawnAcp,
     AgentCleanup,
     AgentCleanupBatch,
     AgentCleanupMerged,
@@ -72,6 +73,13 @@ instance Effect AgentSpawnLeafSubtree where
   type Input AgentSpawnLeafSubtree = SpawnLeafSubtreeRequest
   type Output AgentSpawnLeafSubtree = SpawnLeafSubtreeResponse
   effectId = "agent.spawn_leaf_subtree"
+
+data AgentSpawnAcp
+
+instance Effect AgentSpawnAcp where
+  type Input AgentSpawnAcp = SpawnAcpRequest
+  type Output AgentSpawnAcp = SpawnAcpResponse
+  effectId = "agent.spawn_acp"
 
 data AgentCleanup
 

--- a/haskell/wasm-guest/src/ExoMonad/Guest/Records/Spawn.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Guest/Records/Spawn.hs
@@ -8,13 +8,14 @@ module ExoMonad.Guest.Records.Spawn
 where
 
 import ExoMonad.Guest.Tool.Mode (AsHandler, AsSchema, ToolMode ((:-)), mkHandler, mkSchema)
-import ExoMonad.Guest.Tools.Spawn (SpawnLeafSubtree, SpawnSubtree, SpawnWorkers)
+import ExoMonad.Guest.Tools.Spawn (SpawnAcp, SpawnLeafSubtree, SpawnSubtree, SpawnWorkers)
 import GHC.Generics (Generic)
 
 data SpawnTools mode = SpawnTools
   { spawnSubtree :: mode :- SpawnSubtree,
     spawnLeafSubtree :: mode :- SpawnLeafSubtree,
-    spawnWorkers :: mode :- SpawnWorkers
+    spawnWorkers :: mode :- SpawnWorkers,
+    spawnAcp :: mode :- SpawnAcp
   }
   deriving (Generic)
 
@@ -23,7 +24,8 @@ spawnToolsHandler =
   SpawnTools
     { spawnSubtree = mkHandler @SpawnSubtree,
       spawnLeafSubtree = mkHandler @SpawnLeafSubtree,
-      spawnWorkers = mkHandler @SpawnWorkers
+      spawnWorkers = mkHandler @SpawnWorkers,
+      spawnAcp = mkHandler @SpawnAcp
     }
 
 spawnToolsSchema :: SpawnTools AsSchema
@@ -31,7 +33,8 @@ spawnToolsSchema =
   SpawnTools
     { spawnSubtree = mkSchema @SpawnSubtree,
       spawnLeafSubtree = mkSchema @SpawnLeafSubtree,
-      spawnWorkers = mkSchema @SpawnWorkers
+      spawnWorkers = mkSchema @SpawnWorkers,
+      spawnAcp = mkSchema @SpawnAcp
     }
 
 spawnTools :: SpawnTools AsHandler

--- a/proto/effects/agent.proto
+++ b/proto/effects/agent.proto
@@ -278,6 +278,21 @@ message SpawnLeafSubtreeResponse {
 }
 
 // ============================================================================
+// SpawnAcp - Spawn a Gemini agent via ACP (headless, no Zellij)
+// ============================================================================
+
+message SpawnAcpRequest {
+  // Human-readable name for the agent.
+  string name = 1;
+  // Initial prompt/instructions for the agent.
+  string prompt = 2;
+}
+
+message SpawnAcpResponse {
+  AgentInfo agent = 1;
+}
+
+// ============================================================================
 // Service definition
 // ============================================================================
 
@@ -288,6 +303,7 @@ service AgentEffects {
   rpc SpawnWorker(SpawnWorkerRequest) returns (SpawnWorkerResponse);
   rpc SpawnSubtree(SpawnSubtreeRequest) returns (SpawnSubtreeResponse);
   rpc SpawnLeafSubtree(SpawnLeafSubtreeRequest) returns (SpawnLeafSubtreeResponse);
+  rpc SpawnAcp(SpawnAcpRequest) returns (SpawnAcpResponse);
   rpc Cleanup(CleanupRequest) returns (CleanupResponse);
   rpc CleanupBatch(CleanupBatchRequest) returns (CleanupBatchResponse);
   rpc CleanupMerged(CleanupMergedRequest) returns (CleanupMergedResponse);

--- a/rust/exomonad-proto/proto/effects/agent.proto
+++ b/rust/exomonad-proto/proto/effects/agent.proto
@@ -278,6 +278,21 @@ message SpawnLeafSubtreeResponse {
 }
 
 // ============================================================================
+// SpawnAcp - Spawn a Gemini agent via ACP (headless, no Zellij)
+// ============================================================================
+
+message SpawnAcpRequest {
+  // Human-readable name for the agent.
+  string name = 1;
+  // Initial prompt/instructions for the agent.
+  string prompt = 2;
+}
+
+message SpawnAcpResponse {
+  AgentInfo agent = 1;
+}
+
+// ============================================================================
 // Service definition
 // ============================================================================
 
@@ -288,6 +303,7 @@ service AgentEffects {
   rpc SpawnWorker(SpawnWorkerRequest) returns (SpawnWorkerResponse);
   rpc SpawnSubtree(SpawnSubtreeRequest) returns (SpawnSubtreeResponse);
   rpc SpawnLeafSubtree(SpawnLeafSubtreeRequest) returns (SpawnLeafSubtreeResponse);
+  rpc SpawnAcp(SpawnAcpRequest) returns (SpawnAcpResponse);
   rpc Cleanup(CleanupRequest) returns (CleanupResponse);
   rpc CleanupBatch(CleanupBatchRequest) returns (CleanupBatchResponse);
   rpc CleanupMerged(CleanupMergedRequest) returns (CleanupMergedResponse);


### PR DESCRIPTION
Adds the Haskell side of the `spawn_acp` MCP tool for spawning Gemini agents via ACP (headless, no Zellij tab).

## Changes
- Proto: `SpawnAcpRequest`/`SpawnAcpResponse` messages + service RPC (both proto copies)
- Effect: `AgentSpawnAcp` phantom type + Effect instance
- AgentControl: `SpawnAcpC` GADT constructor + `spawnAcp` smart constructor + interpreter case
- Tool: `SpawnAcp` MCPTool instance with schema, handler, event emission
- Record: `spawnAcp` field added to `SpawnTools`

## Verify
- `just proto-gen` succeeds
- `just wasm-all` compiles without errors