### PR TITLE
feat: configurable root agent type (Claude/Gemini)

### DIFF
--- a/rust/exomonad-core/src/services/mod.rs
+++ b/rust/exomonad-core/src/services/mod.rs
@@ -29,8 +29,8 @@ pub mod zellij_ipc;
 
 pub use self::acp_registry::AcpRegistry;
 pub use self::agent_control::{
-    resolve_parent_tab_name, AgentControlService, AgentInfo, BatchCleanupResult, BatchSpawnResult,
-    SpawnOptions, SpawnResult,
+    resolve_parent_tab_name, AgentControlService, AgentInfo, AgentType, BatchCleanupResult,
+    BatchSpawnResult, SpawnOptions, SpawnResult,
 };
 pub use self::event_log::EventLog;
 pub use self::event_queue::EventQueue;


### PR DESCRIPTION
This PR adds a new configuration option `root_agent_type` to `.exo/config.toml` (and `config.local.toml`).
This allows users to specify whether the root (TL) tab should spawn a Claude or Gemini agent.

Changes:
- Re-exported `AgentType` in `exomonad-core::services`.
- Added `root_agent_type` to `RawConfig` and `Config` in `rust/exomonad/src/config.rs`.
- Updated `Config::discover()` to resolve `root_agent_type`, defaulting to `Claude` (per instructions).
- Updated `exomonad init` logic to use the configured `root_agent_type` when generating the TL tab layout.
- Added tests for the new configuration fields.

Verification:
- `cargo check -p exomonad` passed.
- `cargo test -p exomonad` passed (including new config tests).
- `cargo test -p exomonad-core` passed (unit tests).