### PR TITLE
feat: structured logging for agent spawn and completion events

### DIFF
--- a/rust/exomonad/src/main.rs
+++ b/rust/exomonad/src/main.rs
@@ -1069,6 +1069,7 @@ async fn main() -> Result<()> {
                 claude_session_registry,
                 team_registry.clone(),
                 acp_registry.clone(),
+                event_log.clone(),
             );
             builder = builder.with_handlers(orch_handlers);
             let rt = builder.build().await.context("Failed to build runtime")?;


### PR DESCRIPTION
This PR adds structured event logging to several key agent lifecycle events in ExoMonad.

Specifically:
- **Agent spawning**: Logged for `subtree`, `leaf_subtree`, `worker`, and `acp` spawn types in `AgentHandler`.
- **Completion signaling**: Logged when an agent calls `notify_parent` in `EventHandler`.
- **Message delivery**: Logged after `notify_parent` successfully delivers a message to the parent agent, including the delivery method used (`teams_inbox`, `acp`, or `zellij_stdin`).

These events are appended to the structured event log (`.exo/events.jsonl`) when available.

Changes:
- Added `event_log` field and `with_event_log` builder method to `AgentHandler` and `EventHandler`.
- Updated `orchestration_handlers` in `exomonad-core` to accept and wire `EventLog`.
- Updated `exomonad` server initialization to pass `EventLog` to orchestration handlers.
- Integrated logging calls into spawn and notify handlers.