### PR TITLE
feat: add secure_mode to proto + Rust workspace scrubbing

### DIFF
--- a/proto/effects/agent.proto
+++ b/proto/effects/agent.proto
@@ -270,6 +270,8 @@ message SpawnSubtreeRequest {
   repeated string allowed_tools = 8;
   // Tool patterns to disallow (e.g., "Bash"). Empty = no restriction.
   repeated string disallowed_tools = 9;
+  // Secure mode for agent isolation.
+  bool secure_mode = 10;
 }
 
 message SpawnSubtreeResponse {
@@ -293,6 +295,8 @@ message SpawnLeafSubtreeRequest {
   repeated string allowed_tools = 6;
   // Tool patterns to disallow. Empty = no restriction.
   repeated string disallowed_tools = 7;
+  // Secure mode for agent isolation.
+  bool secure_mode = 8;
 }
 
 message SpawnLeafSubtreeResponse {

--- a/rust/exomonad-core/src/handlers/agent.rs
+++ b/rust/exomonad-core/src/handlers/agent.rs
@@ -292,6 +292,7 @@ impl AgentEffects for AgentHandler {
                 req.allowed_tools.clone(),
                 req.disallowed_tools.clone(),
             ),
+            secure_mode: req.secure_mode,
         };
 
         let result = self
@@ -341,6 +342,7 @@ impl AgentEffects for AgentHandler {
                 req.allowed_tools.clone(),
                 req.disallowed_tools.clone(),
             ),
+            secure_mode: req.secure_mode,
         };
 
         let result = self

--- a/rust/exomonad-core/src/services/agent_control.rs
+++ b/rust/exomonad-core/src/services/agent_control.rs
@@ -22,6 +22,7 @@ use super::git_worktree::GitWorktreeService;
 use super::github::{GitHubService, Repo};
 use super::zellij_events;
 use super::acp_registry::AcpRegistry;
+use crate::services::event_log::EventLog;
 use std::sync::Arc;
 
 const SPAWN_TIMEOUT: Duration = Duration::from_secs(60);
@@ -285,6 +286,9 @@ pub struct SpawnSubtreeOptions {
     /// Claude-specific permission flags (ignored for Gemini).
     #[serde(default)]
     pub claude_flags: ClaudeSpawnFlags,
+    /// Secure mode for agent isolation.
+    #[serde(default)]
+    pub secure_mode: bool,
 }
 
 /// Result of spawning an agent.
@@ -1046,7 +1050,15 @@ impl AgentControlService {
 
             self.create_worktree_checked(&worktree_path, &branch_name, current_branch).await?;
 
+            if options.secure_mode {
+                scrub_worktree(&worktree_path, None, &slug).await?;
+            }
+
             let mut env_vars = self.common_spawn_env(&internal_name, &branch_name);
+            if options.secure_mode {
+                env_vars.remove("EXOMONAD_SESSION_ID");
+                env_vars.insert("EXOMONAD_SECURE_MODE".to_string(), "1".to_string());
+            }
             // Enable Claude Code Agent Teams for native inter-agent messaging
             env_vars.insert(
                 "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS".to_string(),
@@ -1183,7 +1195,15 @@ impl AgentControlService {
 
             self.create_worktree_checked(&worktree_path, &branch_name, &current_branch).await?;
 
+            if options.secure_mode {
+                scrub_worktree(&worktree_path, None, &slug).await?;
+            }
+
             let mut env_vars = self.common_spawn_env(&internal_name, &branch_name);
+            if options.secure_mode {
+                env_vars.remove("EXOMONAD_SESSION_ID");
+                env_vars.insert("EXOMONAD_SECURE_MODE".to_string(), "1".to_string());
+            }
 
             // Write .gemini/settings.json in worktree root
             let role = options.role.as_deref().unwrap_or("dev");
@@ -2428,5 +2448,71 @@ mod tests {
             command_hook.get("args").is_none(),
             "args should not be present when using command string"
         );
+    }
+}
+
+/// Strip sensitive metadata from a worktree for secure agent isolation.
+pub async fn scrub_worktree(worktree_path: &Path, event_log: Option<&EventLog>, agent_id: &str) -> Result<()> {
+    let mut removed_items = Vec::new();
+    for dir_name in [".exo", ".claude", ".gemini"] {
+        let dir = worktree_path.join(dir_name);
+        if dir.exists() {
+            tokio::fs::remove_dir_all(&dir).await?;
+            removed_items.push(dir_name.to_string());
+        }
+    }
+    for pattern in [".env", "CLAUDE.md", "CLAUDE.local.md"] {
+        if pattern == ".env" {
+            let mut entries = tokio::fs::read_dir(worktree_path).await?;
+            while let Some(entry) = entries.next_entry().await? {
+                let name = entry.file_name();
+                let name_str = name.to_string_lossy();
+                if name_str == ".env" || name_str.starts_with(".env.") {
+                    tokio::fs::remove_file(entry.path()).await?;
+                    removed_items.push(name_str.into_owned());
+                }
+            }
+        } else {
+            let file = worktree_path.join(pattern);
+            if file.exists() {
+                tokio::fs::remove_file(&file).await?;
+                removed_items.push(pattern.to_string());
+            }
+        }
+    }
+    if let Some(log) = event_log {
+        let data = serde_json::json!({
+            "removed_items": removed_items,
+        });
+        if let Err(e) = log.append("security.workspace.scrubbed", agent_id, &data) {
+            tracing::warn!("Failed to append security.workspace.scrubbed event: {}", e);
+        }
+    }
+    tracing::info!("Scrubbed worktree {}: removed {:?}", worktree_path.display(), removed_items);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests2 {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_scrub_worktree() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let path = tempdir.path();
+        tokio::fs::create_dir(path.join(".exo")).await.unwrap();
+        tokio::fs::create_dir(path.join(".claude")).await.unwrap();
+        tokio::fs::create_dir(path.join("src")).await.unwrap();
+        tokio::fs::write(path.join(".env"), "SECRET=1").await.unwrap();
+        tokio::fs::write(path.join("CLAUDE.md"), "info").await.unwrap();
+        tokio::fs::write(path.join("src/main.rs"), "fn main() {}").await.unwrap();
+
+        scrub_worktree(path, None, "test-agent").await.unwrap();
+
+        assert!(!path.join(".exo").exists());
+        assert!(!path.join(".claude").exists());
+        assert!(!path.join(".env").exists());
+        assert!(!path.join("CLAUDE.md").exists());
+        assert!(path.join("src/main.rs").exists());
     }
 }

--- a/rust/exomonad-proto/proto/effects/agent.proto
+++ b/rust/exomonad-proto/proto/effects/agent.proto
@@ -270,6 +270,8 @@ message SpawnSubtreeRequest {
   repeated string allowed_tools = 8;
   // Tool patterns to disallow (e.g., "Bash"). Empty = no restriction.
   repeated string disallowed_tools = 9;
+  // Secure mode for agent isolation.
+  bool secure_mode = 10;
 }
 
 message SpawnSubtreeResponse {
@@ -293,6 +295,8 @@ message SpawnLeafSubtreeRequest {
   repeated string allowed_tools = 6;
   // Tool patterns to disallow. Empty = no restriction.
   repeated string disallowed_tools = 7;
+  // Secure mode for agent isolation.
+  bool secure_mode = 8;
 }
 
 message SpawnLeafSubtreeResponse {


### PR DESCRIPTION
Adds `secure_mode` to `SpawnSubtreeRequest` and `SpawnLeafSubtreeRequest` in proto, implements `scrub_worktree` for secure isolation in Rust, and manages sensitive `.env` variables and directories.