### PR TITLE
feat: filesystem scoping hook + secure_mode spawn arg threading

### DIFF
--- a/.exo/lib/SecureHooks.hs
+++ b/.exo/lib/SecureHooks.hs
@@ -1,0 +1,94 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE DataKinds #-}
+
+module SecureHooks
+  ( securePreToolUse,
+  )
+where
+
+import Control.Monad (void)
+import Control.Monad.Freer (Eff, sendM)
+import Data.Aeson qualified as Aeson
+import Data.Aeson.KeyMap qualified as KeyMap
+import Data.ByteString.Lazy qualified as BSL
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Text.Lazy qualified as TL
+import Effects.Log qualified as Log
+import ExoMonad.Effects.Log (LogEmitEvent)
+import ExoMonad.Guest.Tool.SuspendEffect (suspendEffect_)
+import ExoMonad.Guest.Types (HookInput (..), HookOutput, allowResponse, denyResponse)
+import ExoMonad.Types (HookEffects)
+import System.Environment (lookupEnv)
+
+-- | Canonicalize path: split on "/", filter out "." and resolve ".."
+canonicalizePath :: Text -> Text
+canonicalizePath path = T.intercalate "/" $ resolve [] (T.splitOn "/" path)
+  where
+    resolve acc [] = reverse acc
+    resolve acc ("." : rest) = resolve acc rest
+    resolve [] (".." : rest) = ".." : resolve [] rest
+    resolve (_ : acc) (".." : rest) = resolve acc rest
+    resolve acc ("" : rest) = resolve acc rest
+    resolve acc (x : rest) = resolve (x : acc) rest
+
+checkScope :: Text -> Text -> Bool
+checkScope cwd path =
+  let fullPath = if "/" `T.isPrefixOf` path then path else cwd <> "/" <> path
+      canonPath = canonicalizePath fullPath
+      canonCwd = canonicalizePath cwd
+  in canonCwd `T.isPrefixOf` canonPath
+
+emitEvent :: Text -> Text -> HookInput -> Eff HookEffects ()
+emitEvent eventType toolName hookInput = do
+  let args = fromMaybe (Aeson.Object mempty) (hiToolInput hookInput)
+      payload = BSL.toStrict $ Aeson.encode $ Aeson.object
+        [ "tool" Aeson..= toolName,
+          "args" Aeson..= args
+        ]
+  void $ suspendEffect_ @LogEmitEvent (Log.EmitEventRequest
+    { Log.emitEventRequestEventType = TL.fromStrict eventType,
+      Log.emitEventRequestPayload = payload,
+      Log.emitEventRequestTimestamp = 0
+    })
+
+securePreToolUse :: HookInput -> Eff HookEffects HookOutput
+securePreToolUse hookInput = do
+  envVal <- sendM $ lookupEnv "EXOMONAD_SECURE_MODE"
+  case envVal of
+    Nothing -> pure (allowResponse Nothing)
+    Just _ -> do
+      case hiCwd hookInput of
+        Nothing -> pure (allowResponse Nothing)
+        Just cwd -> do
+          let tool = fromMaybe "" (hiToolName hookInput)
+              args = fromMaybe (Aeson.Object mempty) (hiToolInput hookInput)
+          
+          if tool `elem` ["Read", "Write", "Edit", "Glob", "Grep"]
+            then do
+              let mPath = case args of
+                    Aeson.Object obj -> 
+                      -- Some tools use "file_path", some use "path"
+                      case KeyMap.lookup "file_path" obj of
+                        Just (Aeson.String p) -> Just p
+                        _ -> case KeyMap.lookup "path" obj of
+                          Just (Aeson.String p) -> Just p
+                          _ -> Nothing
+                    _ -> Nothing
+              case mPath of
+                Nothing -> pure (allowResponse Nothing)
+                Just path -> do
+                  if checkScope cwd path
+                    then do
+                      emitEvent "security.access.allowed" tool hookInput
+                      pure (allowResponse Nothing)
+                    else do
+                      emitEvent "security.access.denied" tool hookInput
+                      pure (denyResponse ("Access denied: Path escapes current working directory (" <> cwd <> ")"))
+            else if tool == "Bash"
+              then do
+                emitEvent "security.access.warning" tool hookInput
+                pure (allowResponse Nothing)
+              else pure (allowResponse Nothing)

--- a/haskell/proto/src/Effects/Agent.hs
+++ b/haskell/proto/src/Effects/Agent.hs
@@ -1952,31 +1952,36 @@ instance (HsProtobuf.Message SpawnWorkerRequest) where
   encodeMessage
     _
     SpawnWorkerRequest {spawnWorkerRequestName,
-                        spawnWorkerRequestPrompt,
-                        spawnWorkerRequestPermissionMode,
-                        spawnWorkerRequestAllowedTools,
-                        spawnWorkerRequestDisallowedTools}
-    = Hs.mconcat
-        [HsProtobuf.encodeMessageField
-           (HsProtobuf.FieldNumber 1)
-           ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
-              spawnWorkerRequestName),
-         HsProtobuf.encodeMessageField
-           (HsProtobuf.FieldNumber 2)
-           ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
-              spawnWorkerRequestPrompt),
-         HsProtobuf.encodeMessageField
-           (HsProtobuf.FieldNumber 3)
-           ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
-              spawnWorkerRequestPermissionMode),
-         HsProtobuf.encodeMessageField
-           (HsProtobuf.FieldNumber 4)
-           ((Hs.coerce @(Hs.Vector Hs.Text) @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)))
-              spawnWorkerRequestAllowedTools),
-         HsProtobuf.encodeMessageField
+                        spawnWorkerRequestPrompt, spawnWorkerRequestPermissionMode,
+                        spawnWorkerRequestAllowedTools, spawnWorkerRequestDisallowedTools}
+    = Hs.mappend
+        (Hs.mappend
+           (Hs.mappend
+              (Hs.mappend
+                 (HsProtobuf.encodeMessageField
+                    (HsProtobuf.FieldNumber 1)
+                    ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
+                       spawnWorkerRequestName))
+                 (HsProtobuf.encodeMessageField
+                    (HsProtobuf.FieldNumber 2)
+                    ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
+                       spawnWorkerRequestPrompt)))
+              (HsProtobuf.encodeMessageField
+                 (HsProtobuf.FieldNumber 3)
+                 ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
+                    spawnWorkerRequestPermissionMode)))
+           (HsProtobuf.encodeMessageField
+              (HsProtobuf.FieldNumber 4)
+              ((Hs.coerce
+                  @(Hs.Vector Hs.Text)
+                  @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)))
+                 spawnWorkerRequestAllowedTools)))
+        (HsProtobuf.encodeMessageField
            (HsProtobuf.FieldNumber 5)
-           ((Hs.coerce @(Hs.Vector Hs.Text) @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)))
-              spawnWorkerRequestDisallowedTools)]
+           ((Hs.coerce
+               @(Hs.Vector Hs.Text)
+               @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)))
+              spawnWorkerRequestDisallowedTools))
   decodeMessage _
     = Hs.pure SpawnWorkerRequest
         <*>
@@ -1992,11 +1997,15 @@ instance (HsProtobuf.Message SpawnWorkerRequest) where
              (HsProtobuf.at
                 HsProtobuf.decodeMessageField (HsProtobuf.FieldNumber 3)))
         <*>
-          ((HsProtobuf.coerceOver @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)) @(Hs.Vector Hs.Text))
+          ((HsProtobuf.coerceOver
+              @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text))
+              @(Hs.Vector Hs.Text))
              (HsProtobuf.at
                 HsProtobuf.decodeMessageField (HsProtobuf.FieldNumber 4)))
         <*>
-          ((HsProtobuf.coerceOver @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)) @(Hs.Vector Hs.Text))
+          ((HsProtobuf.coerceOver
+              @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text))
+              @(Hs.Vector Hs.Text))
              (HsProtobuf.at
                 HsProtobuf.decodeMessageField (HsProtobuf.FieldNumber 5)))
   dotProto _
@@ -2025,16 +2034,38 @@ instance (HsJSONPB.ToJSONPB SpawnWorkerRequest) where
     = HsJSONPB.object
         ["name" .= ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text)) f1),
          "prompt" .= ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text)) f2),
-         "permissionMode" .= ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text)) f3),
-         "allowedTools" .= ((Hs.coerce @(Hs.Vector Hs.Text) @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text))) f4),
-         "disallowedTools" .= ((Hs.coerce @(Hs.Vector Hs.Text) @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text))) f5)]
+         "permission_mode"
+           .= ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text)) f3),
+         "allowed_tools"
+           .=
+             ((Hs.coerce
+                 @(Hs.Vector Hs.Text)
+                 @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)))
+                f4),
+         "disallowed_tools"
+           .=
+             ((Hs.coerce
+                 @(Hs.Vector Hs.Text)
+                 @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)))
+                f5)]
   toEncodingPB (SpawnWorkerRequest f1 f2 f3 f4 f5)
     = HsJSONPB.pairs
         ["name" .= ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text)) f1),
          "prompt" .= ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text)) f2),
-         "permissionMode" .= ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text)) f3),
-         "allowedTools" .= ((Hs.coerce @(Hs.Vector Hs.Text) @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text))) f4),
-         "disallowedTools" .= ((Hs.coerce @(Hs.Vector Hs.Text) @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text))) f5)]
+         "permission_mode"
+           .= ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text)) f3),
+         "allowed_tools"
+           .=
+             ((Hs.coerce
+                 @(Hs.Vector Hs.Text)
+                 @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)))
+                f4),
+         "disallowed_tools"
+           .=
+             ((Hs.coerce
+                 @(Hs.Vector Hs.Text)
+                 @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)))
+                f5)]
 instance (HsJSONPB.FromJSONPB SpawnWorkerRequest) where
   parseJSONPB
     = HsJSONPB.withObject
@@ -2049,13 +2080,17 @@ instance (HsJSONPB.FromJSONPB SpawnWorkerRequest) where
                      (obj .: "prompt"))
                 <*>
                   ((HsProtobuf.coerceOver @(HsProtobuf.String Hs.Text) @Hs.Text)
-                     (obj .: "permissionMode"))
+                     (obj .: "permission_mode"))
                 <*>
-                  ((HsProtobuf.coerceOver @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)) @(Hs.Vector Hs.Text))
-                     (obj .: "allowedTools"))
+                  ((HsProtobuf.coerceOver
+                      @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text))
+                      @(Hs.Vector Hs.Text))
+                     (obj .: "allowed_tools"))
                 <*>
-                  ((HsProtobuf.coerceOver @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)) @(Hs.Vector Hs.Text))
-                     (obj .: "disallowedTools")))
+                  ((HsProtobuf.coerceOver
+                      @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text))
+                      @(Hs.Vector Hs.Text))
+                     (obj .: "disallowed_tools")))
 instance (HsJSONPB.ToJSON SpawnWorkerRequest) where
   toJSON = HsJSONPB.toAesonValue
   toEncoding = HsJSONPB.toAesonEncoding
@@ -2132,7 +2167,8 @@ data SpawnSubtreeRequest
                          spawnSubtreeRequestAgentType :: (HsProtobuf.Enumerated Effects.Agent.AgentType),
                          spawnSubtreeRequestPermissionMode :: Hs.Text,
                          spawnSubtreeRequestAllowedTools :: (Hs.Vector Hs.Text),
-                         spawnSubtreeRequestDisallowedTools :: (Hs.Vector Hs.Text)}
+                         spawnSubtreeRequestDisallowedTools :: (Hs.Vector Hs.Text),
+                         spawnSubtreeRequestSecureMode :: Hs.Bool}
   deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)
 instance (Hs.NFData SpawnSubtreeRequest)
 instance (HsProtobuf.Named SpawnSubtreeRequest) where
@@ -2145,40 +2181,55 @@ instance (HsProtobuf.Message SpawnSubtreeRequest) where
                          spawnSubtreeRequestBranchName, spawnSubtreeRequestParentSessionId,
                          spawnSubtreeRequestForkSession, spawnSubtreeRequestRole,
                          spawnSubtreeRequestAgentType, spawnSubtreeRequestPermissionMode,
-                         spawnSubtreeRequestAllowedTools, spawnSubtreeRequestDisallowedTools}
-    = Hs.mconcat
-        [HsProtobuf.encodeMessageField
-           (HsProtobuf.FieldNumber 1)
-           ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
-              spawnSubtreeRequestTask),
-         HsProtobuf.encodeMessageField
-           (HsProtobuf.FieldNumber 2)
-           ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
-              spawnSubtreeRequestBranchName),
-         HsProtobuf.encodeMessageField
-           (HsProtobuf.FieldNumber 3)
-           ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
-              spawnSubtreeRequestParentSessionId),
-         HsProtobuf.encodeMessageField
-           (HsProtobuf.FieldNumber 4) spawnSubtreeRequestForkSession,
-         HsProtobuf.encodeMessageField
-           (HsProtobuf.FieldNumber 5)
-           ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
-              spawnSubtreeRequestRole),
-         HsProtobuf.encodeMessageField
-           (HsProtobuf.FieldNumber 6) spawnSubtreeRequestAgentType,
-         HsProtobuf.encodeMessageField
-           (HsProtobuf.FieldNumber 7)
-           ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
-              spawnSubtreeRequestPermissionMode),
-         HsProtobuf.encodeMessageField
-           (HsProtobuf.FieldNumber 8)
-           ((Hs.coerce @(Hs.Vector Hs.Text) @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)))
-              spawnSubtreeRequestAllowedTools),
-         HsProtobuf.encodeMessageField
-           (HsProtobuf.FieldNumber 9)
-           ((Hs.coerce @(Hs.Vector Hs.Text) @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)))
-              spawnSubtreeRequestDisallowedTools)]
+                         spawnSubtreeRequestAllowedTools,
+                         spawnSubtreeRequestDisallowedTools, spawnSubtreeRequestSecureMode}
+    = Hs.mappend
+        (Hs.mappend
+           (Hs.mappend
+              (Hs.mappend
+                 (Hs.mappend
+                    (Hs.mappend
+                       (Hs.mappend
+                          (Hs.mappend
+                             (Hs.mappend
+                                (HsProtobuf.encodeMessageField
+                                   (HsProtobuf.FieldNumber 1)
+                                   ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
+                                      spawnSubtreeRequestTask))
+                                (HsProtobuf.encodeMessageField
+                                   (HsProtobuf.FieldNumber 2)
+                                   ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
+                                      spawnSubtreeRequestBranchName)))
+                             (HsProtobuf.encodeMessageField
+                                (HsProtobuf.FieldNumber 3)
+                                ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
+                                   spawnSubtreeRequestParentSessionId)))
+                          (HsProtobuf.encodeMessageField
+                             (HsProtobuf.FieldNumber 4) spawnSubtreeRequestForkSession))
+                       (HsProtobuf.encodeMessageField
+                          (HsProtobuf.FieldNumber 5)
+                          ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
+                             spawnSubtreeRequestRole)))
+                    (HsProtobuf.encodeMessageField
+                       (HsProtobuf.FieldNumber 6) spawnSubtreeRequestAgentType))
+                 (HsProtobuf.encodeMessageField
+                    (HsProtobuf.FieldNumber 7)
+                    ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
+                       spawnSubtreeRequestPermissionMode)))
+              (HsProtobuf.encodeMessageField
+                 (HsProtobuf.FieldNumber 8)
+                 ((Hs.coerce
+                     @(Hs.Vector Hs.Text)
+                     @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)))
+                    spawnSubtreeRequestAllowedTools)))
+           (HsProtobuf.encodeMessageField
+              (HsProtobuf.FieldNumber 9)
+              ((Hs.coerce
+                  @(Hs.Vector Hs.Text)
+                  @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)))
+                 spawnSubtreeRequestDisallowedTools)))
+        (HsProtobuf.encodeMessageField
+           (HsProtobuf.FieldNumber 10) spawnSubtreeRequestSecureMode)
   decodeMessage _
     = Hs.pure SpawnSubtreeRequest
         <*>
@@ -2208,13 +2259,20 @@ instance (HsProtobuf.Message SpawnSubtreeRequest) where
              (HsProtobuf.at
                 HsProtobuf.decodeMessageField (HsProtobuf.FieldNumber 7)))
         <*>
-          ((HsProtobuf.coerceOver @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)) @(Hs.Vector Hs.Text))
+          ((HsProtobuf.coerceOver
+              @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text))
+              @(Hs.Vector Hs.Text))
              (HsProtobuf.at
                 HsProtobuf.decodeMessageField (HsProtobuf.FieldNumber 8)))
         <*>
-          ((HsProtobuf.coerceOver @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)) @(Hs.Vector Hs.Text))
+          ((HsProtobuf.coerceOver
+              @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text))
+              @(Hs.Vector Hs.Text))
              (HsProtobuf.at
                 HsProtobuf.decodeMessageField (HsProtobuf.FieldNumber 9)))
+        <*>
+          HsProtobuf.at
+            HsProtobuf.decodeMessageField (HsProtobuf.FieldNumber 10)
   dotProto _
     = [HsProtobufAST.DotProtoField
          (HsProtobuf.FieldNumber 1)
@@ -2251,9 +2309,12 @@ instance (HsProtobuf.Message SpawnSubtreeRequest) where
        HsProtobufAST.DotProtoField
          (HsProtobuf.FieldNumber 9)
          (HsProtobufAST.Repeated HsProtobufAST.String)
-         (HsProtobufAST.Single "disallowed_tools") [] ""]
+         (HsProtobufAST.Single "disallowed_tools") [] "",
+       HsProtobufAST.DotProtoField
+         (HsProtobuf.FieldNumber 10) (HsProtobufAST.Prim HsProtobufAST.Bool)
+         (HsProtobufAST.Single "secure_mode") [] ""]
 instance (HsJSONPB.ToJSONPB SpawnSubtreeRequest) where
-  toJSONPB (SpawnSubtreeRequest f1 f2 f3 f4 f5 f6 f7 f8 f9)
+  toJSONPB (SpawnSubtreeRequest f1 f2 f3 f4 f5 f6 f7 f8 f9 f10)
     = HsJSONPB.object
         ["task" .= ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text)) f1),
          "branch_name"
@@ -2263,10 +2324,22 @@ instance (HsJSONPB.ToJSONPB SpawnSubtreeRequest) where
          "fork_session" .= f4,
          "role" .= ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text)) f5),
          "agent_type" .= f6,
-         "permissionMode" .= ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text)) f7),
-         "allowedTools" .= ((Hs.coerce @(Hs.Vector Hs.Text) @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text))) f8),
-         "disallowedTools" .= ((Hs.coerce @(Hs.Vector Hs.Text) @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text))) f9)]
-  toEncodingPB (SpawnSubtreeRequest f1 f2 f3 f4 f5 f6 f7 f8 f9)
+         "permission_mode"
+           .= ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text)) f7),
+         "allowed_tools"
+           .=
+             ((Hs.coerce
+                 @(Hs.Vector Hs.Text)
+                 @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)))
+                f8),
+         "disallowed_tools"
+           .=
+             ((Hs.coerce
+                 @(Hs.Vector Hs.Text)
+                 @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)))
+                f9),
+         "secure_mode" .= f10]
+  toEncodingPB (SpawnSubtreeRequest f1 f2 f3 f4 f5 f6 f7 f8 f9 f10)
     = HsJSONPB.pairs
         ["task" .= ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text)) f1),
          "branch_name"
@@ -2276,9 +2349,21 @@ instance (HsJSONPB.ToJSONPB SpawnSubtreeRequest) where
          "fork_session" .= f4,
          "role" .= ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text)) f5),
          "agent_type" .= f6,
-         "permissionMode" .= ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text)) f7),
-         "allowedTools" .= ((Hs.coerce @(Hs.Vector Hs.Text) @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text))) f8),
-         "disallowedTools" .= ((Hs.coerce @(Hs.Vector Hs.Text) @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text))) f9)]
+         "permission_mode"
+           .= ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text)) f7),
+         "allowed_tools"
+           .=
+             ((Hs.coerce
+                 @(Hs.Vector Hs.Text)
+                 @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)))
+                f8),
+         "disallowed_tools"
+           .=
+             ((Hs.coerce
+                 @(Hs.Vector Hs.Text)
+                 @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)))
+                f9),
+         "secure_mode" .= f10]
 instance (HsJSONPB.FromJSONPB SpawnSubtreeRequest) where
   parseJSONPB
     = HsJSONPB.withObject
@@ -2301,13 +2386,18 @@ instance (HsJSONPB.FromJSONPB SpawnSubtreeRequest) where
                 <*> obj .: "agent_type"
                 <*>
                   ((HsProtobuf.coerceOver @(HsProtobuf.String Hs.Text) @Hs.Text)
-                     (obj .: "permissionMode"))
+                     (obj .: "permission_mode"))
                 <*>
-                  ((HsProtobuf.coerceOver @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)) @(Hs.Vector Hs.Text))
-                     (obj .: "allowedTools"))
+                  ((HsProtobuf.coerceOver
+                      @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text))
+                      @(Hs.Vector Hs.Text))
+                     (obj .: "allowed_tools"))
                 <*>
-                  ((HsProtobuf.coerceOver @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)) @(Hs.Vector Hs.Text))
-                     (obj .: "disallowedTools")))
+                  ((HsProtobuf.coerceOver
+                      @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text))
+                      @(Hs.Vector Hs.Text))
+                     (obj .: "disallowed_tools"))
+                <*> obj .: "secure_mode")
 instance (HsJSONPB.ToJSON SpawnSubtreeRequest) where
   toJSON = HsJSONPB.toAesonValue
   toEncoding = HsJSONPB.toAesonEncoding
@@ -2382,7 +2472,8 @@ data SpawnLeafSubtreeRequest
                              spawnLeafSubtreeRequestAgentType :: (HsProtobuf.Enumerated Effects.Agent.AgentType),
                              spawnLeafSubtreeRequestPermissionMode :: Hs.Text,
                              spawnLeafSubtreeRequestAllowedTools :: (Hs.Vector Hs.Text),
-                             spawnLeafSubtreeRequestDisallowedTools :: (Hs.Vector Hs.Text)}
+                             spawnLeafSubtreeRequestDisallowedTools :: (Hs.Vector Hs.Text),
+                             spawnLeafSubtreeRequestSecureMode :: Hs.Bool}
   deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)
 instance (Hs.NFData SpawnLeafSubtreeRequest)
 instance (HsProtobuf.Named SpawnLeafSubtreeRequest) where
@@ -2393,35 +2484,50 @@ instance (HsProtobuf.Message SpawnLeafSubtreeRequest) where
     _
     SpawnLeafSubtreeRequest {spawnLeafSubtreeRequestTask,
                              spawnLeafSubtreeRequestBranchName, spawnLeafSubtreeRequestRole,
-                             spawnLeafSubtreeRequestAgentType, spawnLeafSubtreeRequestPermissionMode,
-                             spawnLeafSubtreeRequestAllowedTools, spawnLeafSubtreeRequestDisallowedTools}
-    = Hs.mconcat
-        [HsProtobuf.encodeMessageField
-           (HsProtobuf.FieldNumber 1)
-           ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
-              spawnLeafSubtreeRequestTask),
-         HsProtobuf.encodeMessageField
-           (HsProtobuf.FieldNumber 2)
-           ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
-              spawnLeafSubtreeRequestBranchName),
-         HsProtobuf.encodeMessageField
-           (HsProtobuf.FieldNumber 3)
-           ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
-              spawnLeafSubtreeRequestRole),
-         HsProtobuf.encodeMessageField
-           (HsProtobuf.FieldNumber 4) spawnLeafSubtreeRequestAgentType,
-         HsProtobuf.encodeMessageField
-           (HsProtobuf.FieldNumber 5)
-           ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
-              spawnLeafSubtreeRequestPermissionMode),
-         HsProtobuf.encodeMessageField
-           (HsProtobuf.FieldNumber 6)
-           ((Hs.coerce @(Hs.Vector Hs.Text) @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)))
-              spawnLeafSubtreeRequestAllowedTools),
-         HsProtobuf.encodeMessageField
-           (HsProtobuf.FieldNumber 7)
-           ((Hs.coerce @(Hs.Vector Hs.Text) @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)))
-              spawnLeafSubtreeRequestDisallowedTools)]
+                             spawnLeafSubtreeRequestAgentType,
+                             spawnLeafSubtreeRequestPermissionMode,
+                             spawnLeafSubtreeRequestAllowedTools,
+                             spawnLeafSubtreeRequestDisallowedTools,
+                             spawnLeafSubtreeRequestSecureMode}
+    = Hs.mappend
+        (Hs.mappend
+           (Hs.mappend
+              (Hs.mappend
+                 (Hs.mappend
+                    (Hs.mappend
+                       (Hs.mappend
+                          (HsProtobuf.encodeMessageField
+                             (HsProtobuf.FieldNumber 1)
+                             ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
+                                spawnLeafSubtreeRequestTask))
+                          (HsProtobuf.encodeMessageField
+                             (HsProtobuf.FieldNumber 2)
+                             ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
+                                spawnLeafSubtreeRequestBranchName)))
+                       (HsProtobuf.encodeMessageField
+                          (HsProtobuf.FieldNumber 3)
+                          ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
+                             spawnLeafSubtreeRequestRole)))
+                    (HsProtobuf.encodeMessageField
+                       (HsProtobuf.FieldNumber 4) spawnLeafSubtreeRequestAgentType))
+                 (HsProtobuf.encodeMessageField
+                    (HsProtobuf.FieldNumber 5)
+                    ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
+                       spawnLeafSubtreeRequestPermissionMode)))
+              (HsProtobuf.encodeMessageField
+                 (HsProtobuf.FieldNumber 6)
+                 ((Hs.coerce
+                     @(Hs.Vector Hs.Text)
+                     @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)))
+                    spawnLeafSubtreeRequestAllowedTools)))
+           (HsProtobuf.encodeMessageField
+              (HsProtobuf.FieldNumber 7)
+              ((Hs.coerce
+                  @(Hs.Vector Hs.Text)
+                  @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)))
+                 spawnLeafSubtreeRequestDisallowedTools)))
+        (HsProtobuf.encodeMessageField
+           (HsProtobuf.FieldNumber 8) spawnLeafSubtreeRequestSecureMode)
   decodeMessage _
     = Hs.pure SpawnLeafSubtreeRequest
         <*>
@@ -2444,13 +2550,20 @@ instance (HsProtobuf.Message SpawnLeafSubtreeRequest) where
              (HsProtobuf.at
                 HsProtobuf.decodeMessageField (HsProtobuf.FieldNumber 5)))
         <*>
-          ((HsProtobuf.coerceOver @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)) @(Hs.Vector Hs.Text))
+          ((HsProtobuf.coerceOver
+              @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text))
+              @(Hs.Vector Hs.Text))
              (HsProtobuf.at
                 HsProtobuf.decodeMessageField (HsProtobuf.FieldNumber 6)))
         <*>
-          ((HsProtobuf.coerceOver @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)) @(Hs.Vector Hs.Text))
+          ((HsProtobuf.coerceOver
+              @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text))
+              @(Hs.Vector Hs.Text))
              (HsProtobuf.at
                 HsProtobuf.decodeMessageField (HsProtobuf.FieldNumber 7)))
+        <*>
+          HsProtobuf.at
+            HsProtobuf.decodeMessageField (HsProtobuf.FieldNumber 8)
   dotProto _
     = [HsProtobufAST.DotProtoField
          (HsProtobuf.FieldNumber 1)
@@ -2480,28 +2593,55 @@ instance (HsProtobuf.Message SpawnLeafSubtreeRequest) where
        HsProtobufAST.DotProtoField
          (HsProtobuf.FieldNumber 7)
          (HsProtobufAST.Repeated HsProtobufAST.String)
-         (HsProtobufAST.Single "disallowed_tools") [] ""]
+         (HsProtobufAST.Single "disallowed_tools") [] "",
+       HsProtobufAST.DotProtoField
+         (HsProtobuf.FieldNumber 8) (HsProtobufAST.Prim HsProtobufAST.Bool)
+         (HsProtobufAST.Single "secure_mode") [] ""]
 instance (HsJSONPB.ToJSONPB SpawnLeafSubtreeRequest) where
-  toJSONPB (SpawnLeafSubtreeRequest f1 f2 f3 f4 f5 f6 f7)
+  toJSONPB (SpawnLeafSubtreeRequest f1 f2 f3 f4 f5 f6 f7 f8)
     = HsJSONPB.object
         ["task" .= ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text)) f1),
          "branch_name"
            .= ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text)) f2),
          "role" .= ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text)) f3),
          "agent_type" .= f4,
-         "permissionMode" .= ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text)) f5),
-         "allowedTools" .= ((Hs.coerce @(Hs.Vector Hs.Text) @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text))) f6),
-         "disallowedTools" .= ((Hs.coerce @(Hs.Vector Hs.Text) @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text))) f7)]
-  toEncodingPB (SpawnLeafSubtreeRequest f1 f2 f3 f4 f5 f6 f7)
+         "permission_mode"
+           .= ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text)) f5),
+         "allowed_tools"
+           .=
+             ((Hs.coerce
+                 @(Hs.Vector Hs.Text)
+                 @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)))
+                f6),
+         "disallowed_tools"
+           .=
+             ((Hs.coerce
+                 @(Hs.Vector Hs.Text)
+                 @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)))
+                f7),
+         "secure_mode" .= f8]
+  toEncodingPB (SpawnLeafSubtreeRequest f1 f2 f3 f4 f5 f6 f7 f8)
     = HsJSONPB.pairs
         ["task" .= ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text)) f1),
          "branch_name"
            .= ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text)) f2),
          "role" .= ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text)) f3),
          "agent_type" .= f4,
-         "permissionMode" .= ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text)) f5),
-         "allowedTools" .= ((Hs.coerce @(Hs.Vector Hs.Text) @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text))) f6),
-         "disallowedTools" .= ((Hs.coerce @(Hs.Vector Hs.Text) @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text))) f7)]
+         "permission_mode"
+           .= ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text)) f5),
+         "allowed_tools"
+           .=
+             ((Hs.coerce
+                 @(Hs.Vector Hs.Text)
+                 @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)))
+                f6),
+         "disallowed_tools"
+           .=
+             ((Hs.coerce
+                 @(Hs.Vector Hs.Text)
+                 @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)))
+                f7),
+         "secure_mode" .= f8]
 instance (HsJSONPB.FromJSONPB SpawnLeafSubtreeRequest) where
   parseJSONPB
     = HsJSONPB.withObject
@@ -2520,13 +2660,18 @@ instance (HsJSONPB.FromJSONPB SpawnLeafSubtreeRequest) where
                 <*> obj .: "agent_type"
                 <*>
                   ((HsProtobuf.coerceOver @(HsProtobuf.String Hs.Text) @Hs.Text)
-                     (obj .: "permissionMode"))
+                     (obj .: "permission_mode"))
                 <*>
-                  ((HsProtobuf.coerceOver @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)) @(Hs.Vector Hs.Text))
-                     (obj .: "allowedTools"))
+                  ((HsProtobuf.coerceOver
+                      @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text))
+                      @(Hs.Vector Hs.Text))
+                     (obj .: "allowed_tools"))
                 <*>
-                  ((HsProtobuf.coerceOver @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)) @(Hs.Vector Hs.Text))
-                     (obj .: "disallowedTools")))
+                  ((HsProtobuf.coerceOver
+                      @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text))
+                      @(Hs.Vector Hs.Text))
+                     (obj .: "disallowed_tools"))
+                <*> obj .: "secure_mode")
 instance (HsJSONPB.ToJSON SpawnLeafSubtreeRequest) where
   toJSON = HsJSONPB.toAesonValue
   toEncoding = HsJSONPB.toAesonEncoding
@@ -2613,27 +2758,34 @@ instance (HsProtobuf.Message SpawnAcpRequest) where
     SpawnAcpRequest {spawnAcpRequestName, spawnAcpRequestPrompt,
                      spawnAcpRequestPermissionMode, spawnAcpRequestAllowedTools,
                      spawnAcpRequestDisallowedTools}
-    = Hs.mconcat
-        [HsProtobuf.encodeMessageField
-           (HsProtobuf.FieldNumber 1)
-           ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
-              spawnAcpRequestName),
-         HsProtobuf.encodeMessageField
-           (HsProtobuf.FieldNumber 2)
-           ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
-              spawnAcpRequestPrompt),
-         HsProtobuf.encodeMessageField
-           (HsProtobuf.FieldNumber 3)
-           ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
-              spawnAcpRequestPermissionMode),
-         HsProtobuf.encodeMessageField
-           (HsProtobuf.FieldNumber 4)
-           ((Hs.coerce @(Hs.Vector Hs.Text) @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)))
-              spawnAcpRequestAllowedTools),
-         HsProtobuf.encodeMessageField
+    = Hs.mappend
+        (Hs.mappend
+           (Hs.mappend
+              (Hs.mappend
+                 (HsProtobuf.encodeMessageField
+                    (HsProtobuf.FieldNumber 1)
+                    ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
+                       spawnAcpRequestName))
+                 (HsProtobuf.encodeMessageField
+                    (HsProtobuf.FieldNumber 2)
+                    ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
+                       spawnAcpRequestPrompt)))
+              (HsProtobuf.encodeMessageField
+                 (HsProtobuf.FieldNumber 3)
+                 ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
+                    spawnAcpRequestPermissionMode)))
+           (HsProtobuf.encodeMessageField
+              (HsProtobuf.FieldNumber 4)
+              ((Hs.coerce
+                  @(Hs.Vector Hs.Text)
+                  @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)))
+                 spawnAcpRequestAllowedTools)))
+        (HsProtobuf.encodeMessageField
            (HsProtobuf.FieldNumber 5)
-           ((Hs.coerce @(Hs.Vector Hs.Text) @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)))
-              spawnAcpRequestDisallowedTools)]
+           ((Hs.coerce
+               @(Hs.Vector Hs.Text)
+               @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)))
+              spawnAcpRequestDisallowedTools))
   decodeMessage _
     = Hs.pure SpawnAcpRequest
         <*>
@@ -2649,11 +2801,15 @@ instance (HsProtobuf.Message SpawnAcpRequest) where
              (HsProtobuf.at
                 HsProtobuf.decodeMessageField (HsProtobuf.FieldNumber 3)))
         <*>
-          ((HsProtobuf.coerceOver @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)) @(Hs.Vector Hs.Text))
+          ((HsProtobuf.coerceOver
+              @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text))
+              @(Hs.Vector Hs.Text))
              (HsProtobuf.at
                 HsProtobuf.decodeMessageField (HsProtobuf.FieldNumber 4)))
         <*>
-          ((HsProtobuf.coerceOver @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)) @(Hs.Vector Hs.Text))
+          ((HsProtobuf.coerceOver
+              @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text))
+              @(Hs.Vector Hs.Text))
              (HsProtobuf.at
                 HsProtobuf.decodeMessageField (HsProtobuf.FieldNumber 5)))
   dotProto _
@@ -2682,16 +2838,38 @@ instance (HsJSONPB.ToJSONPB SpawnAcpRequest) where
     = HsJSONPB.object
         ["name" .= ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text)) f1),
          "prompt" .= ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text)) f2),
-         "permissionMode" .= ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text)) f3),
-         "allowedTools" .= ((Hs.coerce @(Hs.Vector Hs.Text) @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text))) f4),
-         "disallowedTools" .= ((Hs.coerce @(Hs.Vector Hs.Text) @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text))) f5)]
+         "permission_mode"
+           .= ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text)) f3),
+         "allowed_tools"
+           .=
+             ((Hs.coerce
+                 @(Hs.Vector Hs.Text)
+                 @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)))
+                f4),
+         "disallowed_tools"
+           .=
+             ((Hs.coerce
+                 @(Hs.Vector Hs.Text)
+                 @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)))
+                f5)]
   toEncodingPB (SpawnAcpRequest f1 f2 f3 f4 f5)
     = HsJSONPB.pairs
         ["name" .= ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text)) f1),
          "prompt" .= ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text)) f2),
-         "permissionMode" .= ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text)) f3),
-         "allowedTools" .= ((Hs.coerce @(Hs.Vector Hs.Text) @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text))) f4),
-         "disallowedTools" .= ((Hs.coerce @(Hs.Vector Hs.Text) @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text))) f5)]
+         "permission_mode"
+           .= ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text)) f3),
+         "allowed_tools"
+           .=
+             ((Hs.coerce
+                 @(Hs.Vector Hs.Text)
+                 @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)))
+                f4),
+         "disallowed_tools"
+           .=
+             ((Hs.coerce
+                 @(Hs.Vector Hs.Text)
+                 @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)))
+                f5)]
 instance (HsJSONPB.FromJSONPB SpawnAcpRequest) where
   parseJSONPB
     = HsJSONPB.withObject
@@ -2706,13 +2884,17 @@ instance (HsJSONPB.FromJSONPB SpawnAcpRequest) where
                      (obj .: "prompt"))
                 <*>
                   ((HsProtobuf.coerceOver @(HsProtobuf.String Hs.Text) @Hs.Text)
-                     (obj .: "permissionMode"))
+                     (obj .: "permission_mode"))
                 <*>
-                  ((HsProtobuf.coerceOver @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)) @(Hs.Vector Hs.Text))
-                     (obj .: "allowedTools"))
+                  ((HsProtobuf.coerceOver
+                      @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text))
+                      @(Hs.Vector Hs.Text))
+                     (obj .: "allowed_tools"))
                 <*>
-                  ((HsProtobuf.coerceOver @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)) @(Hs.Vector Hs.Text))
-                     (obj .: "disallowedTools")))
+                  ((HsProtobuf.coerceOver
+                      @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text))
+                      @(Hs.Vector Hs.Text))
+                     (obj .: "disallowed_tools")))
 instance (HsJSONPB.ToJSON SpawnAcpRequest) where
   toJSON = HsJSONPB.toAesonValue
   toEncoding = HsJSONPB.toAesonEncoding


### PR DESCRIPTION
## Summary
- Thread `secure_mode` boolean through Haskell spawn args (`SpawnSubtreeArgs`, `SpawnLeafSubtreeArgs`) and AgentControl effects to proto requests
- Implement `SecureHooks.hs` filesystem scoping hook that enforces worktree-scoped file access when `EXOMONAD_SECURE_MODE=1`
- Wire `securePreToolUse` into dev role PreToolUse hook cascade

## Details
- Guards `Read`, `Write`, `Edit`, `Glob`, `Grep` tools — verifies paths resolve under `hiCwd`
- `Bash` gets warning-level audit event but is allowed (unscopeable without sandboxing)
- Emits `security.access.denied`, `security.access.allowed`, `security.access.warning` events
- No-op when `EXOMONAD_SECURE_MODE` env var is unset (zero behavior change for existing agents)

Wave 2 of secure multi-model integration. Depends on #648 (hiCwd) and #649 (secure_mode proto + scrub_worktree).