### PR TITLE
feat: Add allowed_read_paths to secure_mode spawn

### DIFF
--- a/haskell/wasm-guest/src/ExoMonad/Guest/Effects/AgentControl.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Guest/Effects/AgentControl.hs
@@ -110,17 +110,17 @@ defaultPermFlags = PermissionFlags Nothing [] []
 
 -- | Agent control effect for spawning agents.
 data AgentControl a where
-  SpawnSubtreeC :: Text -> Text -> Text -> Bool -> Maybe Text -> Maybe AgentType -> PermissionFlags -> Maybe Bool -> AgentControl (Either Text SpawnResult)
-  SpawnLeafSubtreeC :: Text -> Text -> Maybe Text -> Maybe AgentType -> PermissionFlags -> Maybe Bool -> AgentControl (Either Text SpawnResult)
+  SpawnSubtreeC :: Text -> Text -> Text -> Bool -> Maybe Text -> Maybe AgentType -> PermissionFlags -> Maybe Bool -> Maybe [Text] -> AgentControl (Either Text SpawnResult)
+  SpawnLeafSubtreeC :: Text -> Text -> Maybe Text -> Maybe AgentType -> PermissionFlags -> Maybe Bool -> Maybe [Text] -> AgentControl (Either Text SpawnResult)
   SpawnWorkerC :: Text -> Text -> PermissionFlags -> AgentControl (Either Text SpawnResult)
   SpawnAcpC :: Text -> Text -> PermissionFlags -> AgentControl (Either Text SpawnResult)
 
 -- Smart constructors (manually written - makeSem doesn't work with WASM cross-compilation)
-spawnSubtree :: (Member AgentControl r) => Text -> Text -> Text -> Bool -> Maybe Text -> Maybe AgentType -> PermissionFlags -> Maybe Bool -> Eff r (Either Text SpawnResult)
-spawnSubtree task branchName parentSessionId forkSession role agentType perms secureMode = send (SpawnSubtreeC task branchName parentSessionId forkSession role agentType perms secureMode)
+spawnSubtree :: (Member AgentControl r) => Text -> Text -> Text -> Bool -> Maybe Text -> Maybe AgentType -> PermissionFlags -> Maybe Bool -> Maybe [Text] -> Eff r (Either Text SpawnResult)
+spawnSubtree task branchName parentSessionId forkSession role agentType perms secureMode allowedReadPaths = send (SpawnSubtreeC task branchName parentSessionId forkSession role agentType perms secureMode allowedReadPaths)
 
-spawnLeafSubtree :: (Member AgentControl r) => Text -> Text -> Maybe Text -> Maybe AgentType -> PermissionFlags -> Maybe Bool -> Eff r (Either Text SpawnResult)
-spawnLeafSubtree task branchName role agentType perms secureMode = send (SpawnLeafSubtreeC task branchName role agentType perms secureMode)
+spawnLeafSubtree :: (Member AgentControl r) => Text -> Text -> Maybe Text -> Maybe AgentType -> PermissionFlags -> Maybe Bool -> Maybe [Text] -> Eff r (Either Text SpawnResult)
+spawnLeafSubtree task branchName role agentType perms secureMode allowedReadPaths = send (SpawnLeafSubtreeC task branchName role agentType perms secureMode allowedReadPaths)
 
 spawnWorker :: (Member AgentControl r) => Text -> Text -> PermissionFlags -> Eff r (Either Text SpawnResult)
 spawnWorker name prompt perms = send (SpawnWorkerC name prompt perms)
@@ -136,7 +136,7 @@ spawnAcp name prompt perms = send (SpawnAcpC name prompt perms)
 -- Effects dispatched async without holding the WASM plugin lock.
 runAgentControlSuspend :: (Member SuspendYield r) => Eff (AgentControl ': r) a -> Eff r a
 runAgentControlSuspend = interpret $ \case
-  SpawnSubtreeC task branchName parentSessionId forkSession role agentType perms secureMode -> do
+  SpawnSubtreeC task branchName parentSessionId forkSession role agentType perms secureMode allowedReadPaths -> do
     let req =
           PA.SpawnSubtreeRequest
             { PA.spawnSubtreeRequestTask = fromText task,
@@ -148,7 +148,8 @@ runAgentControlSuspend = interpret $ \case
               PA.spawnSubtreeRequestPermissionMode = fromText (maybe "" id (permMode perms)),
               PA.spawnSubtreeRequestAllowedTools = V.fromList (map fromText (allowedTools perms)),
               PA.spawnSubtreeRequestDisallowedTools = V.fromList (map fromText (disallowedTools perms)),
-              PA.spawnSubtreeRequestSecureMode = maybe False id secureMode
+              PA.spawnSubtreeRequestSecureMode = maybe False id secureMode,
+              PA.spawnSubtreeRequestAllowedReadPaths = V.fromList (map fromText (maybe [] id allowedReadPaths))
             }
     result <- suspendEffect @Agent.AgentSpawnSubtree req
     pure $ case result of
@@ -156,7 +157,7 @@ runAgentControlSuspend = interpret $ \case
       Right resp -> case PA.spawnSubtreeResponseAgent resp of
         Nothing -> Left "SpawnSubtree succeeded but no agent info returned"
         Just info -> Right (protoAgentInfoToSpawnResult info)
-  SpawnLeafSubtreeC task branchName role agentType perms secureMode -> do
+  SpawnLeafSubtreeC task branchName role agentType perms secureMode allowedReadPaths -> do
     let req =
           PA.SpawnLeafSubtreeRequest
             { PA.spawnLeafSubtreeRequestTask = fromText task,
@@ -166,7 +167,8 @@ runAgentControlSuspend = interpret $ \case
               PA.spawnLeafSubtreeRequestPermissionMode = fromText (maybe "" id (permMode perms)),
               PA.spawnLeafSubtreeRequestAllowedTools = V.fromList (map fromText (allowedTools perms)),
               PA.spawnLeafSubtreeRequestDisallowedTools = V.fromList (map fromText (disallowedTools perms)),
-              PA.spawnLeafSubtreeRequestSecureMode = maybe False id secureMode
+              PA.spawnLeafSubtreeRequestSecureMode = maybe False id secureMode,
+              PA.spawnLeafSubtreeRequestAllowedReadPaths = V.fromList (map fromText (maybe [] id allowedReadPaths))
             }
     result <- suspendEffect @Agent.AgentSpawnLeafSubtree req
     pure $ case result of

--- a/haskell/wasm-guest/src/ExoMonad/Guest/Tools/Spawn.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Guest/Tools/Spawn.hs
@@ -40,7 +40,8 @@ data SpawnSubtreeArgs = SpawnSubtreeArgs
     ssPermissionMode :: Maybe Text,
     ssAllowedTools :: Maybe [Text],
     ssDisallowedTools :: Maybe [Text],
-    ssSecureMode :: Maybe Bool
+    ssSecureMode :: Maybe Bool,
+    ssAllowedReadPaths :: Maybe [Text]
   }
   deriving (Show, Eq, Generic)
 
@@ -54,6 +55,7 @@ instance FromJSON SpawnSubtreeArgs where
       <*> v .:? "allowed_tools"
       <*> v .:? "disallowed_tools"
       <*> v .:? "secure_mode"
+      <*> v .:? "allowed_read_paths"
 
 instance MCPTool SpawnSubtree where
   type ToolArgs SpawnSubtree = SpawnSubtreeArgs
@@ -76,7 +78,7 @@ instance MCPTool SpawnSubtree where
             AC.allowedTools = maybe [] id (ssAllowedTools args),
             AC.disallowedTools = maybe [] id (ssDisallowedTools args)
           }
-    result <- AC.spawnSubtree (ssTask args) (ssBranchName args) "" forkSession Nothing Nothing perms (ssSecureMode args)
+    result <- AC.spawnSubtree (ssTask args) (ssBranchName args) "" forkSession Nothing Nothing perms (ssSecureMode args) (ssAllowedReadPaths args)
     case result of
       Left err -> pure $ errorResult err
       Right spawnResult -> do
@@ -104,7 +106,8 @@ data SpawnLeafSubtreeArgs = SpawnLeafSubtreeArgs
     slsPermissionMode :: Maybe Text,
     slsAllowedTools :: Maybe [Text],
     slsDisallowedTools :: Maybe [Text],
-    slsSecureMode :: Maybe Bool
+    slsSecureMode :: Maybe Bool,
+    slsAllowedReadPaths :: Maybe [Text]
   }
   deriving (Show, Eq, Generic)
 
@@ -117,6 +120,7 @@ instance FromJSON SpawnLeafSubtreeArgs where
       <*> v .:? "allowed_tools"
       <*> v .:? "disallowed_tools"
       <*> v .:? "secure_mode"
+      <*> v .:? "allowed_read_paths"
 
 instance MCPTool SpawnLeafSubtree where
   type ToolArgs SpawnLeafSubtree = SpawnLeafSubtreeArgs
@@ -141,7 +145,7 @@ instance MCPTool SpawnLeafSubtree where
             AC.allowedTools = maybe [] id (slsAllowedTools args),
             AC.disallowedTools = maybe [] id (slsDisallowedTools args)
           }
-    result <- AC.spawnLeafSubtree renderedTask (slsBranchName args) Nothing Nothing perms (slsSecureMode args)
+    result <- AC.spawnLeafSubtree renderedTask (slsBranchName args) Nothing Nothing perms (slsSecureMode args) (slsAllowedReadPaths args)
     case result of
       Left err -> pure $ errorResult err
       Right spawnResult -> do

--- a/proto/effects/agent.proto
+++ b/proto/effects/agent.proto
@@ -272,6 +272,8 @@ message SpawnSubtreeRequest {
   repeated string disallowed_tools = 9;
   // Secure mode for agent isolation.
   bool secure_mode = 10;
+  // Specific absolute paths outside the worktree that the agent is allowed to read.
+  repeated string allowed_read_paths = 11;
 }
 
 message SpawnSubtreeResponse {
@@ -297,6 +299,8 @@ message SpawnLeafSubtreeRequest {
   repeated string disallowed_tools = 7;
   // Secure mode for agent isolation.
   bool secure_mode = 8;
+  // Specific absolute paths outside the worktree that the agent is allowed to read.
+  repeated string allowed_read_paths = 9;
 }
 
 message SpawnLeafSubtreeResponse {

--- a/rust/exomonad-core/src/handlers/agent.rs
+++ b/rust/exomonad-core/src/handlers/agent.rs
@@ -293,6 +293,7 @@ impl AgentEffects for AgentHandler {
                 req.disallowed_tools.clone(),
             ),
             secure_mode: req.secure_mode,
+            allowed_read_paths: req.allowed_read_paths.clone(),
         };
 
         let result = self
@@ -343,6 +344,7 @@ impl AgentEffects for AgentHandler {
                 req.disallowed_tools.clone(),
             ),
             secure_mode: req.secure_mode,
+            allowed_read_paths: req.allowed_read_paths.clone(),
         };
 
         let result = self

--- a/rust/exomonad-core/src/services/agent_control.rs
+++ b/rust/exomonad-core/src/services/agent_control.rs
@@ -289,6 +289,9 @@ pub struct SpawnSubtreeOptions {
     /// Secure mode for agent isolation.
     #[serde(default)]
     pub secure_mode: bool,
+    /// Specific absolute paths outside the worktree that the agent is allowed to read.
+    #[serde(default)]
+    pub allowed_read_paths: Vec<String>,
 }
 
 /// Result of spawning an agent.
@@ -1058,6 +1061,12 @@ impl AgentControlService {
             if options.secure_mode {
                 env_vars.remove("EXOMONAD_SESSION_ID");
                 env_vars.insert("EXOMONAD_SECURE_MODE".to_string(), "1".to_string());
+                if !options.allowed_read_paths.is_empty() {
+                    env_vars.insert(
+                        "EXOMONAD_SECURE_ALLOWED_PATHS".to_string(),
+                        options.allowed_read_paths.join(":"),
+                    );
+                }
             }
             // Enable Claude Code Agent Teams for native inter-agent messaging
             env_vars.insert(
@@ -1203,6 +1212,12 @@ impl AgentControlService {
             if options.secure_mode {
                 env_vars.remove("EXOMONAD_SESSION_ID");
                 env_vars.insert("EXOMONAD_SECURE_MODE".to_string(), "1".to_string());
+                if !options.allowed_read_paths.is_empty() {
+                    env_vars.insert(
+                        "EXOMONAD_SECURE_ALLOWED_PATHS".to_string(),
+                        options.allowed_read_paths.join(":"),
+                    );
+                }
             }
 
             // Write .gemini/settings.json in worktree root

--- a/rust/exomonad-proto/proto/effects/agent.proto
+++ b/rust/exomonad-proto/proto/effects/agent.proto
@@ -272,6 +272,8 @@ message SpawnSubtreeRequest {
   repeated string disallowed_tools = 9;
   // Secure mode for agent isolation.
   bool secure_mode = 10;
+  // Specific absolute paths outside the worktree that the agent is allowed to read.
+  repeated string allowed_read_paths = 11;
 }
 
 message SpawnSubtreeResponse {
@@ -297,6 +299,8 @@ message SpawnLeafSubtreeRequest {
   repeated string disallowed_tools = 7;
   // Secure mode for agent isolation.
   bool secure_mode = 8;
+  // Specific absolute paths outside the worktree that the agent is allowed to read.
+  repeated string allowed_read_paths = 9;
 }
 
 message SpawnLeafSubtreeResponse {


### PR DESCRIPTION
This PR adds the `allowed_read_paths` parameter to the `SpawnSubtreeRequest` and `SpawnLeafSubtreeRequest` in the agent effects protobuf. 
It also updates the Rust I/O runtime to populate the `EXOMONAD_SECURE_ALLOWED_PATHS` environment variable, and modifies the `SecureHooks.hs` script to allow read-only tool accesses that exactly match a path in this list. 

This enables spawned agents to read from specific outside-worktree absolute paths when running in secure mode.