### PR TITLE
feat: dynamic cabal.project.wasm generation for cross-repo WASM builds

### DIFF
--- a/rust/exomonad/src/recompile.rs
+++ b/rust/exomonad/src/recompile.rs
@@ -1,7 +1,66 @@
 //! `exomonad recompile` — build WASM plugin from Haskell source via nix.
 
 use anyhow::{bail, Context, Result};
-use std::path::Path;
+use std::path::{Path, PathBuf};
+
+/// Generate a temporary cabal.project.wasm that bridges core SDK packages
+/// (from the flake_ref directory) with local roles (from project_dir).
+fn generate_cross_repo_cabal_project(
+    sdk_dir: &Path,
+    project_dir: &Path,
+    role: &str,
+) -> Result<PathBuf> {
+    let sdk = sdk_dir.canonicalize()
+        .with_context(|| format!("Failed to canonicalize SDK dir: {}", sdk_dir.display()))?;
+    let proj = project_dir.canonicalize()
+        .with_context(|| format!("Failed to canonicalize project dir: {}", project_dir.display()))?;
+
+    let content = format!(
+        r#"-- Auto-generated cabal.project.wasm for cross-repo build
+-- SDK: {sdk_display}
+-- Roles: {proj_display}
+
+packages:
+    {sdk}/haskell/wasm-guest
+    {sdk}/haskell/proto
+    {sdk}/haskell/vendor/freer-simple
+    {sdk}/haskell/vendor/exomonad-pdk
+    {sdk}/haskell/vendor/proto3-runtime
+    {sdk}/haskell/vendor/proto3-wire
+    {proj}/.exo/roles/{role}
+
+shared: True
+executable-dynamic: False
+
+package *
+  ghc-options: -O1
+
+repository head.hackage
+  url: https://ghc.gitlab.haskell.org/head.hackage/
+  secure: True
+
+if arch(wasm32)
+  constraints: time >= 1.14
+  package *
+    ghc-options: -O1
+
+allow-newer: all
+"#,
+        sdk_display = sdk.display(),
+        proj_display = proj.display(),
+        sdk = sdk.display(),
+        proj = proj.display(),
+        role = role,
+    );
+
+    let out_path = proj.join(".exo").join("cabal.project.wasm");
+    std::fs::create_dir_all(out_path.parent().unwrap())?;
+    std::fs::write(&out_path, content)
+        .with_context(|| format!("Failed to write {}", out_path.display()))?;
+
+    tracing::info!("Generated cross-repo cabal project at {}", out_path.display());
+    Ok(out_path)
+}
 
 /// Build WASM for a role via nix and copy artifact to `.exo/wasm/`.
 pub async fn run_recompile(role: &str, project_dir: &Path, flake_ref: Option<&str>) -> Result<()> {
@@ -20,6 +79,14 @@ pub async fn run_recompile(role: &str, project_dir: &Path, flake_ref: Option<&st
 
     let nix_flake_arg = format!("{}#wasm", flake_ref_str);
 
+    let project_file_arg = if let Some(ref flake) = flake_ref {
+        let sdk_dir = Path::new(flake);
+        let cabal_path = generate_cross_repo_cabal_project(sdk_dir, project_dir, role)?;
+        format!("--project-file={}", cabal_path.display())
+    } else {
+        "--project-file=cabal.project.wasm".to_string()
+    };
+
     let status = std::process::Command::new("nix")
         .args([
             "develop",
@@ -27,7 +94,7 @@ pub async fn run_recompile(role: &str, project_dir: &Path, flake_ref: Option<&st
             "-c",
             "wasm32-wasi-cabal",
             "build",
-            "--project-file=cabal.project.wasm",
+            &project_file_arg,
             &format!("wasm-guest-{role}"),
         ])
         .current_dir(project_dir)


### PR DESCRIPTION
## Summary
- When `flake_ref` is set in config, `exomonad recompile` generates a temporary `cabal.project.wasm` at `.exo/cabal.project.wasm`
- Generated file references core SDK packages via absolute paths (from flake_ref dir) and local roles from the consuming repo
- When `flake_ref` is unset, behavior is unchanged (uses local `cabal.project.wasm`)

Enables consuming repos (e.g., aegis) to run `exomonad recompile` against the exomonad SDK without maintaining their own cabal project file.

Depends on #652 (flake_ref config).