### PR TITLE
feat: add Gemini MCP configuration to exomonad init

### DIFF
--- a/rust/exomonad/src/main.rs
+++ b/rust/exomonad/src/main.rs
@@ -563,15 +563,63 @@ async fn run_init(session_override: Option<String>, recreate: bool, port: u16) -
         ensure_gitignore(&cwd)?;
     }
 
+    // Resolve config
+    let config = config::Config::discover()?;
+    let session = session_override.unwrap_or(config.zellij_session.clone());
+
     // Write hook configuration (SessionStart registers Claude UUID for --fork-session)
     let binary_path = exomonad_core::find_exomonad_binary();
     exomonad_core::hooks::HookConfig::write_persistent(&cwd, &binary_path)
         .context("Failed to write hook configuration")?;
     eprintln!("Hook configuration written to .claude/settings.local.json");
 
-    // Resolve config
-    let config = config::Config::discover()?;
-    let session = session_override.unwrap_or(config.zellij_session);
+    // Gemini MCP configuration
+    if config.root_agent_type == AgentType::Gemini {
+        let gemini_dir = cwd.join(".gemini");
+        if !gemini_dir.exists() {
+            std::fs::create_dir_all(&gemini_dir)?;
+        }
+        let settings_path = gemini_dir.join("settings.json");
+        let mcp_url = format!("http://localhost:{}/agents/tl/root/mcp", config.port);
+
+        let settings = serde_json::json!({
+            "mcpServers": {
+                "exomonad": {
+                    "httpUrl": mcp_url
+                }
+            },
+            "hooks": {
+                "BeforeTool": [
+                    {
+                        "matcher": "*",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": "exomonad hook before-tool --runtime gemini"
+                            }
+                        ]
+                    }
+                ],
+                "AfterAgent": [
+                    {
+                        "matcher": "*",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": "exomonad hook after-agent --runtime gemini"
+                            }
+                        ]
+                    }
+                ]
+            }
+        });
+
+        std::fs::write(
+            &settings_path,
+            serde_json::to_string_pretty(&settings)?
+        )?;
+        eprintln!("Gemini MCP configuration written to .gemini/settings.json");
+    }
 
     // Query existing sessions
     let output = std::process::Command::new("zellij")


### PR DESCRIPTION
This PR adds Gemini MCP configuration to the `exomonad init` command. 

When `root_agent_type` is set to `Gemini` in `.exo/config.toml`, the `init` command now:
1. Creates the `.gemini/` directory if it doesn't exist.
2. Writes `.gemini/settings.json` with the MCP server URL and necessary hooks (`BeforeTool` and `AfterAgent`).
3. Prints a confirmation message.

The configuration format follows the patterns established in `agent_control.rs` for spawned agents.

Verification:
- `cargo build -p exomonad` succeeds.
- `cargo test -p exomonad` passes.