### PR TITLE
feat: add working_dir and permissions to SpawnSubtreeRequest

### DIFF
--- a/proto/effects/agent.proto
+++ b/proto/effects/agent.proto
@@ -248,6 +248,11 @@ message SpawnWorkerResponse {
   AgentInfo agent = 1;
 }
 
+message Permissions {
+  repeated string allow = 1;
+  repeated string deny = 2;
+}
+
 // ============================================================================
 // SpawnSubtree - Spawn a subtree agent (Claude-only) in a new git worktree
 // ============================================================================
@@ -274,6 +279,8 @@ message SpawnSubtreeRequest {
   bool secure_mode = 10;
   // Specific absolute paths outside the worktree that the agent is allowed to read.
   repeated string allowed_read_paths = 11;
+  string working_dir = 12;
+  Permissions permissions = 13;
 }
 
 message SpawnSubtreeResponse {

--- a/rust/exomonad-core/src/domain.rs
+++ b/rust/exomonad-core/src/domain.rs
@@ -607,6 +607,19 @@ impl fmt::Display for AbsolutePath {
 }
 
 // ============================================================================
+// Agent Permissions
+// ============================================================================
+
+/// Permissions for an agent.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentPermissions {
+    /// Tool patterns to allow.
+    pub allow: Vec<String>,
+    /// Tool patterns to deny.
+    pub deny: Vec<String>,
+}
+
+// ============================================================================
 // Tests
 // ============================================================================
 

--- a/rust/exomonad-core/src/handlers/agent.rs
+++ b/rust/exomonad-core/src/handlers/agent.rs
@@ -2,12 +2,13 @@
 //!
 //! Uses proto-generated types from `exomonad_proto::effects::agent`.
 
-use crate::domain::{AgentName, BirthBranch, ClaudeSessionUuid};
+use crate::domain::{AgentName, BirthBranch, ClaudeSessionUuid, AgentPermissions};
 use crate::effects::{
     dispatch_agent_effect, AgentEffects, EffectError, EffectHandler, EffectResult, ResultExt,
 };
 
 use super::non_empty;
+use std::path::PathBuf;
 use crate::services::acp_registry::AcpRegistry;
 use crate::services::agent_control::{
     AgentControlService, AgentInfo, AgentType as ServiceAgentType, ClaudeSpawnFlags,
@@ -294,6 +295,11 @@ impl AgentEffects for AgentHandler {
             ),
             secure_mode: req.secure_mode,
             allowed_read_paths: req.allowed_read_paths.clone(),
+            working_dir: non_empty(req.working_dir).map(PathBuf::from),
+            permissions: req.permissions.map(|p| AgentPermissions {
+                allow: p.allow,
+                deny: p.deny,
+            }),
         };
 
         let result = self
@@ -345,6 +351,8 @@ impl AgentEffects for AgentHandler {
             ),
             secure_mode: req.secure_mode,
             allowed_read_paths: req.allowed_read_paths.clone(),
+            working_dir: None,
+            permissions: None,
         };
 
         let result = self

--- a/rust/exomonad-core/src/hooks.rs
+++ b/rust/exomonad-core/src/hooks.rs
@@ -86,7 +86,11 @@ impl HookConfig {
     ///
     /// Used by `exomonad init` and `spawn_subtree` where hooks must persist
     /// for the lifetime of the agent session.
-    pub fn write_persistent(cwd: &Path, binary_path: &Path) -> Result<()> {
+    pub fn write_persistent(
+        cwd: &Path,
+        binary_path: &Path,
+        permissions: Option<&crate::domain::AgentPermissions>,
+    ) -> Result<()> {
         let claude_dir = cwd.join(".claude");
         let settings_path = claude_dir.join("settings.local.json");
 
@@ -128,6 +132,14 @@ impl HookConfig {
                 "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS".to_string(),
                 json!("1"),
             );
+        }
+
+        // Write permissions if provided
+        if let Some(p) = permissions {
+            settings["permissions"] = json!({
+                "allow": p.allow,
+                "deny": p.deny,
+            });
         }
 
         let content =

--- a/rust/exomonad-proto/proto/effects/agent.proto
+++ b/rust/exomonad-proto/proto/effects/agent.proto
@@ -248,6 +248,11 @@ message SpawnWorkerResponse {
   AgentInfo agent = 1;
 }
 
+message Permissions {
+  repeated string allow = 1;
+  repeated string deny = 2;
+}
+
 // ============================================================================
 // SpawnSubtree - Spawn a subtree agent (Claude-only) in a new git worktree
 // ============================================================================
@@ -274,6 +279,8 @@ message SpawnSubtreeRequest {
   bool secure_mode = 10;
   // Specific absolute paths outside the worktree that the agent is allowed to read.
   repeated string allowed_read_paths = 11;
+  string working_dir = 12;
+  Permissions permissions = 13;
 }
 
 message SpawnSubtreeResponse {

--- a/rust/exomonad/src/main.rs
+++ b/rust/exomonad/src/main.rs
@@ -569,7 +569,7 @@ async fn run_init(session_override: Option<String>, recreate: bool, port: u16) -
 
     // Write hook configuration (SessionStart registers Claude UUID for --fork-session)
     let binary_path = exomonad_core::find_exomonad_binary();
-    exomonad_core::hooks::HookConfig::write_persistent(&cwd, &binary_path)
+    exomonad_core::hooks::HookConfig::write_persistent(&cwd, &binary_path, None)
         .context("Failed to write hook configuration")?;
     eprintln!("Hook configuration written to .claude/settings.local.json");
 


### PR DESCRIPTION
Add `working_dir` and `permissions` fields to `SpawnSubtreeRequest` proto and implement them in Rust.

Changes:
- Updated `proto/effects/agent.proto` and `rust/exomonad-proto/proto/effects/agent.proto` with new fields and `Permissions` message.
- Added `AgentPermissions` struct to `exomonad-core::domain`.
- Updated `HookConfig::write_persistent` to handle writing permissions to `.claude/settings.local.json`.
- Updated `SpawnSubtreeOptions` and `spawn_subtree` implementation to support `working_dir` (skipping worktree creation) and permissions.
- Updated proto handlers in `agent.rs` to map new fields.
- Updated `exomonad` main to match the new `write_persistent` signature.