### PR TITLE
feat: remove secure_mode and scrub_worktree from Rust

### DIFF
--- a/rust/exomonad-core/src/handlers/agent.rs
+++ b/rust/exomonad-core/src/handlers/agent.rs
@@ -293,8 +293,6 @@ impl AgentEffects for AgentHandler {
                 req.allowed_tools.clone(),
                 req.disallowed_tools.clone(),
             ),
-            secure_mode: req.secure_mode,
-            allowed_read_paths: req.allowed_read_paths.clone(),
             working_dir: non_empty(req.working_dir).map(PathBuf::from),
             permissions: req.permissions.map(|p| AgentPermissions {
                 allow: p.allow,
@@ -349,8 +347,6 @@ impl AgentEffects for AgentHandler {
                 req.allowed_tools.clone(),
                 req.disallowed_tools.clone(),
             ),
-            secure_mode: req.secure_mode,
-            allowed_read_paths: req.allowed_read_paths.clone(),
             working_dir: None,
             permissions: None,
         };


### PR DESCRIPTION
This PR removes all references to `secure_mode`, `allowed_read_paths`, and the `scrub_worktree` logic from the Rust codebase.

Key changes:
- Removed fields from `SpawnSubtreeOptions` in `agent_control.rs`.
- Removed `scrub_worktree` function and tests in `agent_control.rs`.
- Removed logic that set secure mode environment variables in `spawn_subtree` and `spawn_leaf_subtree`.
- Updated agent handlers to remove these fields from subtree spawn requests.

Verified with `cargo check --workspace`. Proto changes are handled in a separate PR.