### PR TITLE
feat: implement standalone_repo in Rust service layer

### DIFF
--- a/rust/exomonad-core/src/handlers/agent.rs
+++ b/rust/exomonad-core/src/handlers/agent.rs
@@ -298,6 +298,8 @@ impl AgentEffects for AgentHandler {
                 allow: p.allow,
                 deny: p.deny,
             }),
+            // TODO: wire from req.standalone_repo once proto is merged
+            standalone_repo: false,
         };
 
         let result = self
@@ -349,6 +351,8 @@ impl AgentEffects for AgentHandler {
             ),
             working_dir: None,
             permissions: None,
+            // TODO: wire from req.standalone_repo once proto is merged
+            standalone_repo: false,
         };
 
         let result = self


### PR DESCRIPTION
This PR implements the `standalone_repo` functionality in the Rust service layer.

When `standalone_repo` is true on a spawn request, a fresh `git init` repo is created instead of a git worktree. This provides information isolation for agents.

Changes:
- Added `standalone_repo: bool` to `SpawnSubtreeOptions` struct in `rust/exomonad-core/src/services/agent_control.rs`.
- Implemented `git init` logic in `spawn_subtree` and `spawn_leaf_subtree` methods in `rust/exomonad-core/src/services/agent_control.rs`.
- Added `TODO` wiring in `rust/exomonad-core/src/handlers/agent.rs` (currently hardcoded to `false` until proto field is merged).

Verification:
- `cargo check --workspace` passes.