### PR TITLE
feat: add standalone_repo flag to spawn primitives in proto and Haskell

### DIFF
--- a/haskell/proto/src/Effects/Agent.hs
+++ b/haskell/proto/src/Effects/Agent.hs
@@ -2265,7 +2265,8 @@ data SpawnSubtreeRequest
                          spawnSubtreeRequestAllowedTools :: (Hs.Vector Hs.Text),
                          spawnSubtreeRequestDisallowedTools :: (Hs.Vector Hs.Text),
                          spawnSubtreeRequestWorkingDir :: Hs.Text,
-                         spawnSubtreeRequestPermissions :: (Hs.Maybe Effects.Agent.Permissions)}
+                         spawnSubtreeRequestPermissions :: (Hs.Maybe Effects.Agent.Permissions),
+                         spawnSubtreeRequestStandaloneRepo :: Hs.Bool}
   deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)
 instance (Hs.NFData SpawnSubtreeRequest)
 instance (HsProtobuf.Named SpawnSubtreeRequest) where
@@ -2280,7 +2281,7 @@ instance (HsProtobuf.Message SpawnSubtreeRequest) where
                          spawnSubtreeRequestAgentType, spawnSubtreeRequestPermissionMode,
                          spawnSubtreeRequestAllowedTools,
                          spawnSubtreeRequestDisallowedTools, spawnSubtreeRequestWorkingDir,
-                         spawnSubtreeRequestPermissions}
+                         spawnSubtreeRequestPermissions, spawnSubtreeRequestStandaloneRepo}
     = Hs.mappend
         (Hs.mappend
            (Hs.mappend
@@ -2291,52 +2292,55 @@ instance (HsProtobuf.Message SpawnSubtreeRequest) where
                           (Hs.mappend
                              (Hs.mappend
                                 (Hs.mappend
+                                   (Hs.mappend
+                                      (HsProtobuf.encodeMessageField
+                                         (HsProtobuf.FieldNumber 1)
+                                         ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
+                                            spawnSubtreeRequestTask))
+                                      (HsProtobuf.encodeMessageField
+                                         (HsProtobuf.FieldNumber 2)
+                                         ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
+                                            spawnSubtreeRequestBranchName)))
                                    (HsProtobuf.encodeMessageField
-                                      (HsProtobuf.FieldNumber 1)
+                                      (HsProtobuf.FieldNumber 3)
                                       ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
-                                         spawnSubtreeRequestTask))
-                                   (HsProtobuf.encodeMessageField
-                                      (HsProtobuf.FieldNumber 2)
-                                      ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
-                                         spawnSubtreeRequestBranchName)))
+                                         spawnSubtreeRequestParentSessionId)))
                                 (HsProtobuf.encodeMessageField
-                                   (HsProtobuf.FieldNumber 3)
-                                   ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
-                                      spawnSubtreeRequestParentSessionId)))
+                                   (HsProtobuf.FieldNumber 4) spawnSubtreeRequestForkSession))
                              (HsProtobuf.encodeMessageField
-                                (HsProtobuf.FieldNumber 4) spawnSubtreeRequestForkSession))
+                                (HsProtobuf.FieldNumber 5)
+                                ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
+                                   spawnSubtreeRequestRole)))
                           (HsProtobuf.encodeMessageField
-                             (HsProtobuf.FieldNumber 5)
-                             ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
-                                spawnSubtreeRequestRole)))
+                             (HsProtobuf.FieldNumber 6) spawnSubtreeRequestAgentType))
                        (HsProtobuf.encodeMessageField
-                          (HsProtobuf.FieldNumber 6) spawnSubtreeRequestAgentType))
+                          (HsProtobuf.FieldNumber 7)
+                          ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
+                             spawnSubtreeRequestPermissionMode)))
                     (HsProtobuf.encodeMessageField
-                       (HsProtobuf.FieldNumber 7)
-                       ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
-                          spawnSubtreeRequestPermissionMode)))
+                       (HsProtobuf.FieldNumber 8)
+                       ((Hs.coerce
+                           @(Hs.Vector Hs.Text)
+                           @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)))
+                          spawnSubtreeRequestAllowedTools)))
                  (HsProtobuf.encodeMessageField
-                    (HsProtobuf.FieldNumber 8)
+                    (HsProtobuf.FieldNumber 9)
                     ((Hs.coerce
                         @(Hs.Vector Hs.Text)
                         @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)))
-                       spawnSubtreeRequestAllowedTools)))
+                       spawnSubtreeRequestDisallowedTools)))
               (HsProtobuf.encodeMessageField
-                 (HsProtobuf.FieldNumber 9)
-                 ((Hs.coerce
-                     @(Hs.Vector Hs.Text)
-                     @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)))
-                    spawnSubtreeRequestDisallowedTools)))
+                 (HsProtobuf.FieldNumber 12)
+                 ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
+                    spawnSubtreeRequestWorkingDir)))
            (HsProtobuf.encodeMessageField
-              (HsProtobuf.FieldNumber 12)
-              ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
-                 spawnSubtreeRequestWorkingDir)))
+              (HsProtobuf.FieldNumber 13)
+              ((Hs.coerce
+                  @(Hs.Maybe Effects.Agent.Permissions)
+                  @(HsProtobuf.Nested Effects.Agent.Permissions))
+                 spawnSubtreeRequestPermissions)))
         (HsProtobuf.encodeMessageField
-           (HsProtobuf.FieldNumber 13)
-           ((Hs.coerce
-               @(Hs.Maybe Effects.Agent.Permissions)
-               @(HsProtobuf.Nested Effects.Agent.Permissions))
-              spawnSubtreeRequestPermissions))
+           (HsProtobuf.FieldNumber 14) spawnSubtreeRequestStandaloneRepo)
   decodeMessage _
     = Hs.pure SpawnSubtreeRequest
         <*>
@@ -2387,6 +2391,9 @@ instance (HsProtobuf.Message SpawnSubtreeRequest) where
               @(Hs.Maybe Effects.Agent.Permissions))
              (HsProtobuf.at
                 HsProtobuf.decodeMessageField (HsProtobuf.FieldNumber 13)))
+        <*>
+          HsProtobuf.at
+            HsProtobuf.decodeMessageField (HsProtobuf.FieldNumber 14)
   dotProto _
     = [HsProtobufAST.DotProtoField
          (HsProtobuf.FieldNumber 1)
@@ -2432,9 +2439,13 @@ instance (HsProtobuf.Message SpawnSubtreeRequest) where
          (HsProtobuf.FieldNumber 13)
          (HsProtobufAST.Prim
             (HsProtobufAST.Named (HsProtobufAST.Single "Permissions")))
-         (HsProtobufAST.Single "permissions") [] ""]
+         (HsProtobufAST.Single "permissions") [] "",
+       HsProtobufAST.DotProtoField
+         (HsProtobuf.FieldNumber 14) (HsProtobufAST.Prim HsProtobufAST.Bool)
+         (HsProtobufAST.Single "standalone_repo") [] ""]
 instance (HsJSONPB.ToJSONPB SpawnSubtreeRequest) where
-  toJSONPB (SpawnSubtreeRequest f1 f2 f3 f4 f5 f6 f7 f8 f9 f12 f13)
+  toJSONPB
+    (SpawnSubtreeRequest f1 f2 f3 f4 f5 f6 f7 f8 f9 f12 f13 f14)
     = HsJSONPB.object
         ["task" .= ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text)) f1),
          "branch_name"
@@ -2465,9 +2476,10 @@ instance (HsJSONPB.ToJSONPB SpawnSubtreeRequest) where
              ((Hs.coerce
                  @(Hs.Maybe Effects.Agent.Permissions)
                  @(HsProtobuf.Nested Effects.Agent.Permissions))
-                f13)]
+                f13),
+         "standalone_repo" .= f14]
   toEncodingPB
-    (SpawnSubtreeRequest f1 f2 f3 f4 f5 f6 f7 f8 f9 f12 f13)
+    (SpawnSubtreeRequest f1 f2 f3 f4 f5 f6 f7 f8 f9 f12 f13 f14)
     = HsJSONPB.pairs
         ["task" .= ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text)) f1),
          "branch_name"
@@ -2498,7 +2510,8 @@ instance (HsJSONPB.ToJSONPB SpawnSubtreeRequest) where
              ((Hs.coerce
                  @(Hs.Maybe Effects.Agent.Permissions)
                  @(HsProtobuf.Nested Effects.Agent.Permissions))
-                f13)]
+                f13),
+         "standalone_repo" .= f14]
 instance (HsJSONPB.FromJSONPB SpawnSubtreeRequest) where
   parseJSONPB
     = HsJSONPB.withObject
@@ -2539,7 +2552,8 @@ instance (HsJSONPB.FromJSONPB SpawnSubtreeRequest) where
                   ((HsProtobuf.coerceOver
                       @(HsProtobuf.Nested Effects.Agent.Permissions)
                       @(Hs.Maybe Effects.Agent.Permissions))
-                     (obj .: "permissions")))
+                     (obj .: "permissions"))
+                <*> obj .: "standalone_repo")
 instance (HsJSONPB.ToJSON SpawnSubtreeRequest) where
   toJSON = HsJSONPB.toAesonValue
   toEncoding = HsJSONPB.toAesonEncoding
@@ -2614,7 +2628,8 @@ data SpawnLeafSubtreeRequest
                              spawnLeafSubtreeRequestAgentType :: (HsProtobuf.Enumerated Effects.Agent.AgentType),
                              spawnLeafSubtreeRequestPermissionMode :: Hs.Text,
                              spawnLeafSubtreeRequestAllowedTools :: (Hs.Vector Hs.Text),
-                             spawnLeafSubtreeRequestDisallowedTools :: (Hs.Vector Hs.Text)}
+                             spawnLeafSubtreeRequestDisallowedTools :: (Hs.Vector Hs.Text),
+                             spawnLeafSubtreeRequestStandaloneRepo :: Hs.Bool}
   deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)
 instance (Hs.NFData SpawnLeafSubtreeRequest)
 instance (HsProtobuf.Named SpawnLeafSubtreeRequest) where
@@ -2628,43 +2643,47 @@ instance (HsProtobuf.Message SpawnLeafSubtreeRequest) where
                              spawnLeafSubtreeRequestAgentType,
                              spawnLeafSubtreeRequestPermissionMode,
                              spawnLeafSubtreeRequestAllowedTools,
-                             spawnLeafSubtreeRequestDisallowedTools}
+                             spawnLeafSubtreeRequestDisallowedTools,
+                             spawnLeafSubtreeRequestStandaloneRepo}
     = Hs.mappend
         (Hs.mappend
            (Hs.mappend
               (Hs.mappend
                  (Hs.mappend
                     (Hs.mappend
+                       (Hs.mappend
+                          (HsProtobuf.encodeMessageField
+                             (HsProtobuf.FieldNumber 1)
+                             ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
+                                spawnLeafSubtreeRequestTask))
+                          (HsProtobuf.encodeMessageField
+                             (HsProtobuf.FieldNumber 2)
+                             ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
+                                spawnLeafSubtreeRequestBranchName)))
                        (HsProtobuf.encodeMessageField
-                          (HsProtobuf.FieldNumber 1)
+                          (HsProtobuf.FieldNumber 3)
                           ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
-                             spawnLeafSubtreeRequestTask))
-                       (HsProtobuf.encodeMessageField
-                          (HsProtobuf.FieldNumber 2)
-                          ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
-                             spawnLeafSubtreeRequestBranchName)))
+                             spawnLeafSubtreeRequestRole)))
                     (HsProtobuf.encodeMessageField
-                       (HsProtobuf.FieldNumber 3)
-                       ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
-                          spawnLeafSubtreeRequestRole)))
+                       (HsProtobuf.FieldNumber 4) spawnLeafSubtreeRequestAgentType))
                  (HsProtobuf.encodeMessageField
-                    (HsProtobuf.FieldNumber 4) spawnLeafSubtreeRequestAgentType))
+                    (HsProtobuf.FieldNumber 5)
+                    ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
+                       spawnLeafSubtreeRequestPermissionMode)))
               (HsProtobuf.encodeMessageField
-                 (HsProtobuf.FieldNumber 5)
-                 ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text))
-                    spawnLeafSubtreeRequestPermissionMode)))
+                 (HsProtobuf.FieldNumber 6)
+                 ((Hs.coerce
+                     @(Hs.Vector Hs.Text)
+                     @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)))
+                    spawnLeafSubtreeRequestAllowedTools)))
            (HsProtobuf.encodeMessageField
-              (HsProtobuf.FieldNumber 6)
+              (HsProtobuf.FieldNumber 7)
               ((Hs.coerce
                   @(Hs.Vector Hs.Text)
                   @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)))
-                 spawnLeafSubtreeRequestAllowedTools)))
+                 spawnLeafSubtreeRequestDisallowedTools)))
         (HsProtobuf.encodeMessageField
-           (HsProtobuf.FieldNumber 7)
-           ((Hs.coerce
-               @(Hs.Vector Hs.Text)
-               @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)))
-              spawnLeafSubtreeRequestDisallowedTools))
+           (HsProtobuf.FieldNumber 10) spawnLeafSubtreeRequestStandaloneRepo)
   decodeMessage _
     = Hs.pure SpawnLeafSubtreeRequest
         <*>
@@ -2698,6 +2717,9 @@ instance (HsProtobuf.Message SpawnLeafSubtreeRequest) where
               @(Hs.Vector Hs.Text))
              (HsProtobuf.at
                 HsProtobuf.decodeMessageField (HsProtobuf.FieldNumber 7)))
+        <*>
+          HsProtobuf.at
+            HsProtobuf.decodeMessageField (HsProtobuf.FieldNumber 10)
   dotProto _
     = [HsProtobufAST.DotProtoField
          (HsProtobuf.FieldNumber 1)
@@ -2727,9 +2749,12 @@ instance (HsProtobuf.Message SpawnLeafSubtreeRequest) where
        HsProtobufAST.DotProtoField
          (HsProtobuf.FieldNumber 7)
          (HsProtobufAST.Repeated HsProtobufAST.String)
-         (HsProtobufAST.Single "disallowed_tools") [] ""]
+         (HsProtobufAST.Single "disallowed_tools") [] "",
+       HsProtobufAST.DotProtoField
+         (HsProtobuf.FieldNumber 10) (HsProtobufAST.Prim HsProtobufAST.Bool)
+         (HsProtobufAST.Single "standalone_repo") [] ""]
 instance (HsJSONPB.ToJSONPB SpawnLeafSubtreeRequest) where
-  toJSONPB (SpawnLeafSubtreeRequest f1 f2 f3 f4 f5 f6 f7)
+  toJSONPB (SpawnLeafSubtreeRequest f1 f2 f3 f4 f5 f6 f7 f10)
     = HsJSONPB.object
         ["task" .= ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text)) f1),
          "branch_name"
@@ -2749,8 +2774,9 @@ instance (HsJSONPB.ToJSONPB SpawnLeafSubtreeRequest) where
              ((Hs.coerce
                  @(Hs.Vector Hs.Text)
                  @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)))
-                f7)]
-  toEncodingPB (SpawnLeafSubtreeRequest f1 f2 f3 f4 f5 f6 f7)
+                f7),
+         "standalone_repo" .= f10]
+  toEncodingPB (SpawnLeafSubtreeRequest f1 f2 f3 f4 f5 f6 f7 f10)
     = HsJSONPB.pairs
         ["task" .= ((Hs.coerce @Hs.Text @(HsProtobuf.String Hs.Text)) f1),
          "branch_name"
@@ -2770,7 +2796,8 @@ instance (HsJSONPB.ToJSONPB SpawnLeafSubtreeRequest) where
              ((Hs.coerce
                  @(Hs.Vector Hs.Text)
                  @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)))
-                f7)]
+                f7),
+         "standalone_repo" .= f10]
 instance (HsJSONPB.FromJSONPB SpawnLeafSubtreeRequest) where
   parseJSONPB
     = HsJSONPB.withObject
@@ -2799,7 +2826,8 @@ instance (HsJSONPB.FromJSONPB SpawnLeafSubtreeRequest) where
                   ((HsProtobuf.coerceOver
                       @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text))
                       @(Hs.Vector Hs.Text))
-                     (obj .: "disallowed_tools")))
+                     (obj .: "disallowed_tools"))
+                <*> obj .: "standalone_repo")
 instance (HsJSONPB.ToJSON SpawnLeafSubtreeRequest) where
   toJSON = HsJSONPB.toAesonValue
   toEncoding = HsJSONPB.toAesonEncoding

--- a/proto/effects/agent.proto
+++ b/proto/effects/agent.proto
@@ -279,6 +279,9 @@ message SpawnSubtreeRequest {
   reserved "secure_mode", "allowed_read_paths";
   string working_dir = 12;
   Permissions permissions = 13;
+  // When true, creates a standalone git repo instead of a worktree.
+  // The agent's .git boundary prevents traversal to the parent repository.
+  bool standalone_repo = 14;
 }
 
 message SpawnSubtreeResponse {
@@ -304,6 +307,8 @@ message SpawnLeafSubtreeRequest {
   repeated string disallowed_tools = 7;
   reserved 8, 9;
   reserved "secure_mode", "allowed_read_paths";
+  // When true, creates a standalone git repo instead of a worktree.
+  bool standalone_repo = 10;
 }
 
 message SpawnLeafSubtreeResponse {

--- a/rust/exomonad-proto/proto/effects/agent.proto
+++ b/rust/exomonad-proto/proto/effects/agent.proto
@@ -279,6 +279,9 @@ message SpawnSubtreeRequest {
   reserved "secure_mode", "allowed_read_paths";
   string working_dir = 12;
   Permissions permissions = 13;
+  // When true, creates a standalone git repo instead of a worktree.
+  // The agent's .git boundary prevents traversal to the parent repository.
+  bool standalone_repo = 14;
 }
 
 message SpawnSubtreeResponse {
@@ -304,6 +307,8 @@ message SpawnLeafSubtreeRequest {
   repeated string disallowed_tools = 7;
   reserved 8, 9;
   reserved "secure_mode", "allowed_read_paths";
+  // When true, creates a standalone git repo instead of a worktree.
+  bool standalone_repo = 10;
 }
 
 message SpawnLeafSubtreeResponse {


### PR DESCRIPTION
Added `standalone_repo` boolean flag to `SpawnSubtreeRequest` (field 14) and `SpawnLeafSubtreeRequest` (field 10) in both `proto/effects/agent.proto` and `rust/exomonad-proto/proto/effects/agent.proto`.

Updated Haskell side:
- Regenerated Haskell proto types.
- Updated `SpawnSubtreeArgs` and `SpawnLeafSubtreeArgs` in `ExoMonad.Guest.Tools.Spawn` with `standalone_repo` field, FromJSON instance, and tool schema.
- Updated `AgentControl` GADT and smart constructors in `ExoMonad.Guest.Effects.AgentControl` to include `standalone_repo`.
- Updated `runAgentControlSuspend` interpreter to map the new field to the proto request.

Verified that `wasm-guest-internal` builds successfully with `just wasm role=tl` (after correcting the `just` command to `just wasm tl` and then `wasm-guest:lib:wasm-guest-internal` build).