### PR TITLE
feat: add defaultMode to AgentPermissions and settings.local.json

### DIFF
--- a/rust/exomonad-core/src/domain.rs
+++ b/rust/exomonad-core/src/domain.rs
@@ -617,6 +617,8 @@ pub struct AgentPermissions {
     pub allow: Vec<String>,
     /// Tool patterns to deny.
     pub deny: Vec<String>,
+    /// Permission mode override (e.g., "dontAsk" for deny-by-default).
+    pub default_mode: Option<String>,
 }
 
 // ============================================================================

--- a/rust/exomonad-core/src/handlers/agent.rs
+++ b/rust/exomonad-core/src/handlers/agent.rs
@@ -297,6 +297,7 @@ impl AgentEffects for AgentHandler {
             permissions: req.permissions.map(|p| AgentPermissions {
                 allow: p.allow,
                 deny: p.deny,
+                default_mode: None,
             }),
             standalone_repo: req.standalone_repo,
         };

--- a/rust/exomonad-core/src/hooks.rs
+++ b/rust/exomonad-core/src/hooks.rs
@@ -136,10 +136,14 @@ impl HookConfig {
 
         // Write permissions if provided
         if let Some(p) = permissions {
-            settings["permissions"] = json!({
+            let mut perm_obj = serde_json::json!({
                 "allow": p.allow,
                 "deny": p.deny,
             });
+            if let Some(ref mode) = p.default_mode {
+                perm_obj["defaultMode"] = serde_json::json!(mode);
+            }
+            settings["permissions"] = perm_obj;
         }
 
         let content =


### PR DESCRIPTION
This PR adds `default_mode` to the `AgentPermissions` struct in `exomonad-core` and ensures it is written as `defaultMode` in `settings.local.json` when present.

This is necessary for the deny-by-default allowlist pattern (e.g., using `"defaultMode": "dontAsk"`).

Changes:
- Added `default_mode: Option<String>` to `AgentPermissions` in `domain.rs`.
- Updated `write_persistent` in `hooks.rs` to write `defaultMode` to the JSON configuration.
- Updated `AgentPermissions` construction in `handlers/agent.rs` (set to `None` for now as it's not yet in the proto).

Verified with `cargo check --workspace`.