### PR TITLE
chore(haskell): replace maybe "" id and remove dead stcParentSessionId

### DIFF
--- a/haskell/wasm-guest/src/ExoMonad/Guest/Effects/AgentControl.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Guest/Effects/AgentControl.hs
@@ -36,6 +36,7 @@ where
 
 import Control.Monad.Freer (Eff, Member, interpret, send)
 import Data.Aeson (FromJSON (..), ToJSON (..), object, withObject, withText, (.:), (.=))
+import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Vector qualified as V
@@ -115,7 +116,6 @@ defaultPermFlags = PermissionFlags Nothing [] []
 data SpawnSubtreeConfig = SpawnSubtreeConfig
   { stcTask :: Text,
     stcBranchName :: Text,
-    stcParentSessionId :: Text,
     stcForkSession :: Bool,
     stcRole :: Maybe Text,
     stcAgentType :: Maybe AgentType,
@@ -170,14 +170,14 @@ runAgentControlSuspend = interpret $ \case
           PA.SpawnSubtreeRequest
             { PA.spawnSubtreeRequestTask = fromText (stcTask cfg),
               PA.spawnSubtreeRequestBranchName = fromText (stcBranchName cfg),
-              PA.spawnSubtreeRequestParentSessionId = fromText (stcParentSessionId cfg),
+              PA.spawnSubtreeRequestParentSessionId = fromText "",
               PA.spawnSubtreeRequestForkSession = stcForkSession cfg,
-              PA.spawnSubtreeRequestRole = fromText (maybe "" id (stcRole cfg)),
+              PA.spawnSubtreeRequestRole = fromText (fromMaybe "" (stcRole cfg)),
               PA.spawnSubtreeRequestAgentType = Enumerated (Right (maybe PA.AgentTypeAGENT_TYPE_UNSPECIFIED toProtoAgentType (stcAgentType cfg))),
-              PA.spawnSubtreeRequestPermissionMode = fromText (maybe "" id (permMode (stcPerms cfg))),
+              PA.spawnSubtreeRequestPermissionMode = fromText (fromMaybe "" (permMode (stcPerms cfg))),
               PA.spawnSubtreeRequestAllowedTools = V.fromList (map fromText (allowedTools (stcPerms cfg))),
               PA.spawnSubtreeRequestDisallowedTools = V.fromList (map fromText (disallowedTools (stcPerms cfg))),
-              PA.spawnSubtreeRequestWorkingDir = fromText (maybe "" id (stcWorkingDir cfg)),
+              PA.spawnSubtreeRequestWorkingDir = fromText (fromMaybe "" (stcWorkingDir cfg)),
               PA.spawnSubtreeRequestPermissions = fmap permissionsToProto (stcPermissions cfg),
               PA.spawnSubtreeRequestStandaloneRepo = stcStandaloneRepo cfg
             }
@@ -192,9 +192,9 @@ runAgentControlSuspend = interpret $ \case
           PA.SpawnLeafSubtreeRequest
             { PA.spawnLeafSubtreeRequestTask = fromText (slcTask cfg),
               PA.spawnLeafSubtreeRequestBranchName = fromText (slcBranchName cfg),
-              PA.spawnLeafSubtreeRequestRole = fromText (maybe "" id (slcRole cfg)),
+              PA.spawnLeafSubtreeRequestRole = fromText (fromMaybe "" (slcRole cfg)),
               PA.spawnLeafSubtreeRequestAgentType = Enumerated (Right (maybe PA.AgentTypeAGENT_TYPE_UNSPECIFIED toProtoAgentType (slcAgentType cfg))),
-              PA.spawnLeafSubtreeRequestPermissionMode = fromText (maybe "" id (permMode (slcPerms cfg))),
+              PA.spawnLeafSubtreeRequestPermissionMode = fromText (fromMaybe "" (permMode (slcPerms cfg))),
               PA.spawnLeafSubtreeRequestAllowedTools = V.fromList (map fromText (allowedTools (slcPerms cfg))),
               PA.spawnLeafSubtreeRequestDisallowedTools = V.fromList (map fromText (disallowedTools (slcPerms cfg))),
               PA.spawnLeafSubtreeRequestStandaloneRepo = slcStandaloneRepo cfg
@@ -210,7 +210,7 @@ runAgentControlSuspend = interpret $ \case
           PA.SpawnWorkerRequest
             { PA.spawnWorkerRequestName = fromText name,
               PA.spawnWorkerRequestPrompt = fromText prompt,
-              PA.spawnWorkerRequestPermissionMode = fromText (maybe "" id (permMode perms)),
+              PA.spawnWorkerRequestPermissionMode = fromText (fromMaybe "" (permMode perms)),
               PA.spawnWorkerRequestAllowedTools = V.fromList (map fromText (allowedTools perms)),
               PA.spawnWorkerRequestDisallowedTools = V.fromList (map fromText (disallowedTools perms))
             }
@@ -225,7 +225,7 @@ runAgentControlSuspend = interpret $ \case
           PA.SpawnAcpRequest
             { PA.spawnAcpRequestName = fromText name,
               PA.spawnAcpRequestPrompt = fromText prompt,
-              PA.spawnAcpRequestPermissionMode = fromText (maybe "" id (permMode perms)),
+              PA.spawnAcpRequestPermissionMode = fromText (fromMaybe "" (permMode perms)),
               PA.spawnAcpRequestAllowedTools = V.fromList (map fromText (allowedTools perms)),
               PA.spawnAcpRequestDisallowedTools = V.fromList (map fromText (disallowedTools perms))
             }

--- a/haskell/wasm-guest/src/ExoMonad/Guest/Tools/Spawn.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Guest/Tools/Spawn.hs
@@ -87,7 +87,6 @@ instance MCPTool SpawnSubtree where
         cfg = AC.SpawnSubtreeConfig
           { AC.stcTask = ssTask args
           , AC.stcBranchName = ssBranchName args
-          , AC.stcParentSessionId = ""
           , AC.stcForkSession = forkSession
           , AC.stcRole = Nothing
           , AC.stcAgentType = Nothing


### PR DESCRIPTION
This PR performs two Haskell cleanups in `AgentControl.hs` and `Spawn.hs`:

1.  Replaced all occurrences of `maybe "" id` with `fromMaybe ""` in `AgentControl.hs`.
2.  Removed the dead `stcParentSessionId` field from `SpawnSubtreeConfig` in `AgentControl.hs` and `Spawn.hs`.
3.  Updated the interpreter in `AgentControl.hs` to hardcode the proto field `spawnSubtreeRequestParentSessionId = fromText ""`.

WASM build was attempted but hit dependency/environment conflicts (base version mismatch in freeze file), which are out of scope for this task. The changes are syntactically correct and follow the requested steps.