### PR TITLE
Refactor MCP Tool Schemas to make Null unrepresentable

### DIFF
--- a/haskell/wasm-guest/src/ExoMonad/Guest/Tool/Class.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Guest/Tool/Class.hs
@@ -32,6 +32,7 @@ where
 import Control.Monad.Freer (Eff, Member, sendM)
 import Data.Aeson (FromJSON, ToJSON, Value, object, (.=))
 import Data.Aeson qualified as Aeson
+import Data.Aeson.KeyMap qualified as KM
 import Data.Kind (Type)
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -48,7 +49,7 @@ import GHC.Generics (Generic)
 data ToolDefinition = ToolDefinition
   { tdName :: Text,
     tdDescription :: Text,
-    tdInputSchema :: Value
+    tdInputSchema :: Aeson.Object
   }
   deriving (Show, Eq)
 
@@ -58,7 +59,7 @@ toMCPFormat t =
   object
     [ "name" .= tdName t,
       "description" .= tdDescription t,
-      "inputSchema" .= tdInputSchema t
+      "inputSchema" .= Aeson.Object (tdInputSchema t)
     ]
 
 -- | Create a tool definition from an MCPTool instance.
@@ -142,7 +143,7 @@ class MCPTool (t :: Type) where
   toolDescription :: Text
 
   -- | JSON Schema for the input.
-  toolSchema :: Value
+  toolSchema :: Aeson.Object
 
   -- | Effectful handler that can suspend via coroutine yield.
   toolHandlerEff :: ToolArgs t -> Eff ToolEffects MCPCallOutput

--- a/haskell/wasm-guest/src/ExoMonad/Guest/Tools/Events.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Guest/Tools/Events.hs
@@ -50,10 +50,11 @@ data TaskReport = TaskReport
 
 instance JsonSchema TaskReport where
   toSchema =
-    genericToolSchemaWith @TaskReport
-      [ ("what", "task description"),
-        ("how", "verification command that was run")
-      ]
+    Aeson.Object $
+      genericToolSchemaWith @TaskReport
+        [ ("what", "task description"),
+          ("how", "verification command that was run")
+        ]
 
 instance FromJSON TaskReport where
   parseJSON = withObject "TaskReport" $ \v ->

--- a/haskell/wasm-guest/src/ExoMonad/Guest/Tools/Popup.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Guest/Tools/Popup.hs
@@ -20,6 +20,7 @@ import Control.Applicative ((<|>))
 import Control.Monad.Freer (Eff)
 import Data.Aeson (FromJSON (..), ToJSON (..), Value, object, withObject, withText, (.:), (.:?), (.=))
 import Data.Aeson qualified as Aeson
+import Data.Aeson.KeyMap qualified as KM
 import Data.ByteString.Lazy qualified as BL
 import Data.HashMap.Strict (HashMap)
 import Data.Text (Text)
@@ -227,7 +228,7 @@ instance MCPTool Popup where
   toolName = "popup"
   toolDescription = "Show interactive popup form and get user response"
   toolSchema =
-    object
+    case object
       [ "type" .= ("object" :: Text),
         "properties"
           .= object
@@ -321,7 +322,9 @@ instance MCPTool Popup where
                   ]
             ],
         "required" .= ([] :: [Text])
-      ]
+      ] of
+      Aeson.Object o -> o
+      _ -> KM.empty
   toolHandlerEff args = do
     let request = toShowPopupRequest args
     result <- suspendEffect @PopupShowPopup request

--- a/haskell/wasm-guest/src/ExoMonad/Guest/Tools/Spawn.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Guest/Tools/Spawn.hs
@@ -212,8 +212,9 @@ data WorkerSpec = WorkerSpec
 
 instance JsonSchema WorkerSpec where
   toSchema =
-    genericToolSchemaWith @WorkerSpec
-      [ ("name", "Human-readable name for the leaf agent"),
+    Aeson.Object $
+      genericToolSchemaWith @WorkerSpec
+        [ ("name", "Human-readable name for the leaf agent"),
         ("task", "Short description of the task"),
         ("read_first", "Files the agent should read before starting"),
         ("steps", "Numbered implementation steps"),


### PR DESCRIPTION
Refactored the MCP tool schema types to use `Aeson.Object` instead of `Aeson.Value`.
This ensures that `Null` is unrepresentable at compile time for tool input schemas, which prevents discovery failures in Gemini CLI.

Changes:
- Updated `ToolDefinition` and `MCPTool` in `Class.hs` to use `Aeson.Object` for `tdInputSchema` and `toolSchema`.
- Updated `genericToolSchema` and `genericToolSchemaWith` in `Schema.hs` to return `Aeson.Object`.
- Adjusted `JsonSchema` class and instances in `Schema.hs`, `Spawn.hs`, and `Events.hs` to correctly handle the new types.
- Updated the manual `toolSchema` in `Popup.hs` to return `Aeson.Object`.
- Verified the changes with `just wasm-all`.