### PR TITLE
feat: re-enable popup tool in TL role

### DIFF
--- a/.exo/roles/unified/TLRole.hs
+++ b/.exo/roles/unified/TLRole.hs
@@ -3,8 +3,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
 
--- | TL role config: spawn, PR, merge tools with stop hook checks.
--- Popup disabled: blocks WASM plugin lock for up to 30min, preventing all other MCP calls.
+-- | TL role config: spawn, PR, merge, popup tools with stop hook checks.
 module TLRole (config, Tools) where
 
 import ExoMonad
@@ -15,6 +14,7 @@ import ExoMonad.Types (HookConfig (..), defaultSessionStartHook, teamRegistratio
 
 data Tools mode = Tools
   { spawn :: SpawnTools mode,
+    popups :: PopupTools mode,
     pr :: FilePRTools mode,
     mergePr :: mode :- MergePR,
     notifyParent :: mode :- NotifyParent
@@ -28,6 +28,7 @@ config =
       tools =
         Tools
           { spawn = spawnTools,
+            popups = popupTools,
             pr = filePRTools,
             mergePr = mkHandler @MergePR,
             notifyParent = mkHandler @NotifyParent


### PR DESCRIPTION
Re-enables the popup tool in the TL role's tool record so it's available to TL agents.

- Added `popups :: PopupTools mode` to `Tools` record.
- Added `popups = popupTools` to `tools` field in `config`.
- Updated module header and removed the "Popup disabled" warning.
- Verified with `just wasm-all`.