### PR TITLE
feat: use close_self() for tiled pane cleanup

### DIFF
--- a/rust/exomonad-plugin/src/main.rs
+++ b/rust/exomonad-plugin/src/main.rs
@@ -1043,7 +1043,7 @@ impl ZellijPlugin for ExoMonadPlugin {
                                 self.status_state = PluginState::Idle;
                                 self.status_message = "Ready.".to_string();
                                 should_render = true;
-                                hide_self();
+                                close_self();
                             }
                         },
                         Err(e) => {
@@ -1128,7 +1128,7 @@ impl ZellijPlugin for ExoMonadPlugin {
                         self.status_state = PluginState::Idle;
                         self.status_message = "Ready.".to_string();
                         should_render = true;
-                        hide_self();
+                        close_self();
                     }
                 }
 
@@ -1165,7 +1165,7 @@ impl ZellijPlugin for ExoMonadPlugin {
                         self.status_state = PluginState::Idle;
                         self.status_message = "Ready.".to_string();
                         should_render = true;
-                        hide_self();
+                        close_self();
                     }
                 }
             }


### PR DESCRIPTION
Replace `hide_self()` with `close_self()` in popup and wizard dismiss paths. 
For tiled panes, `hide_self()` leaves a collapsed/empty space, whereas `close_self()` properly closes the pane and reclaims the space.

Popup instances are disposable as they are launched with `launch_new: true`.

Verified that `cli_pipe_output()` is called before `close_self()` in all submit/cancel paths.

Verified build with `cargo build -p exomonad-plugin --target wasm32-wasip1`.