### PR TITLE
feat: replace subprocess-based popup with ZellijIpc pipes

### DIFF
--- a/rust/exomonad-core/src/handlers/groups.rs
+++ b/rust/exomonad-core/src/handlers/groups.rs
@@ -12,6 +12,7 @@ use crate::services::git::GitService;
 use crate::services::git_worktree::GitWorktreeService;
 use crate::services::github::GitHubService;
 use crate::services::team_registry::TeamRegistry;
+use crate::services::zellij_ipc::ZellijIpc;
 
 use super::{
     AgentHandler, CopilotHandler, EventHandler, FilePRHandler, FsHandler, GitHandler,
@@ -89,9 +90,11 @@ pub fn orchestration_handlers(
         event_handler = event_handler.with_event_log(log.clone());
     }
 
+    let zellij_ipc = zellij_session.map(|s| ZellijIpc::new(&s));
+
     vec![
         Box::new(agent_handler),
-        Box::new(PopupHandler::new(zellij_session)),
+        Box::new(PopupHandler::new(zellij_ipc)),
         Box::new(event_handler),
         Box::new(SessionHandler::new(claude_session_registry).with_team_registry(team_registry)),
     ]

--- a/rust/exomonad-core/src/handlers/popup.rs
+++ b/rust/exomonad-core/src/handlers/popup.rs
@@ -2,8 +2,13 @@
 //!
 //! Uses proto-generated types from `exomonad_proto::effects::popup`.
 
-use crate::effects::{dispatch_popup_effect, EffectError, EffectResult, PopupEffects, ResultExt};
-use crate::services::popup::{PopupInput, PopupService};
+use crate::effects::{dispatch_popup_effect, EffectError, EffectResult, PopupEffects};
+use crate::layout::resolve_plugin_path;
+use crate::services::popup::{
+    extract_choice_items, sanitize_payload_field, PopupInput, PopupOutput, PopupService,
+};
+use crate::services::zellij_ipc::ZellijIpc;
+use anyhow::{Context, Result};
 use async_trait::async_trait;
 use exomonad_proto::effects::popup::*;
 
@@ -12,12 +17,12 @@ use exomonad_proto::effects::popup::*;
 /// Handles all effects in the `popup.*` namespace by delegating to
 /// the generated `dispatch_popup_effect` function.
 pub struct PopupHandler {
-    zellij_session: Option<String>,
+    zellij_ipc: Option<ZellijIpc>,
 }
 
 impl PopupHandler {
-    pub fn new(zellij_session: Option<String>) -> Self {
-        Self { zellij_session }
+    pub fn new(zellij_ipc: Option<ZellijIpc>) -> Self {
+        Self { zellij_ipc }
     }
 }
 
@@ -30,6 +35,13 @@ impl PopupEffects for PopupHandler {
         req: ShowPopupRequest,
         ctx: &crate::effects::EffectContext,
     ) -> EffectResult<ShowPopupResponse> {
+        let ipc = self.zellij_ipc.clone().ok_or_else(|| {
+            EffectError::custom(
+                "popup_error",
+                "No Zellij session available — popup requires a Zellij session",
+            )
+        })?;
+
         // Components bytes can be either:
         // - JSON array of component objects (form mode)
         // - JSON object with "panes" key (wizard mode)
@@ -49,9 +61,32 @@ impl PopupEffects for PopupHandler {
             target_tab: Some(target_tab),
         };
 
-        let service = PopupService::new(self.zellij_session.clone());
+        let plugin_path = resolve_plugin_path().ok_or_else(|| {
+            EffectError::custom(
+                "popup_error",
+                "Zellij plugin not found. Run 'just install-all' to install it.",
+            )
+        })?;
 
-        let output = service.show_popup(&input).effect_err("popup")?;
+        // Payload building logic (moved from PopupService)
+        let request_id = uuid::Uuid::new_v4().to_string();
+        let payload = build_payload(&request_id, &input).map_err(|e| {
+            EffectError::custom("popup_error", format!("Failed to build payload: {}", e))
+        })?;
+
+        let popup_service = PopupService::new(ipc, plugin_path);
+
+        let response_str = tokio::task::spawn_blocking(move || {
+            popup_service.show_popup(&payload)
+        })
+        .await
+        .map_err(|e| EffectError::custom("popup_error", format!("Task join failed: {}", e)))?
+        .map_err(|e| EffectError::custom("popup_error", format!("Popup failed: {}", e)))?;
+
+        // Response parsing logic (moved from PopupService)
+        let output = parse_response(&request_id, &response_str).map_err(|e| {
+            EffectError::custom("popup_error", format!("Failed to parse response: {}", e))
+        })?;
 
         let values_bytes = serde_json::to_vec(&output.values).map_err(|e| {
             EffectError::custom("popup_error", format!("Failed to serialize values: {}", e))
@@ -62,6 +97,123 @@ impl PopupEffects for PopupHandler {
             values: values_bytes,
         })
     }
+}
+
+fn build_payload(request_id: &str, input: &PopupInput) -> Result<String> {
+    // Determine mode: wizard (object with "panes") or form (array of components)
+    let payload = if input.raw_json.get("panes").is_some() {
+        // Wizard mode: wrap in WizardRequest envelope
+        let wizard_def: crate::ui_protocol::WizardDefinition =
+            serde_json::from_value(input.raw_json.clone())
+                .context("Failed to parse wizard definition")?;
+        let request = crate::ui_protocol::WizardRequest {
+            request_id: request_id.to_string(),
+            wizard: wizard_def,
+        };
+        serde_json::to_string(&request).context("Failed to serialize WizardRequest")?
+    } else if let Some(components_array) = input.raw_json.as_array() {
+        // Form mode: try typed component parsing
+        let components_res: Result<Vec<crate::ui_protocol::Component>, _> =
+            serde_json::from_value(serde_json::Value::Array(components_array.clone()));
+
+        if let Ok(components) = components_res {
+            let request = crate::ui_protocol::PopupRequest {
+                request_id: request_id.to_string(),
+                definition: crate::ui_protocol::PopupDefinition {
+                    title: input.title.clone(),
+                    components,
+                },
+            };
+            serde_json::to_string(&request).context("Failed to serialize PopupRequest")?
+        } else {
+            let items = extract_choice_items(components_array);
+            if items.is_empty() {
+                anyhow::bail!("Popup must have at least one choice item for Zellij display");
+            }
+
+            let safe_title = sanitize_payload_field(&input.title);
+            let safe_items: Vec<String> =
+                items.iter().map(|s| sanitize_payload_field(s)).collect();
+            format!("{}|{}|{}", request_id, safe_title, safe_items.join(","))
+        }
+    } else {
+        anyhow::bail!("Invalid popup input: expected array of components or wizard object");
+    };
+
+    // Inject target_tab routing into JSON payloads so only the correct plugin instance renders.
+    let payload = if let Some(target_tab) = &input.target_tab {
+        if payload.starts_with('{') {
+            let mut json: serde_json::Value = serde_json::from_str(&payload)
+                .context("Failed to re-parse payload for target_tab injection")?;
+            json["target_tab"] = serde_json::Value::String(target_tab.clone());
+            serde_json::to_string(&json).context("Failed to re-serialize payload")?
+        } else {
+            payload
+        }
+    } else {
+        payload
+    };
+
+    Ok(payload)
+}
+
+fn parse_response(request_id: &str, response_str: &str) -> Result<PopupOutput> {
+    let response_str = response_str.trim();
+
+    if response_str.is_empty() {
+        anyhow::bail!(
+            "Empty response from zellij pipe - plugin may have failed to load or respond"
+        );
+    }
+
+    // Parse response: try JSON first (new format), then legacy "request_id:selection"
+    if response_str.starts_with('{') {
+        let json: serde_json::Value = serde_json::from_str(response_str)
+            .context("Failed to parse JSON popup response")?;
+
+        let resp_request_id = json["request_id"].as_str().unwrap_or("");
+        if resp_request_id != request_id {
+            tracing::warn!(expected = %request_id, received = %resp_request_id, "Request ID mismatch");
+        }
+
+        let result = &json["result"];
+        let button = result["button"].as_str().unwrap_or("submit").to_string();
+        let values = result["values"].clone();
+
+        // For wizard results, include panes_visited in the values
+        if let Some(panes_visited) = result.get("panes_visited") {
+            let mut combined = serde_json::Map::new();
+            combined.insert("values".to_string(), values);
+            combined.insert("panes_visited".to_string(), panes_visited.clone());
+            return Ok(PopupOutput {
+                button,
+                values: serde_json::Value::Object(combined),
+            });
+        }
+
+        return Ok(PopupOutput { button, values });
+    }
+
+    // Legacy format: "request_id:selection" or "request_id:CANCELLED"
+    let (resp_request_id, selection) = response_str.split_once(':').context(format!(
+        "Invalid popup response format: expected 'request_id:selection', got: {:?}",
+        response_str
+    ))?;
+
+    if resp_request_id != request_id {
+        tracing::warn!(expected = %request_id, received = %resp_request_id, "Request ID mismatch");
+    }
+
+    let (button, values) = if selection == "CANCELLED" {
+        ("cancelled".to_string(), serde_json::json!({}))
+    } else {
+        (
+            "submit".to_string(),
+            serde_json::json!({"selected": selection}),
+        )
+    };
+
+    Ok(PopupOutput { button, values })
 }
 
 #[cfg(test)]
@@ -75,15 +227,106 @@ mod tests {
         assert_eq!(handler.namespace(), "popup");
     }
 
-    #[test]
-    fn test_construction_no_session() {
-        let handler = PopupHandler::new(None);
-        assert_eq!(handler.namespace(), "popup");
+        #[test]
+
+        fn test_construction_no_session() {
+
+            let handler = PopupHandler::new(None);
+
+            assert_eq!(handler.namespace(), "popup");
+
+        }
+
+    
+
+        #[test]
+
+        fn test_construction_with_session() {
+
+            let ipc = ZellijIpc::new("my-session");
+
+            let handler = PopupHandler::new(Some(ipc));
+
+            assert_eq!(handler.namespace(), "popup");
+
+        }
+
+    
+
+        #[test]
+
+        fn test_build_payload_form() {
+
+            let input = PopupInput {
+
+                title: "Test".to_string(),
+
+                raw_json: serde_json::json!([{
+
+                    "type": "text",
+
+                    "id": "msg",
+
+                    "content": "Hello"
+
+                }]),
+
+                target_tab: None,
+
+            };
+
+            let res = build_payload("req-123", &input).unwrap();
+
+            assert!(res.contains("req-123"));
+
+            assert!(res.contains("Test"));
+
+            assert!(res.contains("Hello"));
+
+        }
+
+    
+
+        #[test]
+
+        fn test_parse_response_json() {
+
+            let response = serde_json::json!({
+
+                "request_id": "req-123",
+
+                "result": {
+
+                    "button": "submit",
+
+                    "values": {"name": "test"}
+
+                }
+
+            });
+
+            let res = parse_response("req-123", &response.to_string()).unwrap();
+
+            assert_eq!(res.button, "submit");
+
+            assert_eq!(res.values["name"], "test");
+
+        }
+
+    
+
+        #[test]
+
+        fn test_parse_response_legacy() {
+
+            let res = parse_response("req-123", "req-123:Option A").unwrap();
+
+            assert_eq!(res.button, "submit");
+
+            assert_eq!(res.values["selected"], "Option A");
+
+        }
+
     }
 
-    #[test]
-    fn test_construction_with_session() {
-        let handler = PopupHandler::new(Some("my-session".to_string()));
-        assert_eq!(handler.namespace(), "popup");
-    }
-}
+    

--- a/rust/exomonad-core/src/services/popup.rs
+++ b/rust/exomonad-core/src/services/popup.rs
@@ -1,26 +1,13 @@
 //! Popup service for WASM host functions.
 //!
-//! Shows interactive popup forms and wizards via Zellij CLI pipes and returns user response.
+//! Shows interactive popup forms and wizards via Zellij IPC pipes and returns user response.
 //!
-//! Uses the Zellij CLI pipe mechanism:
-//! 1. `zellij pipe --plugin file:plugin.wasm --name exomonad:popup -- "{JSON payload}"`
-//! 2. Plugin receives via `pipe()` with `PipeSource::Cli(pipe_id)` and payload
-//! 3. Plugin blocks CLI, shows popup UI
-//! 4. On submit, plugin calls `cli_pipe_output(&pipe_id, "{JSON response}")`
-//! 5. CLI receives response on stdout
+//! Replaces the old subprocess-based implementation with direct Zellij IPC.
+//! The transport layer is now handled by `ZellijIpc::popup_pipe()`.
 
-use crate::layout::resolve_plugin_path;
-use crate::ui_protocol::transport;
-use anyhow::{Context, Result};
+use crate::services::zellij_ipc::ZellijIpc;
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
-use std::io::Read;
-use std::process::{Command, Stdio};
-use std::sync::mpsc;
-use std::time::Duration;
-
-/// Timeout for waiting for popup response (5 minutes).
-/// Reduced from 30min — popup blocks the WASM plugin lock for the entire duration.
-const POPUP_TIMEOUT: Duration = Duration::from_secs(300);
 
 // ============================================================================
 // Input/Output types
@@ -56,268 +43,31 @@ pub struct PopupOutput {
 
 /// Popup service for showing interactive forms and wizards.
 pub struct PopupService {
-    /// Zellij session name (optional).
-    zellij_session: Option<String>,
+    ipc: ZellijIpc,
+    plugin_path: String,
 }
 
 impl PopupService {
-    /// Create a new popup service with the specified Zellij session.
-    pub fn new(zellij_session: Option<String>) -> Self {
-        Self { zellij_session }
+    /// Create a new popup service with the specified Zellij IPC and plugin path.
+    pub fn new(ipc: ZellijIpc, plugin_path: String) -> Self {
+        Self { ipc, plugin_path }
     }
 
     /// Show a popup and wait for user response.
     ///
-    /// Requires a Zellij session — uses the CLI pipe mechanism to communicate
-    /// with the pre-loaded exomonad-plugin floating pane.
-    #[tracing::instrument(skip(self))]
-    pub fn show_popup(&self, input: &PopupInput) -> Result<PopupOutput> {
-        tracing::info!(title = %input.title, "Showing popup");
-
-        let zellij_session = self
-            .zellij_session
-            .clone()
-            .or_else(|| std::env::var("ZELLIJ_SESSION_NAME").ok());
-
-        tracing::info!(session = ?zellij_session, configured = ?self.zellij_session, "Popup session resolution");
-
-        let session = zellij_session
-            .context("No Zellij session available — popup requires a Zellij session")?;
-
-        self.show_zellij_popup(&session, input)
-    }
-
-    /// Show popup via Zellij pipe to exomonad-plugin.
-    fn show_zellij_popup(&self, session: &str, input: &PopupInput) -> Result<PopupOutput> {
-        let request_id = uuid::Uuid::new_v4().to_string();
-        tracing::info!(request_id = %request_id, session = %session, "[Popup] Starting zellij popup flow");
-
-        // Determine mode: wizard (object with "panes") or form (array of components)
-        let payload = if input.raw_json.get("panes").is_some() {
-            // Wizard mode: wrap in WizardRequest envelope
-            tracing::info!(request_id = %request_id, "[Popup] Wizard mode detected");
-            let wizard_def: crate::ui_protocol::WizardDefinition =
-                serde_json::from_value(input.raw_json.clone())
-                    .context("Failed to parse wizard definition")?;
-            let request = crate::ui_protocol::WizardRequest {
-                request_id: request_id.clone(),
-                wizard: wizard_def,
-            };
-            serde_json::to_string(&request).context("Failed to serialize WizardRequest")?
-        } else if let Some(components_array) = input.raw_json.as_array() {
-            // Form mode: try typed component parsing
-            let components_res: Result<Vec<crate::ui_protocol::Component>, _> =
-                serde_json::from_value(serde_json::Value::Array(components_array.clone()));
-
-            if let Ok(components) = components_res {
-                tracing::info!(request_id = %request_id, count = components.len(), "[Popup] Using JSON payload path");
-                let request = crate::ui_protocol::PopupRequest {
-                    request_id: request_id.clone(),
-                    definition: crate::ui_protocol::PopupDefinition {
-                        title: input.title.clone(),
-                        components,
-                    },
-                };
-                serde_json::to_string(&request).context("Failed to serialize PopupRequest")?
-            } else {
-                tracing::info!(request_id = %request_id, "[Popup] JSON parse failed, using legacy payload path");
-                let items = extract_choice_items(components_array);
-                if items.is_empty() {
-                    anyhow::bail!("Popup must have at least one choice item for Zellij display");
-                }
-
-                let safe_title = sanitize_payload_field(&input.title);
-                let safe_items: Vec<String> =
-                    items.iter().map(|s| sanitize_payload_field(s)).collect();
-                format!("{}|{}|{}", request_id, safe_title, safe_items.join(","))
-            }
-        } else {
-            anyhow::bail!("Invalid popup input: expected array of components or wizard object");
-        };
-
-        // Inject target_tab routing into JSON payloads so only the correct plugin instance renders.
-        let payload = if let Some(target_tab) = &input.target_tab {
-            if payload.starts_with('{') {
-                let mut json: serde_json::Value = serde_json::from_str(&payload)
-                    .context("Failed to re-parse payload for target_tab injection")?;
-                json["target_tab"] = serde_json::Value::String(target_tab.clone());
-                serde_json::to_string(&json).context("Failed to re-serialize payload")?
-            } else {
-                payload
-            }
-        } else {
-            payload
-        };
-
-        tracing::info!(request_id = %request_id, payload_len = payload.len(), "[Popup] Payload built: {}", &payload[..payload.len().min(200)]);
-
-        let plugin_path = match resolve_plugin_path() {
-            Some(p) => {
-                tracing::info!(request_id = %request_id, path = %p, "[Popup] Plugin path resolved");
-                p
-            }
-            None => {
-                tracing::error!(request_id = %request_id, "[Popup] Plugin WASM not found!");
-                anyhow::bail!("Zellij plugin not found. Run 'just install-all' to install it.");
-            }
-        };
-
-        let cmd_args = vec![
-            "--session".to_string(),
-            session.to_string(),
-            "pipe".to_string(),
-            "--plugin".to_string(),
-            plugin_path.clone(),
-            "--name".to_string(),
-            transport::POPUP_PIPE.to_string(),
-            "--".to_string(),
-            payload.clone(),
-        ];
-        tracing::info!(request_id = %request_id, "[Popup] Spawning: zellij {}", cmd_args.join(" "));
-
-        let mut child = Command::new("zellij")
-            .arg("--session")
-            .arg(session)
-            .arg("pipe")
-            .arg("--plugin")
-            .arg(&plugin_path)
-            .arg("--name")
-            .arg(transport::POPUP_PIPE)
-            .arg("--")
-            .arg(&payload)
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .context("Failed to spawn zellij pipe command")?;
-
-        let child_id = child.id();
-        tracing::info!(request_id = %request_id, pid = child_id, "[Popup] zellij pipe spawned successfully");
-
-        let stdout = child.stdout.take().context("stdout was not piped")?;
-        let mut stderr = child.stderr.take().context("stderr was not piped")?;
-
-        // Read stderr in background (diagnostic only)
-        let req_id_stderr = request_id.clone();
-        let stderr_handle = std::thread::spawn(move || {
-            let mut buffer = Vec::new();
-            let _ = stderr.read_to_end(&mut buffer);
-            if !buffer.is_empty() {
-                tracing::info!(request_id = %req_id_stderr, stderr = %String::from_utf8_lossy(&buffer), "[Popup] zellij pipe stderr");
-            }
-        });
-
-        // Read exactly one line from stdout. The plugin sends a single response
-        // line via cli_pipe_output, so we don't need to wait for process exit.
-        let (tx, rx) = mpsc::channel();
-        let req_id_stdout = request_id.clone();
-        std::thread::spawn(move || {
-            use std::io::BufRead;
-            let mut reader = std::io::BufReader::new(stdout);
-            let mut line = String::new();
-            let result = reader.read_line(&mut line);
-            tracing::info!(request_id = %req_id_stdout, bytes = line.len(), ok = result.is_ok(), "[Popup] stdout line read complete");
-            let _ = tx.send(result.map(|_| line));
-        });
-
-        tracing::info!(request_id = %request_id, timeout_secs = POPUP_TIMEOUT.as_secs(), "[Popup] Waiting for response...");
-
-        // Wait for the single response line with timeout
-        let response_str = match rx.recv_timeout(POPUP_TIMEOUT) {
-            Ok(Ok(line)) => {
-                tracing::info!(request_id = %request_id, bytes = line.len(), "[Popup] Got response");
-                // Kill the pipe process — we have what we need
-                let _ = child.kill();
-                let _ = child.wait();
-                let _ = stderr_handle.join();
-                line
-            }
-            Ok(Err(e)) => {
-                tracing::error!(request_id = %request_id, err = %e, "[Popup] stdout read failed");
-                let _ = child.kill();
-                let _ = child.wait();
-                return Err(anyhow::Error::from(e).context("Failed to read popup response"));
-            }
-            Err(mpsc::RecvTimeoutError::Timeout) => {
-                tracing::error!(request_id = %request_id, timeout_secs = POPUP_TIMEOUT.as_secs(), pid = child_id, "[Popup] TIMED OUT — killing zellij pipe process");
-                let _ = child.kill();
-                let _ = child.wait();
-                anyhow::bail!("Popup timed out after {} seconds", POPUP_TIMEOUT.as_secs());
-            }
-            Err(mpsc::RecvTimeoutError::Disconnected) => {
-                tracing::error!(request_id = %request_id, "[Popup] Channel disconnected — stdout thread died");
-                let _ = child.kill();
-                let _ = child.wait();
-                anyhow::bail!("Popup response channel disconnected unexpectedly");
-            }
-        };
-
-        let response_str = response_str.trim();
-
-        if response_str.is_empty() {
-            anyhow::bail!(
-                "Empty response from zellij pipe - plugin may have failed to load or respond"
-            );
-        }
-
-        // Parse response: try JSON first (new format), then legacy "request_id:selection"
-        if response_str.starts_with('{') {
-            let json: serde_json::Value = serde_json::from_str(response_str)
-                .context("Failed to parse JSON popup response")?;
-
-            let resp_request_id = json["request_id"].as_str().unwrap_or("");
-            if resp_request_id != request_id {
-                tracing::warn!(expected = %request_id, received = %resp_request_id, "Request ID mismatch");
-            }
-
-            let result = &json["result"];
-            let button = result["button"].as_str().unwrap_or("submit").to_string();
-            let values = result["values"].clone();
-
-            // For wizard results, include panes_visited in the values
-            if let Some(panes_visited) = result.get("panes_visited") {
-                let mut combined = serde_json::Map::new();
-                combined.insert("values".to_string(), values);
-                combined.insert("panes_visited".to_string(), panes_visited.clone());
-                return Ok(PopupOutput {
-                    button,
-                    values: serde_json::Value::Object(combined),
-                });
-            }
-
-            return Ok(PopupOutput { button, values });
-        }
-
-        // Legacy format: "request_id:selection" or "request_id:CANCELLED"
-        let (resp_request_id, selection) = response_str.split_once(':').context(format!(
-            "Invalid popup response format: expected 'request_id:selection', got: {:?}",
-            response_str
-        ))?;
-
-        if resp_request_id != request_id {
-            tracing::warn!(expected = %request_id, received = %resp_request_id, "Request ID mismatch");
-        }
-
-        let (button, values) = if selection == "CANCELLED" {
-            ("cancelled".to_string(), serde_json::json!({}))
-        } else {
-            (
-                "submit".to_string(),
-                serde_json::json!({"selected": selection}),
-            )
-        };
-
-        Ok(PopupOutput { button, values })
+    /// Synchronous, blocks until the popup plugin sends a response via the pipe.
+    pub fn show_popup(&self, payload: &str) -> Result<String> {
+        self.ipc.popup_pipe(&self.plugin_path, "exomonad-popup", payload)
     }
 }
 
 /// Sanitize a string for use in the legacy payload protocol.
-fn sanitize_payload_field(s: &str) -> String {
+pub fn sanitize_payload_field(s: &str) -> String {
     s.replace('|', "-").replace(',', ";")
 }
 
 /// Extract choice items from popup components (legacy fallback).
-fn extract_choice_items(components: &[serde_json::Value]) -> Vec<String> {
+pub fn extract_choice_items(components: &[serde_json::Value]) -> Vec<String> {
     for component in components {
         if component.get("type").and_then(|t| t.as_str()) == Some("choice") {
             if let Some(options) = component.get("options").and_then(|o| o.as_array()) {


### PR DESCRIPTION
This PR replaces the subprocess-based popup implementation with pure ZellijIpc pipe communication.

Changes:
- Updated `ZellijIpc::send_action_with_response` to break on `UnblockCliPipeInput`.
- Added `ZellijIpc::popup_pipe` for synchronous popup communication.
- Refactored `PopupService` to use `ZellijIpc` and removed all subprocess code (`Command`, `std::thread`, `mpsc`).
- Moved payload building and response parsing logic from `PopupService` to `PopupHandler` to keep the service thin and transport-focused.
- Updated `PopupHandler` to use `tokio::task::spawn_blocking` for the synchronous IPC call.
- Verified with unit tests in `exomonad-core`.