### PR TITLE
refactor: use direct Zellij IPC for tiled popups

### DIFF
--- a/rust/exomonad-core/src/services/zellij_ipc.rs
+++ b/rust/exomonad-core/src/services/zellij_ipc.rs
@@ -197,8 +197,9 @@ impl ZellijIpc {
                     }
                 }
                 Some((ServerToClientMsg::UnblockInputThread, _ctx)) => {
-                    warn!("[ZellijIpc] Received UnblockInputThread before CliPipeOutput");
-                    break;
+                    // UnblockInputThread means Zellij queued the action, NOT that
+                    // the plugin is done. Continue reading until CliPipeOutput.
+                    debug!("[ZellijIpc] Received UnblockInputThread, continuing to wait for CliPipeOutput");
                 }
                 Some((ServerToClientMsg::Exit(_), _ctx)) => break,
                 Some((_, _ctx)) => {


### PR DESCRIPTION
Refactor `PopupService` to use direct `ZellijIpc` for showing popups.
This allows popups to be rendered as tiled panes by setting `floating: false` in `Action::CliPipe`.
It also removes the overhead of spawning a `zellij` subprocess for every popup.

Key changes:
- Added `pipe_to_plugin_blocking` to `ZellijIpc` in `zellij_ipc.rs`.
- Refactored `PopupService::show_zellij_popup` in `popup.rs` to use the new method.
- Passed `floating: false` to ensure popups are tiled.
- Maintained a commented-out version of the old subprocess approach as a fallback/reference.
- Removed unused imports and constants in `popup.rs`.

Verified with `cargo check --workspace` and `cargo test --workspace --lib`.