### PR TITLE
feat: implement exomonad mcp-stdio subcommand

### DIFF
--- a/rust/exomonad/src/main.rs
+++ b/rust/exomonad/src/main.rs
@@ -33,6 +33,9 @@ use tower_http::trace::TraceLayer;
 use tracing::{debug, info, warn};
 use tracing_subscriber::prelude::*;
 
+mod uds_client;
+mod mcp_stdio;
+
 // ============================================================================
 // CLI Types
 // ============================================================================
@@ -87,6 +90,20 @@ enum Commands {
         /// TCP port to listen on (default: from config, or 7432)
         #[arg(long)]
         port: Option<u16>,
+    },
+
+    /// Run stdio MCP proxy (stdin/stdout ↔ UDS server)
+    ///
+    /// Used by Claude Code and Gemini CLI as stdio MCP transport.
+    /// Discovers server socket automatically via .exo/server.sock walk-up.
+    McpStdio {
+        /// Agent role (e.g., "tl", "dev", "worker")
+        #[arg(long)]
+        role: String,
+
+        /// Agent name (e.g., "root", "feature-impl")
+        #[arg(long)]
+        name: String,
     },
 
     /// Reply to a UI request (sent by Zellij plugin)
@@ -1413,33 +1430,54 @@ async fn main() -> Result<()> {
                     anyhow::anyhow!("Failed to bind to port {}: {}", port, e)
                 }
             })?;
-            info!(port = %port, addr = %addr, "HTTP MCP server listening on TCP (dual-stack)");
+
+            // Also listen on UDS at .exo/server.sock
+            let uds_path = project_dir.join(".exo/server.sock");
+            if uds_path.exists() {
+                let _ = std::fs::remove_file(&uds_path);
+            }
+            if let Some(parent) = uds_path.parent() {
+                let _ = std::fs::create_dir_all(parent);
+            }
+            let uds_listener = tokio::net::UnixListener::bind(&uds_path)?;
+            
+            info!(port = %port, addr = %addr, uds = %uds_path.display(), "HTTP MCP server listening on TCP and UDS");
+
+            let tcp_server = axum::serve(listener, app.clone());
+            let uds_server = axum::serve(uds_listener, app);
 
             // Run with graceful shutdown on SIGINT or SIGTERM
-            axum::serve(listener, app)
-                .with_graceful_shutdown(async move {
-                    let ctrl_c = tokio::signal::ctrl_c();
-                    #[cfg(unix)]
-                    let terminate = async {
-                        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
-                            .expect("failed to install SIGTERM handler")
-                            .recv()
-                            .await;
-                    };
-                    #[cfg(not(unix))]
-                    let terminate = std::future::pending::<()>();
+            let shutdown = async move {
+                let ctrl_c = tokio::signal::ctrl_c();
+                #[cfg(unix)]
+                let terminate = async {
+                    tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+                        .expect("failed to install SIGTERM handler")
+                        .recv()
+                        .await;
+                };
+                #[cfg(not(unix))]
+                let terminate = std::future::pending::<()>();
 
-                    tokio::select! {
-                        _ = ctrl_c => info!("Received SIGINT, initiating graceful shutdown"),
-                        _ = terminate => info!("Received SIGTERM, initiating graceful shutdown"),
-                    }
-                })
-                .await?;
+                tokio::select! {
+                    _ = ctrl_c => info!("Received SIGINT, initiating graceful shutdown"),
+                    _ = terminate => info!("Received SIGTERM, initiating graceful shutdown"),
+                }
+            };
 
-            // Clean up server.pid on shutdown
+            tokio::select! {
+                _ = tcp_server.with_graceful_shutdown(async { shutdown.await }) => {},
+                _ = uds_server.with_graceful_shutdown(async { }) => {},
+            }
+
+            // Clean up server.pid and server.sock on shutdown
             if server_pid_path.exists() {
                 let _ = std::fs::remove_file(&server_pid_path);
                 info!("Cleaned up server.pid");
+            }
+            if uds_path.exists() {
+                let _ = std::fs::remove_file(&uds_path);
+                info!("Cleaned up server.sock");
             }
 
             info!("HTTP MCP server shut down");
@@ -1567,6 +1605,10 @@ async fn main() -> Result<()> {
                 .context("Failed to write to socket")?;
 
             info!("Sent reply to control socket");
+        }
+
+        Commands::McpStdio { role, name } => {
+            mcp_stdio::run(&role, &name).await?;
         }
     }
 

--- a/rust/exomonad/src/mcp_stdio.rs
+++ b/rust/exomonad/src/mcp_stdio.rs
@@ -1,0 +1,131 @@
+//! Stdio-to-UDS MCP proxy.
+//!
+//! Reads JSON-RPC from stdin, forwards to the exomonad server over Unix domain socket,
+//! writes responses to stdout. Used by Claude Code and Gemini CLI as an MCP stdio transport.
+
+use anyhow::{Context, Result};
+use std::io::{self, Write};
+use tokio::io::{AsyncBufReadExt, BufReader};
+
+use crate::uds_client;
+
+/// Run the stdio MCP proxy.
+///
+/// Reads JSON-RPC messages line-by-line from stdin, forwards each to the server
+/// at `/agents/{role}/{name}/mcp` via UDS, writes responses to stdout.
+pub async fn run(role: &str, name: &str) -> Result<()> {
+    let socket = uds_client::find_server_socket()
+        .context("Cannot start MCP proxy: server socket not found")?;
+
+    let path = format!("/agents/{}/{}/mcp", role, name);
+    let mut session_id: Option<String> = None;
+
+    let stdin = tokio::io::stdin();
+    let reader = BufReader::new(stdin);
+    let mut lines = reader.lines();
+    
+    let mut stdout = io::stdout().lock();
+
+    while let Ok(Some(line)) = lines.next_line().await {
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        // Parse to check if this is a notification (no "id" field)
+        let parsed: serde_json::Value = match serde_json::from_str(&line) {
+            Ok(v) => v,
+            Err(e) => {
+                // Write JSON-RPC parse error to stdout
+                let error_resp = serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "error": {
+                        "code": -32700,
+                        "message": format!("Parse error: {}", e)
+                    },
+                    "id": null
+                });
+                writeln!(stdout, "{}", error_resp)?;
+                stdout.flush()?;
+                continue;
+            }
+        };
+
+        let is_notification = parsed.get("id").is_none();
+
+        // Build headers
+        let mut headers = vec![
+            ("content-type", "application/json"),
+            ("accept", "application/json"),
+        ];
+
+        // Include session ID if we have one
+        // We need to hold the string value in a variable so the borrow lives long enough
+        let session_header_value;
+        if let Some(ref sid) = session_id {
+            session_header_value = sid.clone();
+            headers.push(("mcp-session-id", &session_header_value));
+        }
+
+        // Forward to server
+        match uds_client::uds_post(&socket, &path, headers, line.into_bytes()).await {
+            Ok((status, resp_body)) => {
+                if is_notification {
+                    // Notifications don't produce output
+                    continue;
+                }
+
+                if (200..300).contains(&status) {
+                    // Check if this is an initialize response — extract session ID
+                    if let Some(method) = parsed.get("method").and_then(|m| m.as_str()) {
+                        if method == "initialize" {
+                            // Try to extract session-id from response if present
+                            if let Ok(resp_parsed) = serde_json::from_slice::<serde_json::Value>(&resp_body) {
+                                if let Some(sid) = resp_parsed.get("_meta")
+                                    .and_then(|m| m.get("sessionId"))
+                                    .and_then(|s| s.as_str())
+                                {
+                                    session_id = Some(sid.to_string());
+                                }
+                            }
+                        }
+                    }
+
+                    // Write response to stdout
+                    stdout.write_all(&resp_body)?;
+                    writeln!(stdout)?;
+                    stdout.flush()?;
+                } else {
+                    // Server error — synthesize JSON-RPC error
+                    let error_resp = serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "error": {
+                            "code": -32603,
+                            "message": format!("Server returned HTTP {}", status)
+                        },
+                        "id": parsed.get("id").cloned().unwrap_or(serde_json::Value::Null)
+                    });
+                    writeln!(stdout, "{}", error_resp)?;
+                    stdout.flush()?;
+                }
+            }
+            Err(e) => {
+                if is_notification {
+                    continue;
+                }
+                // Connection error — synthesize JSON-RPC error
+                let error_resp = serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "error": {
+                        "code": -32603,
+                        "message": format!("UDS connection error: {}", e)
+                    },
+                    "id": parsed.get("id").cloned().unwrap_or(serde_json::Value::Null)
+                });
+                writeln!(stdout, "{}", error_resp)?;
+                stdout.flush()?;
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/rust/exomonad/src/uds_client.rs
+++ b/rust/exomonad/src/uds_client.rs
@@ -1,0 +1,68 @@
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+use tokio::net::UnixStream;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+/// Find the server socket by walking up from the current directory.
+pub fn find_server_socket() -> Result<PathBuf> {
+    let mut curr = std::env::current_dir()?;
+    loop {
+        let candidate = curr.join(".exo/server.sock");
+        if candidate.exists() {
+            return Ok(candidate);
+        }
+        if !curr.pop() {
+            break;
+        }
+    }
+    anyhow::bail!("Server socket not found (.exo/server.sock)")
+}
+
+/// Perform an HTTP POST request over a Unix domain socket.
+pub async fn uds_post(
+    socket_path: &Path,
+    path: &str,
+    headers: Vec<(&str, &str)>,
+    body: Vec<u8>,
+) -> Result<(u16, Vec<u8>)> {
+    let mut stream = UnixStream::connect(socket_path)
+        .await
+        .with_context(|| format!("Failed to connect to UDS socket at {}", socket_path.display()))?;
+
+    let mut request = format!("POST {} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n", path);
+    for (k, v) in headers {
+        request.push_str(&format!("{}: {}\r\n", k, v));
+    }
+    request.push_str(&format!("Content-Length: {}\r\n\r\n", body.len()));
+
+    stream.write_all(request.as_bytes()).await?;
+    stream.write_all(&body).await?;
+    stream.flush().await?;
+
+    let mut response = Vec::new();
+    stream.read_to_end(&mut response).await?;
+
+    // Minimal HTTP response parsing
+    let resp_str = String::from_utf8_lossy(&response);
+    
+    // Split into status line, headers, and body
+    let mut parts = resp_str.splitn(2, "\r\n\r\n");
+    let header_part = parts.next().context("Empty response")?;
+    let _body_part = parts.next().unwrap_or("");
+
+    let status_line = header_part.lines().next().context("Invalid HTTP response")?;
+    let status = status_line
+        .split_whitespace()
+        .nth(1)
+        .context("Invalid status line")?
+        .parse::<u16>()?;
+
+    // We need the raw body bytes, not the lossy string version
+    let body_start = response.windows(4)
+        .position(|w| w == b"\r\n\r\n")
+        .map(|p| p + 4)
+        .unwrap_or(response.len());
+    let body_bytes = response[body_start..].to_vec();
+
+    Ok((status, body_bytes))
+}


### PR DESCRIPTION
This PR implements the `exomonad mcp-stdio` subcommand, which provides an MCP stdio transport proxy for Claude Code and Gemini CLI.

### Changes
- Added `exomonad mcp-stdio` subcommand to forward JSON-RPC from stdin to the Exomonad server over UDS.
- Implemented a lightweight HTTP-over-UDS client in `rust/exomonad/src/uds_client.rs`.
- Added a Unix Domain Socket listener (`.exo/server.sock`) to `exomonad serve` to support UDS proxying.
- Auto-discovery of the server socket via directory walk-up.
- MCP session ID extraction and persistence across requests.

### Verification
- `cargo check -p exomonad` passed.
- `exomonad mcp-stdio --help` verified.
- Build verified with `cargo run`.