### PR TITLE
feat: implement mcp-stdio proxy subcommand

### DIFF
--- a/rust/exomonad/src/main.rs
+++ b/rust/exomonad/src/main.rs
@@ -7,6 +7,7 @@
 //! WASM plugins are loaded from file (server-side only).
 
 mod uds_client;
+mod mcp_stdio;
 
 use exomonad::config;
 use urlencoding::encode;
@@ -85,6 +86,16 @@ enum Commands {
     ///
     /// Loads WASM from file path (not embedded) with hot reload on change.
     Serve,
+
+    /// Run stdio MCP proxy (stdin/stdout ↔ UDS server)
+    McpStdio {
+        /// Agent role (e.g., "tl", "dev", "worker")
+        #[arg(long)]
+        role: String,
+        /// Agent name (e.g., "root", "feature-impl")
+        #[arg(long)]
+        name: String,
+    },
 
     /// Reply to a UI request (sent by Zellij plugin)
     Reply {
@@ -1045,6 +1056,10 @@ async fn main() -> Result<()> {
     });
 
     match cli.command {
+        Commands::McpStdio { ref role, ref name } => {
+            return mcp_stdio::run(role, name).await;
+        }
+
         Commands::Recompile { ref role } => {
             let default_role = config.role.to_string();
             let role_str = role.as_deref().unwrap_or(&default_role);

--- a/rust/exomonad/src/mcp_stdio.rs
+++ b/rust/exomonad/src/mcp_stdio.rs
@@ -1,0 +1,60 @@
+use crate::uds_client;
+use anyhow::{Context, Result};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+/// Run the stdio-to-UDS MCP proxy.
+///
+/// Reads JSON-RPC messages from stdin line-by-line, forwards them to the UDS server,
+/// and writes responses back to stdout.
+pub async fn run(role: &str, name: &str) -> Result<()> {
+    let socket = uds_client::find_server_socket().context("Failed to find server socket")?;
+    let path = format!("/agents/{}/{}/mcp", role, name);
+
+    let stdin = tokio::io::stdin();
+    let mut reader = BufReader::new(stdin).lines();
+    let mut stdout = tokio::io::stdout();
+
+    while let Some(line) = reader.next_line().await? {
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        // Parse to check if it's a request (has "id") or notification (no "id")
+        let msg: serde_json::Value = match serde_json::from_str(&line) {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!("Failed to parse JSON-RPC message from stdin: {}", e);
+                continue;
+            }
+        };
+
+        let is_request = msg.get("id").is_some();
+
+        match uds_client::uds_post(
+            &socket,
+            &path,
+            vec![("content-type", "application/json")],
+            line.into_bytes(),
+        )
+        .await
+        {
+            Ok((status, resp_body)) => {
+                if is_request {
+                    if (200..300).contains(&status) {
+                        stdout.write_all(&resp_body).await?;
+                        stdout.write_all(b"
+").await?;
+                        stdout.flush().await?;
+                    } else {
+                        tracing::warn!("Server returned status {} for MCP request", status);
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::error!("Failed to forward MCP message to server: {}", e);
+            }
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
This PR implements the `exomonad mcp-stdio` subcommand, which acts as a proxy between stdio (used by LLMs like Claude or Gemini) and the exomonad server running over a Unix domain socket.

### Changes:
- Added `rust/exomonad/src/mcp_stdio.rs` which implements the proxy logic:
    - Reads JSON-RPC messages from stdin line-by-line.
    - Forwards requests and notifications to the UDS server via HTTP POST to `/agents/{role}/{name}/mcp`.
    - Writes response bodies for requests back to stdout followed by a newline and flushes.
    - Exits cleanly on EOF.
- Updated `rust/exomonad/src/main.rs`:
    - Registered the new `mcp_stdio` module.
    - Added `McpStdio` variant to the `Commands` enum with `--role` and `--name` arguments.
    - Added a match arm to dispatch the `mcp-stdio` command.

### Verification:
- `cargo build -p exomonad` succeeds.
- `exomonad mcp-stdio --help` shows the new subcommand.
- Tested with a sample JSON-RPC message: it correctly attempts to find the server socket and fails gracefully if not found.
- Existing tests pass.
