### PR TITLE
feat: add event handler infrastructure to WASM guest

### DIFF
--- a/.exo/roles/devswarm/AllRoles.hs
+++ b/.exo/roles/devswarm/AllRoles.hs
@@ -17,6 +17,7 @@ module AllRoles
     roleListTools,
     roleHooks,
     roleToolsMCP,
+    roleEventHandlers,
   )
 where
 
@@ -28,7 +29,7 @@ import Data.Text (Text)
 import ExoMonad.Guest.Tool.Class (MCPCallOutput, ToolDefinition, WasmResult, toMCPFormat)
 import ExoMonad.Guest.Tool.Mode (AsHandler)
 import ExoMonad.Guest.Tool.Record (DispatchRecord (..), ReifyRecord (..))
-import ExoMonad.Types (HookConfig (..), RoleConfig (..))
+import ExoMonad.Types (EventHandlerConfig, HookConfig (..), RoleConfig (..))
 
 -- Import all role configs under unique module names.
 import qualified DevRole
@@ -42,7 +43,9 @@ data RoleCapabilities = RoleCapabilities
     -- | List all tool definitions for this role (raw).
     rcListTools :: [ToolDefinition],
     -- | Get hook config for this role.
-    rcHooks :: HookConfig
+    rcHooks :: HookConfig,
+    -- | Get event handler config for this role.
+    rcEventHandlers :: EventHandlerConfig
   }
 
 -- | Existential wrapper for role configs with heterogeneous tool types.
@@ -59,7 +62,8 @@ mkSomeRoleConfig cfg =
     RoleCapabilities
       { rcDispatch = dispatchRecord (tools cfg),
         rcListTools = reifyToolDefs (Proxy @tools),
-        rcHooks = hooks cfg
+        rcHooks = hooks cfg,
+        rcEventHandlers = eventHandlers cfg
       }
 
 -- | Dispatch a tool call for this role.
@@ -77,6 +81,10 @@ roleToolsMCP = map toMCPFormat . roleListTools
 -- | Get hook config for this role.
 roleHooks :: SomeRoleConfig -> HookConfig
 roleHooks (SomeRoleConfig caps) = rcHooks caps
+
+-- | Get event handler config for this role.
+roleEventHandlers :: SomeRoleConfig -> EventHandlerConfig
+roleEventHandlers (SomeRoleConfig caps) = rcEventHandlers caps
 
 -- | All role configs indexed by role name.
 allConfigs :: Map Text SomeRoleConfig

--- a/.exo/roles/devswarm/DevRole.hs
+++ b/.exo/roles/devswarm/DevRole.hs
@@ -26,5 +26,6 @@ config =
             notifyParent = mkHandler @NotifyParent,
             sendMessage = mkHandler @SendMessage
           },
-      hooks = httpDevHooks
+      hooks = httpDevHooks,
+      eventHandlers = defaultEventHandlers
     }

--- a/.exo/roles/devswarm/Main.hs
+++ b/.exo/roles/devswarm/Main.hs
@@ -12,7 +12,8 @@
 -- parse of the input bytes.
 module Main where
 
-import AllRoles (lookupRole, roleDispatch, roleHooks, roleToolsMCP)
+import AllRoles (lookupRole, roleDispatch, roleEventHandlers, roleHooks, roleToolsMCP)
+import ExoMonad.Guest.Events (EventInput, dispatchEvent)
 import Data.Aeson (Value, (.:), (.:?))
 import Data.Aeson qualified as Aeson
 import Data.ByteString (ByteString)
@@ -32,6 +33,7 @@ import Control.Monad.Freer.Coroutine (runC)
 foreign export ccall handle_mcp_call :: IO CInt
 foreign export ccall handle_list_tools :: IO CInt
 foreign export ccall handle_pre_tool_use :: IO CInt
+foreign export ccall handle_event :: IO CInt
 foreign export ccall resume :: IO CInt
 
 -- | Input for role-aware MCP calls: { "role": "dev", "toolName": "...", "toolArgs": {...} }
@@ -70,6 +72,17 @@ instance Aeson.FromJSON RoleAwareHookInput where
     role <- v .: "role"
     pure $ RoleAwareHookInput role val) val
 
+-- | Input for role-aware event calls: { "role": "dev", "event_type": "pr_review", "payload": {...} }
+data RoleAwareEventInput = RoleAwareEventInput
+  { raeRole :: Text,
+    raeRawValue :: Value
+  }
+
+instance Aeson.FromJSON RoleAwareEventInput where
+  parseJSON val = Aeson.withObject "RoleAwareEventInput" (\v -> do
+    role <- v .: "role"
+    pure $ RoleAwareEventInput role val) val
+
 -- | Dispatch an MCP tool call to the correct role's handler.
 handle_mcp_call :: IO CInt
 handle_mcp_call = wrapHandler $ do
@@ -88,6 +101,30 @@ handle_mcp_call = wrapHandler $ do
         resp <- roleDispatch roleCfg name args
         output (BSL.toStrict $ Aeson.encode resp)
         pure 0
+
+-- | Handle an event call (PRReview, CIStatus, Timeout) for a given role.
+handle_event :: IO CInt
+handle_event = wrapHandler $ do
+  inp <- input @ByteString
+  case Aeson.eitherDecodeStrict inp of
+    Left err -> do
+      outputError $ "Event parse error: " <> T.pack err
+      pure 1
+    Right raei -> case lookupRole (raeRole raei) of
+      Nothing -> do
+        outputError $ "Unknown role: " <> raeRole raei
+        pure 1
+      Just roleCfg ->
+        case Aeson.fromJSON (raeRawValue raei) of
+          Aeson.Error err -> do
+            outputError $ "Event input parse error: " <> T.pack err
+            pure 1
+          Aeson.Success eventInput -> do
+            let handlers = roleEventHandlers roleCfg
+            status <- runM $ runC (dispatchEvent handlers eventInput)
+            result <- statusToWasmResult status
+            output (BSL.toStrict $ Aeson.encode result)
+            pure 0
 
 -- | List tools for a given role. Reads role from input JSON.
 -- Returns WasmResult (Done envelope) for consistency with all other exports.

--- a/.exo/roles/devswarm/TLRole.hs
+++ b/.exo/roles/devswarm/TLRole.hs
@@ -42,5 +42,6 @@ config =
             onStop = \_ -> runStopHookChecks,
             onSubagentStop = \_ -> runStopHookChecks,
             onSessionStart = defaultSessionStartHook
-          }
+          },
+      eventHandlers = defaultEventHandlers
     }

--- a/.exo/roles/devswarm/WorkerRole.hs
+++ b/.exo/roles/devswarm/WorkerRole.hs
@@ -32,5 +32,6 @@ config =
             onStop = \_ -> pure allowStopResponse,
             onSubagentStop = \_ -> pure allowStopResponse,
             onSessionStart = defaultSessionStartHook
-          }
+          },
+      eventHandlers = defaultEventHandlers
     }

--- a/.exo/roles/devswarm/devswarm.cabal
+++ b/.exo/roles/devswarm/devswarm.cabal
@@ -48,7 +48,7 @@ executable wasm-guest-devswarm
         DevRole
         WorkerRole
         HttpDevHooks
-    ghc-options: -no-hs-main -optl-mexec-model=reactor -optl-Wl,--export=hs_init -optl-Wl,--export=handle_mcp_call -optl-Wl,--export=handle_pre_tool_use -optl-Wl,--export=handle_list_tools -optl-Wl,--export=resume -optl-Wl,--allow-undefined
+    ghc-options: -no-hs-main -optl-mexec-model=reactor -optl-Wl,--export=hs_init -optl-Wl,--export=handle_mcp_call -optl-Wl,--export=handle_pre_tool_use -optl-Wl,--export=handle_list_tools -optl-Wl,--export=handle_event -optl-Wl,--export=resume -optl-Wl,--allow-undefined
     build-depends:
         base,
         wasm-guest:wasm-guest-internal,

--- a/haskell/wasm-guest/src/ExoMonad/Guest/Events.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Guest/Events.hs
@@ -1,0 +1,138 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module ExoMonad.Guest.Events
+  ( EventHandlerConfig (..),
+    EventAction (..),
+    PRReviewEvent (..),
+    CIStatusEvent (..),
+    TimeoutEvent (..),
+    EventInput (..),
+    defaultEventHandlers,
+    dispatchEvent,
+  )
+where
+
+import Control.Monad.Freer (Eff)
+import Data.Aeson (FromJSON, ToJSON, Value, object, withObject, (.:), (.=))
+import Data.Aeson qualified as Aeson
+import Data.Text (Text)
+import GHC.Generics (Generic)
+import ExoMonad.Guest.Types (HookEffects)
+
+-- | PR review event types
+data PRReviewEvent
+  = ReviewReceived
+      { prNumber :: Int,
+        comments :: Text
+      }
+  | ReviewApproved
+      { prNumber :: Int
+      }
+  | ReviewTimeout
+      { prNumber :: Int,
+        minutesElapsed :: Int
+      }
+  deriving (Show, Generic)
+
+instance FromJSON PRReviewEvent where
+  parseJSON = withObject "PRReviewEvent" $ \v -> do
+    kind <- v .: "kind"
+    case kind of
+      "review_received" -> ReviewReceived <$> v .: "pr_number" <*> v .: "comments"
+      "approved" -> ReviewApproved <$> v .: "pr_number"
+      "timeout" -> ReviewTimeout <$> v .: "pr_number" <*> v .: "minutes_elapsed"
+      other -> fail $ "Unknown PRReviewEvent kind: " <> show other
+
+instance ToJSON PRReviewEvent where
+  toJSON (ReviewReceived n c) = object ["kind" .= ("review_received" :: Text), "pr_number" .= n, "comments" .= c]
+  toJSON (ReviewApproved n) = object ["kind" .= ("approved" :: Text), "pr_number" .= n]
+  toJSON (ReviewTimeout n m) = object ["kind" .= ("timeout" :: Text), "pr_number" .= n, "minutes_elapsed" .= m]
+
+-- | CI status event
+data CIStatusEvent = CIStatusEvent
+  { ciPrNumber :: Int,
+    ciStatus :: Text,
+    ciBranch :: Text
+  }
+  deriving (Show, Generic)
+
+instance FromJSON CIStatusEvent where
+  parseJSON = withObject "CIStatusEvent" $ \v ->
+    CIStatusEvent <$> v .: "pr_number" <*> v .: "status" <*> v .: "branch"
+
+instance ToJSON CIStatusEvent where
+  toJSON (CIStatusEvent n s b) = object ["pr_number" .= n, "status" .= s, "branch" .= b]
+
+-- | Timeout event
+data TimeoutEvent = TimeoutEvent
+  { tePrNumber :: Int,
+    teMinutesElapsed :: Int
+  }
+  deriving (Show, Generic)
+
+instance FromJSON TimeoutEvent where
+  parseJSON = withObject "TimeoutEvent" $ \v ->
+    TimeoutEvent <$> v .: "pr_number" <*> v .: "minutes_elapsed"
+
+instance ToJSON TimeoutEvent where
+  toJSON (TimeoutEvent n m) = object ["pr_number" .= n, "minutes_elapsed" .= m]
+
+-- | Event handler return type
+data EventAction
+  = InjectMessage Text
+  | NotifyParentAction Text Int  -- message, pr_number
+  | NoAction
+  deriving (Show, Generic)
+
+instance ToJSON EventAction where
+  toJSON (InjectMessage msg) = object ["action" .= ("inject_message" :: Text), "message" .= msg]
+  toJSON (NotifyParentAction msg pr) = object ["action" .= ("notify_parent" :: Text), "message" .= msg, "pr_number" .= pr]
+  toJSON NoAction = object ["action" .= ("no_action" :: Text)]
+
+instance FromJSON EventAction where
+  parseJSON = withObject "EventAction" $ \v -> do
+    action <- v .: "action"
+    case action of
+      "inject_message" -> InjectMessage <$> v .: "message"
+      "notify_parent" -> NotifyParentAction <$> v .: "message" <*> v .: "pr_number"
+      "no_action" -> pure NoAction
+      other -> fail $ "Unknown EventAction: " <> show other
+
+-- | Configuration for event handlers per role.
+data EventHandlerConfig = EventHandlerConfig
+  { onPRReview :: PRReviewEvent -> Eff HookEffects EventAction,
+    onCIStatus :: CIStatusEvent -> Eff HookEffects EventAction,
+    onTimeout :: TimeoutEvent -> Eff HookEffects EventAction
+  }
+
+-- | Default event handlers (all NoAction).
+defaultEventHandlers :: EventHandlerConfig
+defaultEventHandlers =
+  EventHandlerConfig
+    { onPRReview = \_ -> pure NoAction,
+      onCIStatus = \_ -> pure NoAction,
+      onTimeout = \_ -> pure NoAction
+    }
+
+-- | Top-level event type wrapper for dispatching.
+data EventInput
+  = PRReviewInput PRReviewEvent
+  | CIStatusInput CIStatusEvent
+  | TimeoutInput TimeoutEvent
+  deriving (Show, Generic)
+
+instance FromJSON EventInput where
+  parseJSON = withObject "EventInput" $ \v -> do
+    eventType <- v .: "event_type"
+    payload <- v .: "payload"
+    case eventType of
+      "pr_review" -> PRReviewInput <$> Aeson.parseJSON payload
+      "ci_status" -> CIStatusInput <$> Aeson.parseJSON payload
+      "timeout" -> TimeoutInput <$> Aeson.parseJSON payload
+      other -> fail $ "Unknown event_type: " <> show other
+
+-- | Dispatch an event to the appropriate handler.
+dispatchEvent :: EventHandlerConfig -> EventInput -> Eff HookEffects EventAction
+dispatchEvent cfg (PRReviewInput ev) = onPRReview cfg ev
+dispatchEvent cfg (CIStatusInput ev) = onCIStatus cfg ev
+dispatchEvent cfg (TimeoutInput ev) = onTimeout cfg ev

--- a/haskell/wasm-guest/src/ExoMonad/Guest/Types.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Guest/Types.hs
@@ -1,3 +1,8 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeOperators #-}
+
 -- | Shared types for MCP and hook handling.
 module ExoMonad.Guest.Types
   ( -- * MCP Call types
@@ -11,6 +16,7 @@ module ExoMonad.Guest.Types
     StopHookOutput (..),
     StopDecision (..),
     Runtime (..),
+    HookEffects,
     allowResponse,
     denyResponse,
     postToolUseResponse,
@@ -24,6 +30,13 @@ import Data.Aeson qualified as Aeson
 import Data.Text (Text)
 import Data.Text qualified as T
 import GHC.Generics (Generic)
+import Control.Monad.Freer (Eff)
+import ExoMonad.Guest.Tool.Suspend.Types (SuspendYield)
+
+-- | Effects available to hooks.
+-- Currently allows arbitrary IO via IO (required for Host Calls).
+-- Future versions may restrict this to specific effects (Git, GitHub, Log).
+type HookEffects = '[SuspendYield, IO]
 
 -- ============================================================================
 -- MCP Call Types

--- a/haskell/wasm-guest/src/ExoMonad/Types.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Types.hs
@@ -7,6 +7,8 @@ module ExoMonad.Types
   ( RoleConfig (..),
     HookConfig (..),
     HookEffects,
+    EventHandlerConfig,
+    defaultEventHandlers,
     defaultHooks,
     defaultSessionStartHook,
     teamRegistrationPostToolUse,
@@ -24,22 +26,18 @@ import Data.Text.Lazy qualified as TL
 import ExoMonad.Effects.Log (LogError, LogInfo)
 import ExoMonad.Effects.Log qualified as Log
 import ExoMonad.Effects.Session qualified as Session
-import ExoMonad.Guest.Tool.Suspend.Types (SuspendYield)
 import ExoMonad.Guest.Tool.SuspendEffect (suspendEffect, suspendEffect_)
-import ExoMonad.Guest.Types (HookInput (..), HookOutput (..), HookSpecificOutput (..), StopHookOutput, allowResponse, allowStopResponse, postToolUseResponse)
+import ExoMonad.Guest.Events (EventHandlerConfig, defaultEventHandlers)
+import ExoMonad.Guest.Types (HookInput (..), HookOutput (..), HookSpecificOutput (..), StopHookOutput, HookEffects, allowResponse, allowStopResponse, postToolUseResponse)
 import GHC.Generics (Generic)
-
--- | Effects available to hooks.
--- Currently allows arbitrary IO via IO (required for Host Calls).
--- Future versions may restrict this to specific effects (Git, GitHub, Log).
-type HookEffects = '[SuspendYield, IO]
 
 -- | Role configuration.
 -- Defines the role name, available tools, and lifecycle hooks.
 data RoleConfig tools = RoleConfig
   { roleName :: Text,
     tools :: tools,
-    hooks :: HookConfig
+    hooks :: HookConfig,
+    eventHandlers :: EventHandlerConfig
   }
   deriving (Generic)
 

--- a/haskell/wasm-guest/wasm-guest.cabal
+++ b/haskell/wasm-guest/wasm-guest.cabal
@@ -69,6 +69,7 @@ library wasm-guest-internal
         ExoMonad.Guest.Tools.Spawn
         ExoMonad.Guest.Tools.Events
         ExoMonad.Guest.Prompt
+        ExoMonad.Guest.Events
         ExoMonad.Guest.Events.Templates
         -- SpawnSpec compiler
         ExoMonad.Guest.SpawnSpec.Types


### PR DESCRIPTION
This PR adds the event handler infrastructure to the ExoMonad WASM guest and the `devswarm` role.

Key changes:
- Created new module `ExoMonad.Guest.Events` with PR review, CI status, and timeout event types.
- Added `eventHandlers` field to `RoleConfig` in `ExoMonad.Types`.
- Resolved a circular dependency between `ExoMonad.Types` and `ExoMonad.Guest.Events` by moving `HookEffects` to `ExoMonad.Guest.Types`.
- Added `roleEventHandlers` accessor to `AllRoles.hs`.
- Added `handle_event` FFI export to `Main.hs` for role-aware event dispatching.
- Updated `DevRole.hs`, `TLRole.hs`, and `WorkerRole.hs` to include default event handlers.
- Registered the new `ExoMonad.Guest.Events` module in `wasm-guest.cabal`.
- Verified that the WASM guest and roles build successfully.

Build command: `nix develop .#wasm -c wasm32-wasi-cabal build --project-file=cabal.project.wasm all`