### PR TITLE
feat: unify notify-parent delivery codepath

### DIFF
--- a/rust/exomonad-core/src/handlers/events.rs
+++ b/rust/exomonad-core/src/handlers/events.rs
@@ -194,68 +194,22 @@ impl EventEffects for EventHandler {
             "notify_parent: routing completion to parent"
         );
 
-        if let Some(ref log) = self.event_log {
-            let _ = log.append(
-                "agent.notify_parent",
-                &agent_id_str,
-                &serde_json::json!({
-                    "parent": &parent_session_id,
-                    "status": &req.status,
-                    "message": &req.message,
-                }),
-            );
-        }
-
-        let event = Event {
-            event_id: 0, // Assigned by EventQueue
-            event_type: Some(event::EventType::WorkerComplete(WorkerComplete {
-                worker_id: agent_id_str.clone(),
-                status: req.status.clone(),
-                message: req.message.clone(),
-                changes: Vec::new(),
-            })),
-        };
-
-        self.queue.notify_event(&parent_session_id, event).await;
-
-        // Deliver notification to parent: prefer Teams inbox, fall back to Zellij injection.
-        let notification = format_parent_notification(&agent_id_str, &req.status, &req.message);
-        let parent_key = if parent_session_id == "root" {
-            "root".to_string()
-        } else {
-            parent_session_id.clone()
-        };
         let tab_name = crate::services::agent_control::resolve_parent_tab_name(ctx);
 
-        let delivery_result = crate::services::delivery::deliver_to_agent(
+        crate::services::delivery::notify_parent_delivery(
             self.team_registry.as_deref(),
             self.acp_registry.as_deref(),
+            self.event_log.as_deref(),
+            &self.queue,
             &self.project_dir,
-            &parent_key,
-            &tab_name,
             &agent_id_str,
-            &notification,
-            &format!("Agent completion: {}", agent_id_str),
+            &parent_session_id,
+            &tab_name,
+            &req.status,
+            &req.message,
+            None,
         )
         .await;
-
-        if let Some(ref log) = self.event_log {
-            let delivery_method = match delivery_result {
-                DeliveryResult::Teams => "teams_inbox",
-                DeliveryResult::Acp => "acp",
-                DeliveryResult::Uds => "unix_socket",
-                DeliveryResult::Zellij => "zellij_stdin",
-                DeliveryResult::Failed => "failed",
-            };
-            let _ = log.append(
-                "agent.message_delivered",
-                &agent_id_str,
-                &serde_json::json!({
-                    "parent": &parent_session_id,
-                    "method": delivery_method,
-                }),
-            );
-        }
 
         Ok(NotifyParentResponse { ack: true })
     }
@@ -311,30 +265,6 @@ impl EventEffects for EventHandler {
     }
 }
 
-fn format_parent_notification(agent_id: &str, status: &str, message: &str) -> String {
-    match status {
-        "success" => format!(
-            "[CHILD COMPLETE: {}] {}",
-            agent_id,
-            if message.is_empty() {
-                "Task completed successfully."
-            } else {
-                message
-            }
-        ),
-        "failure" => format!(
-            "[CHILD FAILED: {}] {}",
-            agent_id,
-            if message.is_empty() {
-                "Task failed."
-            } else {
-                message
-            }
-        ),
-        _ => format!("[CHILD STATUS: {} - {}] {}", agent_id, status, message),
-    }
-}
-
 fn resolve_recipient_tab_name(recipient: &str) -> String {
     if recipient == "root" {
         "TL".to_string()
@@ -347,39 +277,6 @@ fn resolve_recipient_tab_name(recipient: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_format_parent_notification_success() {
-        let msg = format_parent_notification("agent-1", "success", "All done");
-        assert_eq!(msg, "[CHILD COMPLETE: agent-1] All done");
-    }
-
-    #[test]
-    fn test_format_parent_notification_success_empty() {
-        let msg = format_parent_notification("agent-1", "success", "");
-        assert_eq!(
-            msg,
-            "[CHILD COMPLETE: agent-1] Task completed successfully."
-        );
-    }
-
-    #[test]
-    fn test_format_parent_notification_failure() {
-        let msg = format_parent_notification("agent-2", "failure", "Something went wrong");
-        assert_eq!(msg, "[CHILD FAILED: agent-2] Something went wrong");
-    }
-
-    #[test]
-    fn test_format_parent_notification_failure_empty() {
-        let msg = format_parent_notification("agent-2", "failure", "");
-        assert_eq!(msg, "[CHILD FAILED: agent-2] Task failed.");
-    }
-
-    #[test]
-    fn test_format_parent_notification_unknown() {
-        let msg = format_parent_notification("agent-3", "running", "Working...");
-        assert_eq!(msg, "[CHILD STATUS: agent-3 - running] Working...");
-    }
 
     #[test]
     fn test_event_handler_namespace() {

--- a/rust/exomonad-core/src/services/delivery.rs
+++ b/rust/exomonad-core/src/services/delivery.rs
@@ -1,7 +1,11 @@
+use crate::services::acp_registry::AcpRegistry;
+use crate::services::event_log::EventLog;
+use crate::services::event_queue::EventQueue;
 use crate::services::team_registry::TeamRegistry;
 use crate::services::teams_mailbox;
 use crate::services::zellij_events;
 use agent_client_protocol::{Agent, PromptRequest};
+use exomonad_proto::effects::events::{event, Event, WorkerComplete};
 use tracing::{debug, info, warn};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -11,6 +15,107 @@ pub enum DeliveryResult {
     Uds,
     Zellij,
     Failed,
+}
+
+pub fn format_parent_notification(agent_id: &str, status: &str, message: &str) -> String {
+    match status {
+        "success" => format!(
+            "[CHILD COMPLETE: {}] {}",
+            agent_id,
+            if message.is_empty() {
+                "Task completed successfully."
+            } else {
+                message
+            }
+        ),
+        "failure" => format!(
+            "[CHILD FAILED: {}] {}",
+            agent_id,
+            if message.is_empty() {
+                "Task failed."
+            } else {
+                message
+            }
+        ),
+        _ => format!("[CHILD STATUS: {} - {}] {}", agent_id, status, message),
+    }
+}
+
+pub async fn notify_parent_delivery(
+    team_registry: Option<&TeamRegistry>,
+    acp_registry: Option<&AcpRegistry>,
+    event_log: Option<&EventLog>,
+    event_queue: &EventQueue,
+    project_dir: &std::path::Path,
+    agent_id: &str,
+    parent_session_id: &str,
+    parent_tab_name: &str,
+    status: &str,
+    message: &str,
+    summary: Option<&str>,
+) -> DeliveryResult {
+    // 1. Log to event log
+    if let Some(log) = event_log {
+        let _ = log.append(
+            "agent.notify_parent",
+            agent_id,
+            &serde_json::json!({
+                "parent": parent_session_id,
+                "status": status,
+                "message": message,
+            }),
+        );
+    }
+
+    // 2. Publish to event queue
+    let event = Event {
+        event_id: 0,
+        event_type: Some(event::EventType::WorkerComplete(WorkerComplete {
+            worker_id: agent_id.to_string(),
+            status: status.to_string(),
+            message: message.to_string(),
+            changes: Vec::new(),
+        })),
+    };
+    event_queue.notify_event(parent_session_id, event).await;
+
+    // 3. Format and deliver
+    let notification = format_parent_notification(agent_id, status, message);
+    let default_summary = format!("Agent completion: {}", agent_id);
+    let summary = summary.unwrap_or(&default_summary);
+
+    let delivery_result = deliver_to_agent(
+        team_registry,
+        acp_registry,
+        project_dir,
+        parent_session_id,
+        parent_tab_name,
+        agent_id,
+        &notification,
+        summary,
+    )
+    .await;
+
+    // 4. Log delivery result
+    if let Some(log) = event_log {
+        let delivery_method = match delivery_result {
+            DeliveryResult::Teams => "teams_inbox",
+            DeliveryResult::Acp => "acp",
+            DeliveryResult::Uds => "unix_socket",
+            DeliveryResult::Zellij => "zellij_stdin",
+            DeliveryResult::Failed => "failed",
+        };
+        let _ = log.append(
+            "agent.message_delivered",
+            agent_id,
+            &serde_json::json!({
+                "parent": parent_session_id,
+                "method": delivery_method,
+            }),
+        );
+    }
+
+    delivery_result
 }
 
 /// Deliver a notification via HTTP POST over a Unix domain socket.
@@ -167,6 +272,39 @@ pub async fn deliver_to_agent(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_format_parent_notification_success() {
+        let msg = format_parent_notification("agent-1", "success", "All done");
+        assert_eq!(msg, "[CHILD COMPLETE: agent-1] All done");
+    }
+
+    #[test]
+    fn test_format_parent_notification_success_empty() {
+        let msg = format_parent_notification("agent-1", "success", "");
+        assert_eq!(
+            msg,
+            "[CHILD COMPLETE: agent-1] Task completed successfully."
+        );
+    }
+
+    #[test]
+    fn test_format_parent_notification_failure() {
+        let msg = format_parent_notification("agent-2", "failure", "Something went wrong");
+        assert_eq!(msg, "[CHILD FAILED: agent-2] Something went wrong");
+    }
+
+    #[test]
+    fn test_format_parent_notification_failure_empty() {
+        let msg = format_parent_notification("agent-2", "failure", "");
+        assert_eq!(msg, "[CHILD FAILED: agent-2] Task failed.");
+    }
+
+    #[test]
+    fn test_format_parent_notification_unknown() {
+        let msg = format_parent_notification("agent-3", "running", "Working...");
+        assert_eq!(msg, "[CHILD STATUS: agent-3 - running] Working...");
+    }
 
     #[test]
     fn test_delivery_result_variants_distinct() {

--- a/rust/exomonad-core/src/services/github_poller.rs
+++ b/rust/exomonad-core/src/services/github_poller.rs
@@ -217,25 +217,34 @@ impl GitHubPoller {
                 message,
                 pr_number: pr_num,
             } => {
-                // Use delivery to send to parent (branch without last segment)
-                let parent_branch = branch
+                let agent_slug = branch.rsplit_once('.').map(|(_, s)| s).unwrap_or(branch);
+                let parent_session_id = branch
                     .rsplit_once('.')
-                    .map(|(parent, _)| parent)
-                    .unwrap_or("main");
-                let parent_slug = parent_branch
-                    .rsplit_once('.')
-                    .map(|(_, s)| s)
-                    .unwrap_or(parent_branch);
-                let notify_msg = format!("[Event Handler] {}", message);
-                crate::services::delivery::deliver_to_agent(
+                    .map(|(parent, _)| parent.to_string())
+                    .unwrap_or_else(|| "root".to_string());
+                let parent_tab = if parent_session_id == "root" || !parent_session_id.contains('.') {
+                    "TL".to_string()
+                } else {
+                    let parent_slug = parent_session_id
+                        .rsplit_once('.')
+                        .map(|(_, s)| s)
+                        .unwrap_or(&parent_session_id);
+                    AgentType::Claude.tab_display_name(parent_slug)
+                };
+
+                let summary = format!("Auto-notify: PR #{}", pr_num);
+                crate::services::delivery::notify_parent_delivery(
                     self.team_registry.as_deref(),
                     self.acp_registry.as_deref(),
+                    self.event_log.as_deref(),
+                    &self.event_queue,
                     &self.project_dir,
-                    parent_branch,
-                    parent_slug,
-                    branch,
-                    &notify_msg,
-                    &format!("Auto-notify: PR #{}", pr_num),
+                    agent_slug,
+                    &parent_session_id,
+                    &parent_tab,
+                    "success",
+                    &message,
+                    Some(&summary),
                 )
                 .await;
             }


### PR DESCRIPTION
Refactored `NotifyParent` logic into a shared `notify_parent_delivery` function in `services/delivery.rs`.
Both `EventHandler::notify_parent` and `GitHubPoller::handle_event_action` now use this shared pipeline, ensuring consistent notification delivery (logging, event queue, and agent delivery).

Summary of changes:
- Created `notify_parent_delivery` in `delivery.rs` as the source of truth for parent notification.
- Moved `format_parent_notification` to `delivery.rs`.
- Refactored `handlers/events.rs` and `services/github_poller.rs` to use the shared function.
- Verified with unit tests in `exomonad-core`.