### PR TITLE
feat: add SiblingMergedEvent type and wire into event handlers

### DIFF
--- a/.exo/lib/PRReviewHandler.hs
+++ b/.exo/lib/PRReviewHandler.hs
@@ -2,6 +2,7 @@
 
 module PRReviewHandler
   ( prReviewEventHandlers,
+    siblingMergedHandler,
   )
 where
 
@@ -11,7 +12,7 @@ import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.Lazy qualified as TL
 import ExoMonad.Effects.Log qualified as Log
-import ExoMonad.Guest.Events (EventAction (..), EventHandlerConfig (..), PRReviewEvent (..), defaultEventHandlers)
+import ExoMonad.Guest.Events (EventAction (..), EventHandlerConfig (..), PRReviewEvent (..), SiblingMergedEvent (..), defaultEventHandlers)
 import ExoMonad.Guest.Tool.SuspendEffect (suspendEffect_)
 import ExoMonad.Guest.Types (HookEffects)
 
@@ -20,7 +21,8 @@ import ExoMonad.Guest.Types (HookEffects)
 prReviewEventHandlers :: EventHandlerConfig
 prReviewEventHandlers =
   defaultEventHandlers
-    { onPRReview = prReviewHandler
+    { onPRReview = prReviewHandler,
+      onSiblingMerged = siblingMergedHandler
     }
 
 -- | Handle PR review events for dev/tl roles.
@@ -56,3 +58,16 @@ prReviewHandler (ReviewTimeout n mins) = do
          <> " — no Copilot review after " <> T.pack (show mins)
          <> " minutes, proceeding with success"
   pure (NotifyParentAction msg n)
+
+-- | Handle sibling merged events.
+siblingMergedHandler :: SiblingMergedEvent -> Eff HookEffects EventAction
+siblingMergedHandler (SiblingMergedEvent merged parent _prNum) = do
+  void $ suspendEffect_ @Log.LogInfo $ Log.InfoRequest
+    { Log.infoRequestMessage = TL.fromStrict $
+        "[PRReviewHandler] Sibling branch merged: " <> merged
+    , Log.infoRequestFields = ""
+    }
+  let msg = "[Sibling Merged] PR on branch " <> merged
+         <> " was merged into " <> parent
+         <> ". Rebase your branch to pick up the changes: git fetch origin && git rebase origin/" <> parent
+  pure (InjectMessage msg)

--- a/haskell/wasm-guest/CLAUDE.md
+++ b/haskell/wasm-guest/CLAUDE.md
@@ -118,9 +118,10 @@ GitHub poller (Rust, 60s interval)
 
 | Type | Purpose |
 |------|---------|
-| `EventHandlerConfig` | Per-role handler config: `onPRReview`, `onCIStatus`, `onTimeout` |
+| `EventHandlerConfig` | Per-role handler config: `onPRReview`, `onCIStatus`, `onTimeout`, `onSiblingMerged` |
 | `EventAction` | Handler return: `InjectMessage Text`, `NotifyParentAction Text Int`, `NoAction` |
 | `PRReviewEvent` | `ReviewReceived` (comments), `ReviewApproved`, `ReviewTimeout` |
+| `SiblingMergedEvent` | `mergedBranch`, `parentBranch`, `siblingPRNumber` |
 | `EventInput` | Top-level wrapper with `event_type` discriminator for dispatch |
 
 ### PR Review Handler (`.exo/lib/PRReviewHandler.hs`)
@@ -130,6 +131,7 @@ GitHub poller (Rust, 60s interval)
 | `ReviewReceived` | `InjectMessage` | Copilot comments injected into agent pane |
 | `ReviewApproved` | `NotifyParentAction` | Auto-notifies parent via `notify_parent_delivery` |
 | `ReviewTimeout` (15 min) | `NotifyParentAction` | Auto-notifies parent with timeout note |
+| `SiblingMerged` | `InjectMessage` | Injects rebase instructions when a sibling branch is merged |
 
 ### Wiring
 

--- a/haskell/wasm-guest/src/ExoMonad/Guest/Events.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Guest/Events.hs
@@ -6,6 +6,7 @@ module ExoMonad.Guest.Events
     PRReviewEvent (..),
     CIStatusEvent (..),
     TimeoutEvent (..),
+    SiblingMergedEvent (..),
     EventInput (..),
     defaultEventHandlers,
     dispatchEvent,
@@ -77,6 +78,21 @@ instance FromJSON TimeoutEvent where
 instance ToJSON TimeoutEvent where
   toJSON (TimeoutEvent n m) = object ["pr_number" .= n, "minutes_elapsed" .= m]
 
+-- | Sibling merged event
+data SiblingMergedEvent = SiblingMergedEvent
+  { mergedBranch :: Text,
+    parentBranch :: Text,
+    siblingPRNumber :: Int
+  }
+  deriving (Show, Generic)
+
+instance FromJSON SiblingMergedEvent where
+  parseJSON = withObject "SiblingMergedEvent" $ \v ->
+    SiblingMergedEvent <$> v .: "merged_branch" <*> v .: "parent_branch" <*> v .: "sibling_pr_number"
+
+instance ToJSON SiblingMergedEvent where
+  toJSON (SiblingMergedEvent mb pb n) = object ["merged_branch" .= mb, "parent_branch" .= pb, "sibling_pr_number" .= n]
+
 -- | Event handler return type
 data EventAction
   = InjectMessage Text
@@ -102,7 +118,8 @@ instance FromJSON EventAction where
 data EventHandlerConfig = EventHandlerConfig
   { onPRReview :: PRReviewEvent -> Eff HookEffects EventAction,
     onCIStatus :: CIStatusEvent -> Eff HookEffects EventAction,
-    onTimeout :: TimeoutEvent -> Eff HookEffects EventAction
+    onTimeout :: TimeoutEvent -> Eff HookEffects EventAction,
+    onSiblingMerged :: SiblingMergedEvent -> Eff HookEffects EventAction
   }
 
 -- | Default event handlers (all NoAction).
@@ -111,7 +128,8 @@ defaultEventHandlers =
   EventHandlerConfig
     { onPRReview = \_ -> pure NoAction,
       onCIStatus = \_ -> pure NoAction,
-      onTimeout = \_ -> pure NoAction
+      onTimeout = \_ -> pure NoAction,
+      onSiblingMerged = \_ -> pure NoAction
     }
 
 -- | Top-level event type wrapper for dispatching.
@@ -119,6 +137,7 @@ data EventInput
   = PRReviewInput PRReviewEvent
   | CIStatusInput CIStatusEvent
   | TimeoutInput TimeoutEvent
+  | SiblingMergedInput SiblingMergedEvent
   deriving (Show, Generic)
 
 instance FromJSON EventInput where
@@ -129,6 +148,7 @@ instance FromJSON EventInput where
       "pr_review" -> PRReviewInput <$> Aeson.parseJSON payload
       "ci_status" -> CIStatusInput <$> Aeson.parseJSON payload
       "timeout" -> TimeoutInput <$> Aeson.parseJSON payload
+      "sibling_merged" -> SiblingMergedInput <$> Aeson.parseJSON payload
       other -> fail $ "Unknown event_type: " <> show other
 
 -- | Dispatch an event to the appropriate handler.
@@ -136,3 +156,4 @@ dispatchEvent :: EventHandlerConfig -> EventInput -> Eff HookEffects EventAction
 dispatchEvent cfg (PRReviewInput ev) = onPRReview cfg ev
 dispatchEvent cfg (CIStatusInput ev) = onCIStatus cfg ev
 dispatchEvent cfg (TimeoutInput ev) = onTimeout cfg ev
+dispatchEvent cfg (SiblingMergedInput ev) = onSiblingMerged cfg ev


### PR DESCRIPTION
This PR adds the `SiblingMergedEvent` type to the Haskell WASM guest and wires it into the event handling system.

Key changes:
- Added `SiblingMergedEvent` data type to `ExoMonad.Guest.Events`.
- Updated `EventHandlerConfig` and `EventInput` to handle `sibling_merged` events.
- Implemented `siblingMergedHandler` in `PRReviewHandler.hs` which provides rebase instructions when a sibling branch is merged.
- Documented the new event type in `haskell/wasm-guest/CLAUDE.md`.
- Verified the build with `just wasm-all`.