### PR TITLE
feat: route CI status changes through WASM event handlers

### DIFF
--- a/.exo/lib/PRReviewHandler.hs
+++ b/.exo/lib/PRReviewHandler.hs
@@ -12,16 +12,17 @@ import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.Lazy qualified as TL
 import ExoMonad.Effects.Log qualified as Log
-import ExoMonad.Guest.Events (EventAction (..), EventHandlerConfig (..), PRReviewEvent (..), SiblingMergedEvent (..), defaultEventHandlers)
+import ExoMonad.Guest.Events (CIStatusEvent (..), EventAction (..), EventHandlerConfig (..), PRReviewEvent (..), SiblingMergedEvent (..), defaultEventHandlers)
 import ExoMonad.Guest.Tool.SuspendEffect (suspendEffect_)
 import ExoMonad.Guest.Types (HookEffects)
 
 -- | Event handler config with PR review handling.
--- CI and timeout handlers use defaults (NoAction).
+-- Timeout handlers use defaults (NoAction).
 prReviewEventHandlers :: EventHandlerConfig
 prReviewEventHandlers =
   defaultEventHandlers
     { onPRReview = prReviewHandler,
+      onCIStatus = ciStatusHandler,
       onSiblingMerged = siblingMergedHandler
     }
 
@@ -70,4 +71,21 @@ siblingMergedHandler (SiblingMergedEvent merged parent _prNum) = do
   let msg = "[Sibling Merged] PR on branch " <> merged
          <> " was merged into " <> parent
          <> ". Rebase your branch to pick up the changes: git fetch origin && git rebase origin/" <> parent
+  pure (InjectMessage msg)
+
+-- | Handle CI status events.
+ciStatusHandler :: CIStatusEvent -> Eff HookEffects EventAction
+ciStatusHandler (CIStatusEvent n status_ branch_) = do
+  void $ suspendEffect_ @Log.LogInfo $ Log.InfoRequest
+    { Log.infoRequestMessage = TL.fromStrict $
+        "[PRReviewHandler] CI status changed on PR #" <> T.pack (show n)
+        <> ": " <> status_
+    , Log.infoRequestFields = ""
+    }
+  let msg = "[CI Status] PR #" <> T.pack (show n) <> " on branch " <> branch_
+         <> ": " <> status_
+         <> case status_ of
+              "success" -> "\n\nCI passed."
+              "failure" -> "\n\nCI failed. Check the logs and fix the issue before proceeding."
+              _ -> ""
   pure (InjectMessage msg)

--- a/rust/exomonad-core/src/services/github_poller.rs
+++ b/rust/exomonad-core/src/services/github_poller.rs
@@ -576,11 +576,24 @@ impl GitHubPoller {
 
             // Check CI changes
             if ci_status != old_state.last_ci_status {
-                // Status changed!
-                let message = format!("[CI STATUS: {}] {}", branch, ci_status);
-                // TODO: Route CI status changes through WASM event handlers (onCIStatus)
-                // once CI pipeline is stable. Currently only logs + emits to event queue.
-                self.emit_event(branch, &ci_status, &message, agent_type, Some(pr_number))
+                info!("[Poller] CI status changed for {}: {} -> {}", branch, old_state.last_ci_status, ci_status);
+                if let Ok(Some(action)) = self
+                    .call_handle_event(
+                        branch,
+                        agent_type,
+                        "ci_status",
+                        serde_json::json!({
+                            "pr_number": pr_number.as_u64(),
+                            "status": ci_status,
+                            "branch": branch,
+                        }),
+                    )
+                    .await
+                {
+                    self.handle_event_action(action, branch, agent_type, pr_number)
+                        .await;
+                }
+                self.emit_event(branch, &ci_status, &format!("[CI STATUS: {}] {}", branch, ci_status), agent_type, Some(pr_number))
                     .await;
                 old_state.last_ci_status = ci_status;
             }


### PR DESCRIPTION
This PR implements routing for CI status changes through WASM event handlers.

Changes:
- Added `ciStatusHandler` to `.exo/lib/PRReviewHandler.hs` and wired it into `prReviewEventHandlers`.
- Updated `rust/exomonad-core/src/services/github_poller.rs` to call `call_handle_event` when CI status changes, replacing the previous TODO.
- Verified that `cargo build -p exomonad-core` succeeds and workspace unit tests pass.
- WASM integration tests fail as expected due to missing binaries in this environment.