### PR TITLE
feat: replace silent error swallowing with logged warnings

### DIFF
--- a/rust/exomonad-core/src/handlers/agent.rs
+++ b/rust/exomonad-core/src/handlers/agent.rs
@@ -227,7 +227,7 @@ impl AgentEffects for AgentHandler {
         let agent_info = worker_result_to_proto(&req.name, &result);
 
         if let Some(ref log) = self.event_log {
-            let _ = log.append(
+            if let Err(e) = log.append(
                 "agent.spawned",
                 &ctx.agent_name.to_string(),
                 &serde_json::json!({
@@ -237,7 +237,9 @@ impl AgentEffects for AgentHandler {
                     "worktree": &agent_info.worktree_path,
                     "spawn_type": "worker",
                 }),
-            );
+            ) {
+                warn!(error = %e, "Failed to write agent.spawned event");
+            }
         }
 
         Ok(SpawnWorkerResponse {
@@ -313,7 +315,7 @@ impl AgentEffects for AgentHandler {
         let agent_info = subtree_result_to_proto(&req.branch_name, &result);
 
         if let Some(ref log) = self.event_log {
-            let _ = log.append(
+            if let Err(e) = log.append(
                 "agent.spawned",
                 &ctx.agent_name.to_string(),
                 &serde_json::json!({
@@ -323,7 +325,9 @@ impl AgentEffects for AgentHandler {
                     "worktree": &agent_info.worktree_path,
                     "spawn_type": "subtree",
                 }),
-            );
+            ) {
+                warn!(error = %e, "Failed to write agent.spawned event");
+            }
         }
 
         Ok(SpawnSubtreeResponse {
@@ -359,7 +363,7 @@ impl AgentEffects for AgentHandler {
         let agent_info = leaf_subtree_result_to_proto(&req.branch_name, &result);
 
         if let Some(ref log) = self.event_log {
-            let _ = log.append(
+            if let Err(e) = log.append(
                 "agent.spawned",
                 &ctx.agent_name.to_string(),
                 &serde_json::json!({
@@ -369,7 +373,9 @@ impl AgentEffects for AgentHandler {
                     "worktree": &agent_info.worktree_path,
                     "spawn_type": "leaf_subtree",
                 }),
-            );
+            ) {
+                warn!(error = %e, "Failed to write agent.spawned event");
+            }
         }
 
         Ok(SpawnLeafSubtreeResponse {
@@ -461,7 +467,7 @@ impl AgentEffects for AgentHandler {
         };
 
         if let Some(ref log) = self.event_log {
-            let _ = log.append(
+            if let Err(e) = log.append(
                 "agent.spawned",
                 &ctx.agent_name.to_string(),
                 &serde_json::json!({
@@ -471,7 +477,9 @@ impl AgentEffects for AgentHandler {
                     "worktree": &agent_info.worktree_path,
                     "spawn_type": "acp",
                 }),
-            );
+            ) {
+                warn!(error = %e, "Failed to write agent.spawned event");
+            }
         }
 
         Ok(SpawnAcpResponse {

--- a/rust/exomonad-core/src/handlers/git.rs
+++ b/rust/exomonad-core/src/handlers/git.rs
@@ -119,8 +119,14 @@ impl GitEffects for GitHandler {
                 short_sha: c.hash.chars().take(7).collect(),
                 message: c.message,
                 author: c.author.clone(),
-                author_email: extract_email(&c.author).unwrap_or_default(),
-                timestamp: parse_git_date(&c.date).unwrap_or(0),
+                author_email: extract_email(&c.author).unwrap_or_else(|| {
+                    tracing::debug!(author = %c.author, "Could not extract email from git author");
+                    String::new()
+                }),
+                timestamp: parse_git_date(&c.date).unwrap_or_else(|| {
+                    tracing::debug!(date = %c.date, "Could not parse git date");
+                    0
+                }),
             })
             .collect();
 
@@ -184,8 +190,14 @@ impl GitEffects for GitHandler {
         info!(branch = %info.branch, "[Git] get_repo_info complete");
         Ok(GetRepoInfoResponse {
             branch: info.branch,
-            owner: info.owner.map(Into::into).unwrap_or_default(),
-            name: info.name.map(Into::into).unwrap_or_default(),
+            owner: info.owner.map(Into::into).unwrap_or_else(|| {
+                tracing::debug!("Could not determine repo owner from remote URL");
+                String::new()
+            }),
+            name: info.name.map(Into::into).unwrap_or_else(|| {
+                tracing::debug!("Could not determine repo name from remote URL");
+                String::new()
+            }),
         })
     }
 

--- a/rust/exomonad-core/src/hooks.rs
+++ b/rust/exomonad-core/src/hooks.rs
@@ -275,7 +275,9 @@ impl HookConfig {
 
                         // Write back cleaned settings
                         if let Ok(cleaned) = serde_json::to_string_pretty(&settings) {
-                            fs::write(&self.settings_path, cleaned).ok();
+                            if let Err(e) = fs::write(&self.settings_path, cleaned) {
+                                tracing::warn!(path = %self.settings_path.display(), error = %e, "Failed to write cleaned settings");
+                            }
                         }
                     }
                 }

--- a/rust/exomonad-core/src/services/agent_control.rs
+++ b/rust/exomonad-core/src/services/agent_control.rs
@@ -1965,7 +1965,11 @@ impl AgentControlService {
         // Rename pane via direct IPC
         let ipc = self.ipc()?;
         let pane_name = name.to_string();
-        let _ = tokio::task::spawn_blocking(move || ipc.rename_pane(&pane_name)).await;
+        match tokio::task::spawn_blocking(move || ipc.rename_pane(&pane_name)).await {
+            Ok(Err(e)) => tracing::warn!(error = %e, "Zellij pane rename failed"),
+            Err(e) => tracing::warn!(error = %e, "Zellij pane rename task panicked"),
+            Ok(Ok(())) => {}
+        }
 
         Ok(())
     }
@@ -2062,7 +2066,11 @@ impl AgentControlService {
             debug!(tab = %tn, "Switching to tab before spawning pane");
             let ipc = self.ipc()?;
             let tab = tn.to_string();
-            let _ = tokio::task::spawn_blocking(move || ipc.go_to_tab_name(&tab)).await;
+            match tokio::task::spawn_blocking(move || ipc.go_to_tab_name(&tab)).await {
+                Ok(Err(e)) => tracing::warn!(error = %e, "Zellij go-to-tab failed"),
+                Err(e) => tracing::warn!(error = %e, "Zellij go-to-tab task panicked"),
+                Ok(Ok(())) => {}
+            }
         }
 
         let full_command =
@@ -2083,7 +2091,11 @@ impl AgentControlService {
         // Rename pane via direct IPC
         let ipc = self.ipc()?;
         let rename_target = name.to_string();
-        let _ = tokio::task::spawn_blocking(move || ipc.rename_pane(&rename_target)).await;
+        match tokio::task::spawn_blocking(move || ipc.rename_pane(&rename_target)).await {
+            Ok(Err(e)) => tracing::warn!(error = %e, "Zellij pane rename failed"),
+            Err(e) => tracing::warn!(error = %e, "Zellij pane rename task panicked"),
+            Ok(Ok(())) => {}
+        }
 
         info!(name, "Successfully created Zellij pane");
         Ok(())
@@ -2147,11 +2159,16 @@ impl AgentControlService {
         // untracked file warnings (which force `git worktree remove --force`).
         let gitignore = target_dir.join(".gitignore");
         if !gitignore.exists() {
-            let _ = tokio::fs::write(&gitignore, "# Runtime artifacts\nserver.sock\nserver.pid\n")
-                .await;
+            if let Err(e) = tokio::fs::write(&gitignore, "# Runtime artifacts\nserver.sock\nserver.pid\n")
+                .await
+            {
+                tracing::warn!(path = %gitignore.display(), error = %e, "Failed to write .gitignore");
+            }
         }
 
-        let _ = tokio::fs::remove_file(&target).await;
+        if let Err(e) = tokio::fs::remove_file(&target).await {
+            tracing::debug!(path = %target.display(), error = %e, "Could not remove old socket symlink");
+        }
 
         match tokio::fs::symlink(&source, &target).await {
             Ok(()) => info!(

--- a/rust/exomonad-core/src/services/delivery.rs
+++ b/rust/exomonad-core/src/services/delivery.rs
@@ -68,7 +68,7 @@ pub async fn notify_parent_delivery(
 ) -> DeliveryResult {
     // 1. Log to event log
     if let Some(log) = event_log {
-        let _ = log.append(
+        if let Err(e) = log.append(
             "agent.notify_parent",
             agent_id,
             &serde_json::json!({
@@ -76,7 +76,9 @@ pub async fn notify_parent_delivery(
                 "status": status,
                 "message": message,
             }),
-        );
+        ) {
+            tracing::warn!(error = %e, "Failed to write notify_parent event");
+        }
     }
 
     // 2. Publish to event queue
@@ -117,14 +119,16 @@ pub async fn notify_parent_delivery(
             DeliveryResult::Zellij => "zellij_stdin",
             DeliveryResult::Failed => "failed",
         };
-        let _ = log.append(
+        if let Err(e) = log.append(
             "agent.message_delivered",
             agent_id,
             &serde_json::json!({
                 "parent": parent_session_id,
                 "method": delivery_method,
             }),
-        );
+        ) {
+            tracing::warn!(error = %e, "Failed to write message_delivered event");
+        }
     }
 
     delivery_result


### PR DESCRIPTION
This PR replaces silent error swallowing patterns (`.ok()` and `let _ =`) with appropriate `tracing::warn!` and `tracing::debug!` log entries across the `exomonad-core` crate.

Affected files:
- `rust/exomonad-core/src/hooks.rs`
- `rust/exomonad-core/src/services/delivery.rs`
- `rust/exomonad-core/src/handlers/agent.rs`
- `rust/exomonad-core/src/handlers/git.rs`
- `rust/exomonad-core/src/services/agent_control.rs`

These changes follow the project's logging requirements (as stated in `CLAUDE.md`) while ensuring no changes to function signatures or error propagation strategy for these intentionally non-fatal operations.