### PR TITLE
feat: add event log entries to file_pr and merge_pr handlers

### DIFF
--- a/rust/exomonad-core/src/handlers/file_pr.rs
+++ b/rust/exomonad-core/src/handlers/file_pr.rs
@@ -8,6 +8,7 @@ use crate::effects::{
 };
 use crate::services::file_pr::{self, FilePRInput};
 use crate::services::git_worktree::GitWorktreeService;
+use crate::services::event_log::EventLog;
 use async_trait::async_trait;
 use exomonad_proto::effects::file_pr::*;
 use std::sync::Arc;
@@ -18,11 +19,20 @@ use std::sync::Arc;
 /// the generated `dispatch_file_pr_effect` function.
 pub struct FilePRHandler {
     git_wt: Arc<GitWorktreeService>,
+    event_log: Option<Arc<EventLog>>,
 }
 
 impl FilePRHandler {
     pub fn new(git_wt: Arc<GitWorktreeService>) -> Self {
-        Self { git_wt }
+        Self {
+            git_wt,
+            event_log: None,
+        }
+    }
+
+    pub fn with_event_log(mut self, log: Arc<EventLog>) -> Self {
+        self.event_log = Some(log);
+        self
     }
 }
 
@@ -70,6 +80,29 @@ impl FilePrEffects for FilePRHandler {
             created = output.created,
             "[FilePR] file_pr complete"
         );
+
+        if let Some(ref log) = self.event_log {
+            let event_type = if output.created {
+                "pr.filed"
+            } else {
+                "pr.updated"
+            };
+            if let Err(e) = log.append(
+                event_type,
+                &ctx.agent_name.to_string(),
+                &serde_json::json!({
+                    "pr_number": output.pr_number.as_u64(),
+                    "pr_url": output.pr_url,
+                    "head_branch": output.head_branch,
+                    "base_branch": output.base_branch,
+                    "created": output.created,
+                    "title": input.title,
+                }),
+            ) {
+                tracing::warn!(error = %e, "Failed to write event log");
+            }
+        }
+
         Ok(FilePrResponse {
             pr_url: output.pr_url,
             pr_number: output.pr_number.as_u64() as i64,

--- a/rust/exomonad-core/src/handlers/groups.rs
+++ b/rust/exomonad-core/src/handlers/groups.rs
@@ -46,11 +46,20 @@ pub fn git_handlers(
     git: Arc<GitService>,
     github: Option<GitHubService>,
     git_wt: Arc<GitWorktreeService>,
+    event_log: Option<Arc<EventLog>>,
 ) -> Vec<Box<dyn EffectHandler>> {
+    let mut file_pr_handler = FilePRHandler::new(git_wt.clone());
+    let mut merge_pr_handler = MergePRHandler::new(git_wt);
+
+    if let Some(ref log) = event_log {
+        file_pr_handler = file_pr_handler.with_event_log(log.clone());
+        merge_pr_handler = merge_pr_handler.with_event_log(log.clone());
+    }
+
     let mut handlers: Vec<Box<dyn EffectHandler>> = vec![
         Box::new(GitHandler::new(git)),
-        Box::new(FilePRHandler::new(git_wt.clone())),
-        Box::new(MergePRHandler::new(git_wt)),
+        Box::new(file_pr_handler),
+        Box::new(merge_pr_handler),
         Box::new(CopilotHandler::new()),
     ];
     if let Some(gh) = github {
@@ -138,7 +147,7 @@ mod tests {
         let git = Arc::new(GitService::new(Arc::new(MockExecutor)));
         let git_wt = Arc::new(GitWorktreeService::new(tmp.path().to_path_buf()));
 
-        let handlers = git_handlers(git, None, git_wt);
+        let handlers = git_handlers(git, None, git_wt, None);
         assert_eq!(handlers.len(), 4);
         let namespaces: Vec<_> = handlers.iter().map(|h| h.namespace()).collect();
         assert!(namespaces.contains(&"git"));
@@ -155,7 +164,7 @@ mod tests {
         let git_wt = Arc::new(GitWorktreeService::new(tmp.path().to_path_buf()));
         let github = GitHubService::new("test-token".to_string()).unwrap();
 
-        let handlers = git_handlers(git, Some(github), git_wt);
+        let handlers = git_handlers(git, Some(github), git_wt, None);
         assert_eq!(handlers.len(), 5);
         let namespaces: Vec<_> = handlers.iter().map(|h| h.namespace()).collect();
         assert!(namespaces.contains(&"github"));

--- a/rust/exomonad-core/src/handlers/merge_pr.rs
+++ b/rust/exomonad-core/src/handlers/merge_pr.rs
@@ -1,17 +1,27 @@
 use crate::effects::{dispatch_merge_pr_effect, EffectResult, MergePrEffects, ResultExt};
 use crate::services::git_worktree::GitWorktreeService;
 use crate::services::merge_pr;
+use crate::services::event_log::EventLog;
 use async_trait::async_trait;
 use exomonad_proto::effects::merge_pr::*;
 use std::sync::Arc;
 
 pub struct MergePRHandler {
     git_wt: Arc<GitWorktreeService>,
+    event_log: Option<Arc<EventLog>>,
 }
 
 impl MergePRHandler {
     pub fn new(git_wt: Arc<GitWorktreeService>) -> Self {
-        Self { git_wt }
+        Self {
+            git_wt,
+            event_log: None,
+        }
+    }
+
+    pub fn with_event_log(mut self, log: Arc<EventLog>) -> Self {
+        self.event_log = Some(log);
+        self
     }
 }
 
@@ -22,7 +32,7 @@ impl MergePrEffects for MergePRHandler {
     async fn merge_pr(
         &self,
         req: MergePrRequest,
-        _ctx: &crate::effects::EffectContext,
+        ctx: &crate::effects::EffectContext,
     ) -> EffectResult<MergePrResponse> {
         let pr_number = crate::domain::PRNumber::new(req.pr_number as u64);
         tracing::info!(pr_number = pr_number.as_u64(), strategy = %req.strategy, "[MergePR] merge_pr starting");
@@ -39,6 +49,23 @@ impl MergePrEffects for MergePRHandler {
             git_fetched = result.git_fetched,
             "[MergePR] merge_pr complete"
         );
+
+        if let Some(ref log) = self.event_log {
+            if result.success {
+                if let Err(e) = log.append(
+                    "pr.merged",
+                    &ctx.agent_name.to_string(),
+                    &serde_json::json!({
+                        "pr_number": pr_number.as_u64(),
+                        "strategy": req.strategy,
+                        "git_fetched": result.git_fetched,
+                    }),
+                ) {
+                    tracing::warn!(error = %e, "Failed to write event log");
+                }
+            }
+        }
+
         Ok(MergePrResponse {
             success: result.success,
             message: result.message,

--- a/rust/exomonad-core/src/lib.rs
+++ b/rust/exomonad-core/src/lib.rs
@@ -32,7 +32,7 @@
 //! let mut builder = RuntimeBuilder::new()
 //!     .with_wasm_path(wasm_path)
 //!     .with_handlers(core_handlers(project_dir.clone(), None))
-//!     .with_handlers(git_handlers(git, github, git_wt));
+//!     .with_handlers(git_handlers(git, github, git_wt, None));
 //!
 //! // Add custom domain handlers
 //! builder = builder.with_effect_handler(MyDomainHandler::new());

--- a/rust/exomonad/src/main.rs
+++ b/rust/exomonad/src/main.rs
@@ -1263,7 +1263,12 @@ async fn main() -> Result<()> {
                 project_dir.clone(),
                 event_log.clone(),
             ));
-            builder = builder.with_handlers(exomonad_core::git_handlers(git, github, git_wt));
+            builder = builder.with_handlers(exomonad_core::git_handlers(
+                git,
+                github,
+                git_wt,
+                event_log.clone(),
+            ));
             let orch_handlers = exomonad_core::orchestration_handlers(
                 agent_control.clone(),
                 event_queue.clone(),


### PR DESCRIPTION
This PR adds event log entries to the `file_pr` and `merge_pr` handlers in `exomonad-core`, following the same pattern as `AgentHandler`.

### Changes:
- Added `event_log` field and `with_event_log` builder method to `FilePRHandler` and `MergePRHandler`.
- `FilePRHandler` now logs `pr.filed` or `pr.updated` events on success.
- `MergePRHandler` now logs `pr.merged` events on success.
- Updated `git_handlers` in `groups.rs` to accept an optional `EventLog` and inject it into the handlers.
- Wired up the `EventLog` injection in `exomonad/src/main.rs`.
- Updated documentation and tests to reflect the new `git_handlers` signature.

Verified with `cargo check --workspace` and unit tests in `exomonad-core`.