### PR TITLE
feat: add DuckDB to nix dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -66,7 +66,7 @@
               ++ haskellPkgs "ghc912"
               ++ rustPkgs
               ++ orchestrationPkgs
-              ++ [ pkgs.sqlite ]
+              ++ [ pkgs.sqlite pkgs.duckdb ]
               ++ [ proto3SuitePkg ];  # For compile-proto-file (Haskell proto codegen)
 
             shellHook = ''


### PR DESCRIPTION
Adds `duckdb` to the Nix development shell's `packages` list, immediately following `sqlite`.

Verified with `nix develop --command duckdb --version` which returns `v1.4.1`.