### PR TITLE
feat: create claude-teams-bridge crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,6 +880,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
+name = "claude-teams-bridge"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "dirs 6.0.0",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "clipboard-win"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1318,7 +1331,7 @@ version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.4.1",
 ]
 
 [[package]]
@@ -1337,7 +1350,16 @@ version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys 0.5.0",
 ]
 
 [[package]]
@@ -1348,8 +1370,20 @@ checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.4.6",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.5.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1359,7 +1393,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
- "redox_users",
+ "redox_users 0.4.6",
  "winapi",
 ]
 
@@ -1551,7 +1585,7 @@ dependencies = [
  "axum",
  "chrono",
  "clap 4.5.57",
- "dirs",
+ "dirs 5.0.1",
  "duct",
  "exomonad-proto",
  "extism",
@@ -4186,6 +4220,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "ref-cast"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4803,7 +4848,7 @@ version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
- "dirs",
+ "dirs 5.0.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "rust/exomonad-proto",
+    "rust/claude-teams-bridge",
     "rust/exomonad-core",
     "rust/exomonad",
 ]

--- a/rust/claude-teams-bridge/Cargo.toml
+++ b/rust/claude-teams-bridge/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "claude-teams-bridge"
+version = "0.1.0"
+edition = "2021"
+description = "Read/write messages through Claude Code's Teams filesystem"
+license = "BSD-3-Clause"
+repository = "https://github.com/tidepool-heavy-industries/claude-teams-bridge"
+keywords = ["claude", "teams", "mcp", "agent"]
+categories = ["development-tools"]
+
+[dependencies]
+chrono = { version = "0.4", features = ["serde"] }
+dirs = "6"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["time", "sync", "fs"] }
+tracing = "0.1"
+
+[dev-dependencies]
+tempfile = "3"
+tokio = { version = "1", features = ["full", "test-util"] }

--- a/rust/claude-teams-bridge/src/config.rs
+++ b/rust/claude-teams-bridge/src/config.rs
@@ -1,0 +1,108 @@
+use crate::paths;
+use serde::{Deserialize, Serialize};
+use std::io;
+use std::path::Path;
+use tracing::info;
+
+/// Claude Code team configuration (matches CC's config.json format).
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct TeamConfig {
+    pub name: String,
+    pub description: String,
+    pub created_at: u64,
+    pub lead_agent_id: String,
+    pub lead_session_id: String,
+    pub members: Vec<TeamMember>,
+}
+
+/// A member of a Claude Code team.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct TeamMember {
+    pub agent_id: String,
+    pub name: String,
+    pub agent_type: String,
+    pub model: String,
+    pub joined_at: u64,
+    pub cwd: String,
+}
+
+/// Read team config from `~/.claude/teams/{team}/config.json`.
+pub fn read_team_config(team: &str) -> io::Result<TeamConfig> {
+    let path = paths::config_path(team)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "HOME directory not found"))?;
+    let content = std::fs::read_to_string(&path)?;
+    serde_json::from_str(&content)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))
+}
+
+/// Write team config atomically.
+pub fn write_team_config(team: &str, config: &TeamConfig) -> io::Result<()> {
+    let path = paths::config_path(team)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "HOME directory not found"))?;
+    write_team_config_at(&path, config)
+}
+
+fn write_team_config_at(path: &Path, config: &TeamConfig) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let json = serde_json::to_string_pretty(config)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+    let tmp = path.with_extension("json.tmp");
+    std::fs::write(&tmp, &json)?;
+    std::fs::rename(&tmp, path)?;
+    info!(path = %path.display(), "Wrote team config");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn sample_config() -> TeamConfig {
+        TeamConfig {
+            name: "test-team".into(),
+            description: "A test team".into(),
+            created_at: 1700000000,
+            lead_agent_id: "lead-1".into(),
+            lead_session_id: "session-1".into(),
+            members: vec![TeamMember {
+                agent_id: "agent-1".into(),
+                name: "worker".into(),
+                agent_type: "claude".into(),
+                model: "opus".into(),
+                joined_at: 1700000001,
+                cwd: "/tmp".into(),
+            }],
+        }
+    }
+
+    #[test]
+    fn test_roundtrip() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("config.json");
+        let config = sample_config();
+        write_team_config_at(&path, &config).unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        let loaded: TeamConfig = serde_json::from_str(&content).unwrap();
+        assert_eq!(loaded.name, "test-team");
+        assert_eq!(loaded.members.len(), 1);
+        assert_eq!(loaded.members[0].name, "worker");
+    }
+
+    #[test]
+    fn test_camel_case_serialization() {
+        let config = sample_config();
+        let json = serde_json::to_string(&config).unwrap();
+        assert!(json.contains("createdAt"));
+        assert!(json.contains("leadAgentId"));
+        assert!(json.contains("leadSessionId"));
+        assert!(json.contains("agentType"));
+        assert!(json.contains("joinedAt"));
+        assert!(!json.contains("created_at"));
+    }
+}

--- a/rust/claude-teams-bridge/src/discovery.rs
+++ b/rust/claude-teams-bridge/src/discovery.rs
@@ -1,0 +1,96 @@
+use crate::paths;
+use std::io;
+use std::path::Path;
+
+/// List all team names in `~/.claude/teams/`.
+pub fn list_teams() -> io::Result<Vec<String>> {
+    let base = paths::teams_base_dir()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "HOME directory not found"))?;
+    list_teams_at(&base)
+}
+
+fn list_teams_at(base: &Path) -> io::Result<Vec<String>> {
+    if !base.exists() {
+        return Ok(Vec::new());
+    }
+    let mut teams = Vec::new();
+    for entry in std::fs::read_dir(base)? {
+        let entry = entry?;
+        if entry.file_type()?.is_dir() {
+            if let Some(name) = entry.file_name().to_str() {
+                teams.push(name.to_string());
+            }
+        }
+    }
+    teams.sort();
+    Ok(teams)
+}
+
+/// List all inbox names (recipients) for a team.
+pub fn list_inboxes(team: &str) -> io::Result<Vec<String>> {
+    let dir = paths::inbox_dir(team)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "HOME directory not found"))?;
+    list_inboxes_at(&dir)
+}
+
+fn list_inboxes_at(dir: &Path) -> io::Result<Vec<String>> {
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+    let mut names = Vec::new();
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) == Some("json") {
+            if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+                if !stem.starts_with('.') {
+                    names.push(stem.to_string());
+                }
+            }
+        }
+    }
+    names.sort();
+    Ok(names)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_list_teams_empty() {
+        let tmp = tempdir().unwrap();
+        let result = list_teams_at(tmp.path()).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_list_teams() {
+        let tmp = tempdir().unwrap();
+        std::fs::create_dir(tmp.path().join("alpha")).unwrap();
+        std::fs::create_dir(tmp.path().join("beta")).unwrap();
+        std::fs::write(tmp.path().join("not-a-dir.txt"), "").unwrap();
+
+        let result = list_teams_at(tmp.path()).unwrap();
+        assert_eq!(result, vec!["alpha", "beta"]);
+    }
+
+    #[test]
+    fn test_list_inboxes() {
+        let tmp = tempdir().unwrap();
+        std::fs::write(tmp.path().join("alice.json"), "[]").unwrap();
+        std::fs::write(tmp.path().join("bob.json"), "[]").unwrap();
+        std::fs::write(tmp.path().join(".tmp.json"), "[]").unwrap();
+        std::fs::write(tmp.path().join("readme.txt"), "").unwrap();
+
+        let result = list_inboxes_at(tmp.path()).unwrap();
+        assert_eq!(result, vec!["alice", "bob"]);
+    }
+
+    #[test]
+    fn test_list_nonexistent() {
+        let result = list_teams_at(Path::new("/nonexistent/path")).unwrap();
+        assert!(result.is_empty());
+    }
+}

--- a/rust/claude-teams-bridge/src/inbox.rs
+++ b/rust/claude-teams-bridge/src/inbox.rs
@@ -1,0 +1,190 @@
+use crate::paths;
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use std::io;
+use std::path::Path;
+use tracing::{debug, info};
+
+/// Message in a Claude Code Teams inbox file.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct TeamsMessage {
+    pub from: String,
+    pub text: String,
+    pub summary: String,
+    pub timestamp: String,
+    pub read: bool,
+}
+
+/// Write a message to a Claude Teams inbox file.
+/// Returns the timestamp of the written message for delivery verification.
+pub fn write_to_inbox(
+    team: &str,
+    recipient: &str,
+    from: &str,
+    text: &str,
+    summary: &str,
+) -> io::Result<String> {
+    let home = dirs::home_dir()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "HOME directory not found"))?;
+    write_to_inbox_at_base(&home, team, recipient, from, text, summary)
+}
+
+pub(crate) fn write_to_inbox_at_base(
+    base: &Path,
+    team: &str,
+    recipient: &str,
+    from: &str,
+    text: &str,
+    summary: &str,
+) -> io::Result<String> {
+    let inbox_dir = paths::inbox_dir_at(base, team);
+
+    if !inbox_dir.exists() {
+        std::fs::create_dir_all(&inbox_dir)?;
+        info!(dir = %inbox_dir.display(), "Created Teams inbox directory");
+    }
+
+    let inbox_file = inbox_dir.join(format!("{}.json", recipient));
+
+    let mut messages: Vec<TeamsMessage> = if inbox_file.exists() {
+        let content = std::fs::read_to_string(&inbox_file)?;
+        serde_json::from_str(&content).unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+
+    let timestamp = Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+    messages.push(TeamsMessage {
+        from: from.to_string(),
+        text: text.to_string(),
+        summary: summary.to_string(),
+        timestamp: timestamp.clone(),
+        read: false,
+    });
+
+    info!(
+        team = %team,
+        recipient = %recipient,
+        file = %inbox_file.display(),
+        count = messages.len(),
+        "Writing to Teams inbox"
+    );
+
+    let json = serde_json::to_string_pretty(&messages)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+
+    // Atomic write: temp file + rename
+    let tmp_file = inbox_dir.join(format!(".{}.json.tmp", recipient));
+    std::fs::write(&tmp_file, &json)?;
+    std::fs::rename(&tmp_file, &inbox_file)?;
+
+    debug!(bytes = json.len(), "Teams inbox write complete");
+    Ok(timestamp)
+}
+
+/// Read all messages from an inbox.
+pub fn read_inbox(team: &str, recipient: &str) -> io::Result<Vec<TeamsMessage>> {
+    let path = paths::inbox_path(team, recipient)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "HOME directory not found"))?;
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let content = std::fs::read_to_string(&path)?;
+    serde_json::from_str(&content)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))
+}
+
+/// Check if a specific message (by timestamp) was read by CC.
+pub fn is_message_read(team: &str, recipient: &str, timestamp: &str) -> bool {
+    let Some(path) = paths::inbox_path(team, recipient) else {
+        debug!(team, recipient, "is_message_read: no inbox path");
+        return false;
+    };
+    let Ok(content) = std::fs::read_to_string(&path) else {
+        debug!(team, recipient, path = %path.display(), "is_message_read: cannot read inbox file");
+        return false;
+    };
+    let Ok(messages) = serde_json::from_str::<Vec<TeamsMessage>>(&content) else {
+        debug!(team, recipient, "is_message_read: cannot parse inbox JSON");
+        return false;
+    };
+    match messages.iter().find(|m| m.timestamp == timestamp) {
+        Some(m) => m.read,
+        None => {
+            debug!(team, recipient, timestamp, total_messages = messages.len(), "is_message_read: message not found");
+            false
+        }
+    }
+}
+
+/// Get unread messages from an inbox.
+pub fn unread_messages(team: &str, recipient: &str) -> io::Result<Vec<TeamsMessage>> {
+    read_inbox(team, recipient).map(|msgs| msgs.into_iter().filter(|m| !m.read).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_write_creates_inbox_dir() {
+        let tmp = tempdir().unwrap();
+        let base = tmp.path();
+        let team_dir = base.join(".claude").join("teams").join("test-team");
+        std::fs::create_dir_all(&team_dir).unwrap();
+
+        let result = write_to_inbox_at_base(base, "test-team", "lead", "agent", "msg", "sum");
+        assert!(result.is_ok());
+        assert!(team_dir.join("inboxes").exists());
+        assert!(team_dir.join("inboxes").join("lead.json").exists());
+    }
+
+    #[test]
+    fn test_write_and_read() {
+        let tmp = tempdir().unwrap();
+        let base = tmp.path();
+        let inbox_dir = paths::inbox_dir_at(base, "test-team");
+        std::fs::create_dir_all(&inbox_dir).unwrap();
+
+        write_to_inbox_at_base(base, "test-team", "r", "a1", "Hello", "sum1").unwrap();
+        write_to_inbox_at_base(base, "test-team", "r", "a2", "World", "sum2").unwrap();
+
+        let inbox_file = inbox_dir.join("r.json");
+        let content = std::fs::read_to_string(&inbox_file).unwrap();
+        let messages: Vec<TeamsMessage> = serde_json::from_str(&content).unwrap();
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].from, "a1");
+        assert_eq!(messages[0].text, "Hello");
+        assert!(!messages[0].read);
+        assert_eq!(messages[1].from, "a2");
+        assert_eq!(messages[1].summary, "sum2");
+    }
+
+    #[test]
+    fn test_unread_filters_read_messages() {
+        let tmp = tempdir().unwrap();
+        let base = tmp.path();
+        let inbox_dir = paths::inbox_dir_at(base, "t");
+        std::fs::create_dir_all(&inbox_dir).unwrap();
+
+        // Write two messages, mark one as read manually
+        write_to_inbox_at_base(base, "t", "r", "a", "msg1", "s").unwrap();
+        write_to_inbox_at_base(base, "t", "r", "a", "msg2", "s").unwrap();
+
+        let inbox_file = inbox_dir.join("r.json");
+        let content = std::fs::read_to_string(&inbox_file).unwrap();
+        let mut messages: Vec<TeamsMessage> = serde_json::from_str(&content).unwrap();
+        messages[0].read = true;
+        std::fs::write(&inbox_file, serde_json::to_string(&messages).unwrap()).unwrap();
+
+        // read_inbox and unread_messages need real HOME, so test via file directly
+        let content2 = std::fs::read_to_string(&inbox_file).unwrap();
+        let all: Vec<TeamsMessage> = serde_json::from_str(&content2).unwrap();
+        let unread: Vec<&TeamsMessage> = all.iter().filter(|m| !m.read).collect();
+        assert_eq!(all.len(), 2);
+        assert_eq!(unread.len(), 1);
+        assert_eq!(unread[0].text, "msg2");
+    }
+}

--- a/rust/claude-teams-bridge/src/lib.rs
+++ b/rust/claude-teams-bridge/src/lib.rs
@@ -1,0 +1,18 @@
+//! Read/write messages through Claude Code's Teams filesystem.
+//!
+//! This crate provides typed access to Claude Code's on-disk mailbox format —
+//! the `~/.claude/teams/` directory that Claude Code's InboxPoller watches.
+
+mod config;
+mod discovery;
+mod inbox;
+mod paths;
+mod registry;
+mod verifier;
+
+pub use config::{read_team_config, write_team_config, TeamConfig, TeamMember};
+pub use discovery::{list_inboxes, list_teams};
+pub use inbox::{is_message_read, read_inbox, unread_messages, write_to_inbox, TeamsMessage};
+pub use paths::{config_path, inbox_path, teams_base_dir};
+pub use registry::{TeamInfo, TeamRegistry};
+pub use verifier::wait_for_read;

--- a/rust/claude-teams-bridge/src/paths.rs
+++ b/rust/claude-teams-bridge/src/paths.rs
@@ -1,0 +1,48 @@
+use std::path::{Path, PathBuf};
+
+/// Claude Code Teams base directory (~/.claude/teams/).
+pub fn teams_base_dir() -> Option<PathBuf> {
+    dirs::home_dir().map(|h| h.join(".claude").join("teams"))
+}
+
+/// Team directory path.
+pub fn team_dir(team: &str) -> Option<PathBuf> {
+    teams_base_dir().map(|b| b.join(team))
+}
+
+/// Team config.json path.
+pub fn config_path(team: &str) -> Option<PathBuf> {
+    team_dir(team).map(|d| d.join("config.json"))
+}
+
+/// Inboxes directory for a team.
+pub fn inbox_dir(team: &str) -> Option<PathBuf> {
+    team_dir(team).map(|d| d.join("inboxes"))
+}
+
+/// Inbox file path for a specific recipient.
+pub fn inbox_path(team: &str, recipient: &str) -> Option<PathBuf> {
+    inbox_dir(team).map(|d| d.join(format!("{}.json", recipient)))
+}
+
+// --- Internal helpers for testing with custom base paths ---
+
+#[allow(dead_code)]
+pub(crate) fn inbox_dir_at(base: &Path, team: &str) -> PathBuf {
+    base.join(".claude").join("teams").join(team).join("inboxes")
+}
+
+#[allow(dead_code)]
+pub(crate) fn inbox_path_at(base: &Path, team: &str, recipient: &str) -> PathBuf {
+    inbox_dir_at(base, team).join(format!("{}.json", recipient))
+}
+
+#[allow(dead_code)]
+pub(crate) fn config_path_at(base: &Path, team: &str) -> PathBuf {
+    base.join(".claude").join("teams").join(team).join("config.json")
+}
+
+#[allow(dead_code)]
+pub(crate) fn teams_base_dir_at(base: &Path) -> PathBuf {
+    base.join(".claude").join("teams")
+}

--- a/rust/claude-teams-bridge/src/registry.rs
+++ b/rust/claude-teams-bridge/src/registry.rs
@@ -1,0 +1,93 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use tracing::info;
+
+/// Info about an agent's Claude Teams membership.
+#[derive(Debug, Clone)]
+pub struct TeamInfo {
+    pub team_name: String,
+    pub inbox_name: String,
+}
+
+/// Maps agent identity keys to Claude Teams info.
+pub struct TeamRegistry {
+    inner: Arc<Mutex<HashMap<String, TeamInfo>>>,
+}
+
+impl Default for TeamRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TeamRegistry {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    pub async fn register(&self, key: &str, info: TeamInfo) {
+        info!(
+            key = %key,
+            team_name = %info.team_name,
+            inbox_name = %info.inbox_name,
+            "Registering Claude Teams info"
+        );
+        let mut map = self.inner.lock().await;
+        map.insert(key.to_string(), info);
+    }
+
+    pub async fn get(&self, key: &str) -> Option<TeamInfo> {
+        let map = self.inner.lock().await;
+        map.get(key).cloned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_get_missing_returns_none() {
+        let reg = TeamRegistry::new();
+        assert!(reg.get("nonexistent").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_register_then_get() {
+        let reg = TeamRegistry::new();
+        reg.register("root", TeamInfo {
+            team_name: "exo-root".into(),
+            inbox_name: "root-inbox".into(),
+        }).await;
+        let result = reg.get("root").await.unwrap();
+        assert_eq!(result.team_name, "exo-root");
+        assert_eq!(result.inbox_name, "root-inbox");
+    }
+
+    #[tokio::test]
+    async fn test_register_overwrites() {
+        let reg = TeamRegistry::new();
+        reg.register("root", TeamInfo { team_name: "team1".into(), inbox_name: "inbox1".into() }).await;
+        reg.register("root", TeamInfo { team_name: "team2".into(), inbox_name: "inbox2".into() }).await;
+        let result = reg.get("root").await.unwrap();
+        assert_eq!(result.team_name, "team2");
+    }
+
+    #[tokio::test]
+    async fn test_default_same_as_new() {
+        let reg = TeamRegistry::default();
+        assert!(reg.get("any").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_multiple_keys_coexist() {
+        let reg = TeamRegistry::new();
+        reg.register("root", TeamInfo { team_name: "root-team".into(), inbox_name: "root-inbox".into() }).await;
+        reg.register("agent", TeamInfo { team_name: "agent-team".into(), inbox_name: "agent-inbox".into() }).await;
+        assert_eq!(reg.get("root").await.unwrap().team_name, "root-team");
+        assert_eq!(reg.get("agent").await.unwrap().team_name, "agent-team");
+    }
+}

--- a/rust/claude-teams-bridge/src/verifier.rs
+++ b/rust/claude-teams-bridge/src/verifier.rs
@@ -1,0 +1,39 @@
+use crate::inbox::is_message_read;
+use std::time::Duration;
+
+/// Poll until CC's InboxPoller reads a message, or timeout.
+pub async fn wait_for_read(
+    team: &str,
+    recipient: &str,
+    timestamp: &str,
+    timeout: Duration,
+) -> bool {
+    let interval = Duration::from_secs(2);
+    let start = tokio::time::Instant::now();
+
+    loop {
+        if is_message_read(team, recipient, timestamp) {
+            return true;
+        }
+        if start.elapsed() >= timeout {
+            return false;
+        }
+        tokio::time::sleep(interval).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_timeout_returns_false() {
+        let result = wait_for_read(
+            "nonexistent-team",
+            "nobody",
+            "2024-01-01T00:00:00.000Z",
+            Duration::from_millis(100),
+        ).await;
+        assert!(!result);
+    }
+}


### PR DESCRIPTION
Create a new standalone Rust crate at `rust/claude-teams-bridge/` that extracts Claude Code Teams filesystem logic into a publishable library.

This crate includes:
- `paths.rs`: Path resolution for `~/.claude/teams/`.
- `inbox.rs`: Typed message format and mailbox R/W logic.
- `config.rs`: Team configuration (`config.json`) handling.
- `discovery.rs`: Listing teams and inboxes.
- `registry.rs`: Thread-safe agent identity to team mapping.
- `verifier.rs`: Asynchronous polling for message delivery verification.

All tests in the new crate pass, and the workspace builds successfully.