### PR TITLE
feat: Claude rules file bootstrapping in exomonad init

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,7 +157,7 @@ cargo build -p exomonad
 
 ### Configuration
 
-**Bootstrap:** `exomonad init` auto-creates `.exo/config.toml` (empty, all defaults) and `.gitignore` entries if missing. Works in any project directory. All fields are optional — auto-detection handles the common case.
+**Bootstrap:** `exomonad init` auto-creates `.exo/config.toml` (empty, all defaults) and `.gitignore` entries if missing. Works in any project directory. All fields are optional — auto-detection handles the common case. **Claude rules:** `exomonad init` copies `.exo/rules/exomonad.md` → `.claude/rules/exomonad.md` (if the template exists and the destination doesn't). Template resolution: project-local `.exo/rules/` → global `~/.exo/rules/`. This gives fresh Claude instances automatic knowledge of exomonad MCP tools.
 
 ```toml
 # All fields below are optional — shown with their auto-detected defaults

--- a/rust/exomonad/src/main.rs
+++ b/rust/exomonad/src/main.rs
@@ -679,6 +679,33 @@ async fn run_init(session_override: Option<String>, recreate: bool) -> Result<()
         .context("Failed to write hook configuration")?;
     info!("Hook configuration written to .claude/settings.local.json");
 
+    // Copy Claude rules template if available and not already present
+    {
+        let rules_dest = cwd.join(".claude/rules/exomonad.md");
+        if !rules_dest.exists() {
+            // Resolution: project-local .exo/rules/ → global ~/.exo/rules/
+            let local_template = cwd.join(".exo/rules/exomonad.md");
+            let global_template = std::env::var("HOME")
+                .ok()
+                .map(|h| PathBuf::from(h).join(".exo/rules/exomonad.md"));
+
+            let source = if local_template.exists() {
+                Some(local_template)
+            } else {
+                global_template.filter(|p| p.exists())
+            };
+
+            if let Some(src) = source {
+                std::fs::create_dir_all(cwd.join(".claude/rules"))?;
+                std::fs::copy(&src, &rules_dest)?;
+                info!(
+                    src = %src.display(),
+                    "Copied Claude rules to .claude/rules/exomonad.md"
+                );
+            }
+        }
+    }
+
     // Write Gemini MCP configuration if root agent is Gemini
     if config.root_agent_type == AgentType::Gemini {
         let gemini_dir = cwd.join(".gemini");
@@ -840,10 +867,16 @@ fn ensure_gitignore(project_dir: &std::path::Path) -> Result<()> {
     };
 
     let has_line = |line: &str| content.lines().any(|l| l.trim() == line);
-    let needed: Vec<&str> = [".exo/*", "!.exo/config.toml", "!.exo/roles/", "!.exo/lib/"]
-        .into_iter()
-        .filter(|line| !has_line(line))
-        .collect();
+    let needed: Vec<&str> = [
+        ".exo/*",
+        "!.exo/config.toml",
+        "!.exo/roles/",
+        "!.exo/lib/",
+        "!.exo/rules/",
+    ]
+    .into_iter()
+    .filter(|line| !has_line(line))
+    .collect();
 
     if needed.is_empty() {
         return Ok(());


### PR DESCRIPTION
This PR adds Claude rules file bootstrapping to `exomonad init`.

When `exomonad init` runs, it now:
1. Looks for a template at `.exo/rules/exomonad.md` (project-local).
2. Falls back to `~/.exo/rules/exomonad.md` (global install).
3. Copies it to `.claude/rules/exomonad.md` if the destination doesn't exist.
4. Updates `.gitignore` to include `!.exo/rules/`.

This ensures fresh Claude instances automatically have knowledge of exomonad MCP tools.

Changes:
- `rust/exomonad/src/main.rs`: Added copy logic to `run_init` and updated `ensure_gitignore`.
- `CLAUDE.md`: Documented the new behavior in the Bootstrap section.

Verified with `cargo check` and `cargo test`.