### PR TITLE
feat: add `yolo` config field for Gemini agents

### DIFF
--- a/rust/exomonad-core/src/services/agent_control.rs
+++ b/rust/exomonad-core/src/services/agent_control.rs
@@ -460,6 +460,8 @@ pub struct AgentControlService {
     git_wt: Arc<GitWorktreeService>,
     /// ACP connection registry for Gemini agents.
     pub acp_registry: Option<Arc<AcpRegistry>>,
+    /// When true, spawned Gemini agents receive `--yolo` flag.
+    yolo: bool,
 }
 
 impl AgentControlService {
@@ -479,6 +481,7 @@ impl AgentControlService {
             birth_branch: BirthBranch::root(),
             git_wt,
             acp_registry: None,
+            yolo: false,
         }
     }
 
@@ -504,6 +507,12 @@ impl AgentControlService {
     /// Set the birth-branch (git identity) for this agent.
     pub fn with_birth_branch(mut self, branch: BirthBranch) -> Self {
         self.birth_branch = branch;
+        self
+    }
+
+    /// Enable `--yolo` flag for spawned Gemini agents.
+    pub fn with_yolo(mut self, yolo: bool) -> Self {
+        self.yolo = yolo;
         self
     }
 
@@ -559,6 +568,7 @@ impl AgentControlService {
             birth_branch: BirthBranch::root(),
             git_wt,
             acp_registry: None,
+            yolo: false,
         })
     }
 
@@ -1851,6 +1861,7 @@ impl AgentControlService {
         env_vars: &HashMap<String, String>,
         cwd: &Path,
         claude_flags: Option<&ClaudeSpawnFlags>,
+        yolo: bool,
     ) -> String {
         let cmd = agent_type.command();
 
@@ -1878,7 +1889,10 @@ impl AgentControlService {
                 }
                 flags
             }
-            AgentType::Gemini | AgentType::Shoal => String::new(),
+            AgentType::Gemini => {
+                if yolo { " --yolo".to_string() } else { String::new() }
+            }
+            AgentType::Shoal => String::new(),
         };
 
         let agent_command = match (prompt, fork_session_id) {
@@ -1937,7 +1951,7 @@ impl AgentControlService {
         info!(name, cwd = %cwd.display(), agent_type = ?agent_type, fork = fork_session_id.is_some(), "Creating tmux window");
 
         let full_command = Self::build_agent_command(
-            agent_type, prompt, fork_session_id, &env_vars, cwd, claude_flags,
+            agent_type, prompt, fork_session_id, &env_vars, cwd, claude_flags, self.yolo,
         );
         let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
         let tmux = self.tmux()?;
@@ -2049,7 +2063,7 @@ impl AgentControlService {
     ) -> Result<String> {
         info!(name, cwd = %cwd.display(), agent_type = ?agent_type, parent = ?parent_window_name, "Creating tmux pane");
 
-        let full_command = Self::build_agent_command(agent_type, prompt, None, &env_vars, cwd, claude_flags);
+        let full_command = Self::build_agent_command(agent_type, prompt, None, &env_vars, cwd, claude_flags, self.yolo);
         let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
         let tmux = self.tmux()?;
 

--- a/rust/exomonad/src/config.rs
+++ b/rust/exomonad/src/config.rs
@@ -53,6 +53,10 @@ pub struct RawConfig {
 
     /// Initial prompt for the root agent (used with `gemini --prompt-interactive`).
     pub initial_prompt: Option<String>,
+
+    /// When true, spawned Gemini agents receive `--yolo` flag.
+    #[serde(default)]
+    pub yolo: bool,
 }
 
 /// Final resolved configuration.
@@ -78,6 +82,8 @@ pub struct Config {
     pub extra_mcp_servers: std::collections::HashMap<String, McpServerConfig>,
     /// Initial prompt for the root agent.
     pub initial_prompt: Option<String>,
+    /// When true, spawned Gemini agents receive `--yolo` flag.
+    pub yolo: bool,
 }
 
 impl Config {
@@ -191,6 +197,9 @@ impl Config {
 
         let initial_prompt = local_raw.initial_prompt.or(global_raw.initial_prompt);
 
+        // Resolve yolo: local > global > false
+        let yolo = local_raw.yolo || global_raw.yolo;
+
         Ok(Self {
             project_dir,
             role,
@@ -203,6 +212,7 @@ impl Config {
             wasm_name,
             extra_mcp_servers,
             initial_prompt,
+            yolo,
         })
     }
 
@@ -232,6 +242,7 @@ impl Default for Config {
             wasm_name: "devswarm".to_string(),
             extra_mcp_servers: std::collections::HashMap::new(),
             initial_prompt: None,
+            yolo: false,
         }
     }
 }

--- a/rust/exomonad/src/main.rs
+++ b/rust/exomonad/src/main.rs
@@ -1147,6 +1147,7 @@ async fn main() -> Result<()> {
             agent_control = agent_control.with_worktree_base(worktree_base.clone());
             agent_control = agent_control.with_birth_branch(exomonad_core::BirthBranch::root());
             agent_control = agent_control.with_tmux_session(config.tmux_session.clone());
+            agent_control = agent_control.with_yolo(config.yolo);
             let event_session_id = uuid::Uuid::new_v4().to_string();
             let agent_control = Arc::new(agent_control);
 


### PR DESCRIPTION
## Summary

Adds a `yolo` boolean field to `.exo/config.toml`. When set to `true`, all Gemini agents spawned via `spawn_leaf_subtree` and `spawn_workers` automatically receive `--yolo` as a CLI flag.

### Changes

- **`rust/exomonad/src/config.rs`**: Added `yolo: bool` to `RawConfig` (with `#[serde(default)]`) and `Config`. Resolution: either local or global config can enable it.
- **`rust/exomonad-core/src/services/agent_control.rs`**: Added `yolo` field to `AgentControlService` with `with_yolo()` builder. Modified `build_agent_command` to append `--yolo` for Gemini agents when enabled.
- **`rust/exomonad/src/main.rs`**: Threads `config.yolo` into the service.

### Verify

- `cargo check --workspace` passes
- `cargo test --workspace --lib` passes (13/13)