### PR TITLE
refactor: replace partial 'error' in MergePR.hs with safe pattern match

### DIFF
--- a/haskell/wasm-guest/src/ExoMonad/Guest/Tools/MergePR.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Guest/Tools/MergePR.hs
@@ -128,15 +128,12 @@ checkCopilotReadiness prNum = do
           -- Filter to Copilot reviews (author login contains "copilot")
           let copilotReviews = filter isCopilotReview reviews
 
-          if null copilotReviews
-            then pure $ NotReady $ "No Copilot review yet on PR #" <> T.pack (show prNum)
+          case reverse copilotReviews of
+            [] -> pure $ NotReady $ "No Copilot review yet on PR #" <> T.pack (show prNum)
                   <> ". Wait for [PR READY] or [REVIEW TIMEOUT] from the event system."
-            else do
+            (latest:_) -> do
               -- Check the latest Copilot review
-              let latest = case reverse copilotReviews of
-                    (l:_) -> l
-                    [] -> error "unreachable"
-                  reviewSha = TL.toStrict (GH.reviewCommitId latest)
+              let reviewSha = TL.toStrict (GH.reviewCommitId latest)
                   state = GH.reviewState latest
               case state of
                 Protobuf.Enumerated (Right GH.ReviewStateREVIEW_STATE_APPROVED) ->


### PR DESCRIPTION
This PR replaces the partial function call 'error "unreachable"' in 'MergePR.hs' with a safe pattern match by refactoring the 'if null' check into a 'case reverse' block.

Changes:
- Replaced 'if null copilotReviews' and 'error "unreachable"' with 'case reverse copilotReviews of'.
- Simplified the logic for retrieving the latest Copilot review.
- Verified that 'MergePR.hs' still compiles (pre-existing errors in other files persist but do not affect this module).
- Verified LANGUAGE pragmas remain intact.
- Confirmed no other 'error', 'undefined', 'head', or 'tail' calls are present in 'MergePR.hs'.