### PR TITLE
feat: Agent Tree State Machine Observability (Rust + SQL)

### DIFF
--- a/.exo/bin/kaizen
+++ b/.exo/bin/kaizen
@@ -9,17 +9,21 @@
 #   kaizen prs                # shortcut for pr_pipeline
 #   kaizen tools              # shortcut for tool_summary
 #   kaizen reviews            # shortcut for copilot_reviews
+#   kaizen tree               # shortcut for agent_tree
+#   kaizen timeline           # shortcut for swarm_timeline
+#   kaizen delivery           # shortcut for delivery_audit
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SQL_FILE="$SCRIPT_DIR/kaizen.sql"
-EVENTS_FILE="$SCRIPT_DIR/events.jsonl"
+LOG_DIR="$SCRIPT_DIR/logs"
 
-if [ ! -f "$EVENTS_FILE" ]; then
-  echo "No event log found at $EVENTS_FILE" >&2
+# Ensure log directory exists and has at least one jsonl file
+if [ ! -d "$LOG_DIR" ] || [ -z "$(ls "$LOG_DIR"/*.jsonl 2>/dev/null)" ]; then
+  echo "No event logs found in $LOG_DIR" >&2
   exit 1
 fi
 
-# SQL uses relative path '.exo/events.jsonl', so cd to repo root
+# SQL uses relative path '.exo/logs/*.jsonl', so cd to repo root
 cd "$SCRIPT_DIR/.." || exit 1
 
 case "${1:-}" in
@@ -28,6 +32,9 @@ case "${1:-}" in
   prs)      QUERY="SELECT * FROM pr_pipeline ORDER BY filed_at" ;;
   tools)    QUERY="SELECT * FROM tool_summary" ;;
   reviews)  QUERY="SELECT * FROM copilot_reviews ORDER BY review_ts" ;;
+  tree)     QUERY="SELECT * FROM agent_tree" ;;
+  timeline) QUERY="SELECT * FROM swarm_timeline ORDER BY ts" ;;
+  delivery) QUERY="SELECT * FROM delivery_audit ORDER BY ts" ;;
   "")       exec duckdb -init "$SQL_FILE" ;;
   *)        QUERY="$1" ;;
 esac

--- a/.exo/kaizen.sql
+++ b/.exo/kaizen.sql
@@ -2,7 +2,7 @@
 -- Load: duckdb -init .exo/kaizen.sql
 -- Or use: .exo/bin/kaizen
 
--- Base: typed event table
+-- Base: typed event table (globs all per-agent logs)
 CREATE VIEW events AS
 SELECT
   ts::TIMESTAMP AS ts,
@@ -10,16 +10,16 @@ SELECT
   type,
   agent_id,
   data
-FROM read_json_auto('.exo/events.jsonl');
+FROM read_json_auto('.exo/logs/*.jsonl');
 
 -- Agent lifecycles: spawn → complete, with duration
 CREATE VIEW agent_lifecycles AS
 SELECT
-  s.data->>'child_agent' AS agent_id,
-  s.data->>'agent_type' AS agent_type,
-  s.data->>'spawn_type' AS spawn_type,
-  s.data->>'branch' AS branch,
-  s.data->>'slug' AS slug,
+  data->>'child_agent' AS agent_id,
+  data->>'agent_type' AS agent_type,
+  data->>'spawn_type' AS spawn_type,
+  data->>'branch' AS branch,
+  data->>'slug' AS slug,
   s.ts AS spawned_at,
   c.ts AS completed_at,
   EXTRACT(EPOCH FROM (c.ts - s.ts)) * 1000 AS duration_ms,
@@ -31,6 +31,16 @@ LEFT JOIN events c
   ON c.type = 'agent.completed'
   AND c.agent_id = s.data->>'child_agent'
 WHERE s.type = 'agent.spawned';
+
+-- Agent tree: parent-child hierarchy
+CREATE VIEW agent_tree AS
+SELECT
+  agent_id AS parent_id,
+  data->>'child_agent' AS child_id,
+  data->>'agent_type' AS agent_type,
+  data->>'spawn_type' AS spawn_type
+FROM events
+WHERE type = 'agent.spawned';
 
 -- PR pipeline: filed → merged, with duration
 CREATE VIEW pr_pipeline AS
@@ -54,25 +64,39 @@ LEFT JOIN events mf
   AND CAST(mf.data->>'pr_number' AS INTEGER) = CAST(f.data->>'pr_number' AS INTEGER)
 WHERE f.type = 'pr.filed';
 
--- Tool usage: call counts by tool and agent
+-- Tool usage: call counts and duration by tool and agent
 CREATE VIEW tool_usage AS
 SELECT
   data->>'tool_name' AS tool_name,
-  data->>'agent_id' AS agent_id,
-  COUNT(*) AS call_count
+  agent_id,
+  COUNT(*) AS call_count,
+  AVG(CAST(data->>'duration_ms' AS DOUBLE)) AS avg_duration_ms
 FROM events
 WHERE type = 'tool.called'
-GROUP BY data->>'tool_name', data->>'agent_id';
+GROUP BY data->>'tool_name', agent_id;
 
 -- Tool summary: aggregated across agents
 CREATE VIEW tool_summary AS
 SELECT
   tool_name,
   SUM(call_count) AS total_calls,
-  COUNT(DISTINCT agent_id) AS agent_count
+  COUNT(DISTINCT agent_id) AS agent_count,
+  AVG(avg_duration_ms) AS avg_duration_ms
 FROM tool_usage
 GROUP BY tool_name
 ORDER BY total_calls DESC;
+
+-- Delivery audit: message delivery chain
+CREATE VIEW delivery_audit AS
+SELECT
+  ts,
+  agent_id AS sender,
+  data->>'recipient' AS recipient,
+  data->>'method' AS method,
+  data->>'outcome' AS outcome,
+  data->>'detail' AS detail
+FROM events
+WHERE type = 'message.delivery';
 
 -- Copilot reviews: structured review data
 CREATE VIEW copilot_reviews AS
@@ -85,6 +109,26 @@ SELECT
   json_array_length(COALESCE(data->'reviews', '[]'::JSON)) AS review_count
 FROM events
 WHERE type = 'copilot.review';
+
+-- Swarm timeline: flat interleaved timeline with human-readable summaries
+CREATE VIEW swarm_timeline AS
+SELECT
+  ts,
+  agent_id,
+  type,
+  CASE
+    WHEN type = 'agent.spawned' THEN 'Spawned ' || (data->>'child_agent') || ' (' || (data->>'agent_type') || ')'
+    WHEN type = 'agent.completed' THEN 'Completed with status ' || (data->>'status')
+    WHEN type = 'tool.called' THEN 'Called tool ' || (data->>'tool_name') || ' (' || (data->>'duration_ms') || 'ms)'
+    WHEN type = 'message.delivery' THEN 'Delivered message to ' || (data->>'recipient') || ' via ' || (data->>'method')
+    WHEN type = 'pr.filed' THEN 'Filed PR #' || (data->>'pr_number')
+    WHEN type = 'pr.merged' THEN 'Merged PR #' || (data->>'pr_number')
+    WHEN type = 'hook.stop' THEN 'Hook stop: ' || (data->>'decision') || ' (' || COALESCE(data->>'reason', 'no reason') || ')'
+    WHEN type = 'event.dispatched' THEN 'Event dispatched: ' || (data->>'event_type') || ' -> ' || (data->>'action')
+    ELSE type
+  END AS summary
+FROM events
+ORDER BY ts;
 
 -- Swarm summary: one-row overview
 CREATE VIEW swarm_summary AS

--- a/rust/exomonad-core/src/handlers/events.rs
+++ b/rust/exomonad-core/src/handlers/events.rs
@@ -193,6 +193,7 @@ impl EventEffects for EventHandler {
             &req.status,
             &req.message,
             None,
+            "agent",
         )
         .await;
 
@@ -215,6 +216,7 @@ impl EventEffects for EventHandler {
         let delivery_result = crate::services::delivery::deliver_to_agent(
             self.team_registry.as_deref(),
             self.acp_registry.as_deref(),
+            self.event_log.as_deref(),
             &self.project_dir,
             &req.recipient,
             &tab_name,

--- a/rust/exomonad-core/src/handlers/log.rs
+++ b/rust/exomonad-core/src/handlers/log.rs
@@ -200,8 +200,8 @@ mod tests {
     #[test]
     fn test_log_handler_with_event_log() {
         let tmp = tempfile::tempdir().unwrap();
-        let log_path = tmp.path().join("events.jsonl");
-        let event_log = Arc::new(EventLog::open(log_path).unwrap());
+        let log_dir = tmp.path().join("logs");
+        let event_log = Arc::new(EventLog::open(log_dir).unwrap());
         let handler = LogHandler::new().with_event_log(event_log.clone());
 
         assert!(handler.event_log.is_some());

--- a/rust/exomonad-core/src/services/delivery.rs
+++ b/rust/exomonad-core/src/services/delivery.rs
@@ -65,6 +65,7 @@ pub async fn notify_parent_delivery(
     status: &str,
     message: &str,
     summary: Option<&str>,
+    source: &str,
 ) -> DeliveryResult {
     // 1. Log to event log
     if let Some(log) = event_log {
@@ -75,6 +76,7 @@ pub async fn notify_parent_delivery(
                 "parent": parent_session_id,
                 "status": status,
                 "message": message,
+                "source": source,
             }),
         ) {
             tracing::warn!(error = %e, "Failed to write notify_parent event");
@@ -101,6 +103,7 @@ pub async fn notify_parent_delivery(
     let delivery_result = deliver_to_agent(
         team_registry,
         acp_registry,
+        event_log,
         project_dir,
         parent_session_id,
         parent_tab_name,
@@ -109,27 +112,6 @@ pub async fn notify_parent_delivery(
         summary,
     )
     .await;
-
-    // 4. Log delivery result
-    if let Some(log) = event_log {
-        let delivery_method = match delivery_result {
-            DeliveryResult::Teams => "teams_inbox",
-            DeliveryResult::Acp => "acp",
-            DeliveryResult::Uds => "unix_socket",
-            DeliveryResult::Tmux => "tmux_stdin",
-            DeliveryResult::Failed => "failed",
-        };
-        if let Err(e) = log.append(
-            "agent.message_delivered",
-            agent_id,
-            &serde_json::json!({
-                "parent": parent_session_id,
-                "method": delivery_method,
-            }),
-        ) {
-            tracing::warn!(error = %e, "Failed to write message_delivered event");
-        }
-    }
 
     delivery_result
 }
@@ -201,6 +183,7 @@ async fn deliver_via_uds(
 pub async fn deliver_to_agent(
     team_registry: Option<&TeamRegistry>,
     acp_registry: Option<&super::acp_registry::AcpRegistry>,
+    event_log: Option<&EventLog>,
     project_dir: &std::path::Path,
     agent_key: &str,
     tmux_target: &str,
@@ -225,6 +208,20 @@ pub async fn deliver_to_agent(
                         timestamp = %timestamp,
                         "Wrote message to Teams inbox, spawning delivery verifier (30s)"
                     );
+
+                    if let Some(log) = event_log {
+                        let _ = log.append(
+                            "message.delivery",
+                            from,
+                            &serde_json::json!({
+                                "recipient": agent_key,
+                                "method": "teams_inbox",
+                                "outcome": "success",
+                                "detail": format!("{}/{}", team_info.team_name, team_info.inbox_name),
+                            }),
+                        );
+                    }
+
                     // Spawn background task to verify CC's InboxPoller read the message.
                     // If not read within 30s, fall back to tmux STDIN injection.
                     let team_name = team_info.team_name.clone();
@@ -268,6 +265,18 @@ pub async fn deliver_to_agent(
                         error = %e,
                         "Teams inbox write failed, falling back to ACP/tmux"
                     );
+                    if let Some(log) = event_log {
+                        let _ = log.append(
+                            "message.delivery",
+                            from,
+                            &serde_json::json!({
+                                "recipient": agent_key,
+                                "method": "teams_inbox",
+                                "outcome": "failed",
+                                "detail": e.to_string(),
+                            }),
+                        );
+                    }
                 }
             }
         }
@@ -286,6 +295,18 @@ pub async fn deliver_to_agent(
             {
                 Ok(_) => {
                     info!(agent = %agent_key, "Delivered message via ACP prompt");
+                    if let Some(log) = event_log {
+                        let _ = log.append(
+                            "message.delivery",
+                            from,
+                            &serde_json::json!({
+                                "recipient": agent_key,
+                                "method": "acp",
+                                "outcome": "success",
+                                "detail": conn.session_id,
+                            }),
+                        );
+                    }
                     return DeliveryResult::Acp;
                 }
                 Err(e) => {
@@ -294,6 +315,18 @@ pub async fn deliver_to_agent(
                         error = ?e,
                         "ACP prompt failed, falling back to tmux"
                     );
+                    if let Some(log) = event_log {
+                        let _ = log.append(
+                            "message.delivery",
+                            from,
+                            &serde_json::json!({
+                                "recipient": agent_key,
+                                "method": "acp",
+                                "outcome": "failed",
+                                "detail": format!("{:?}", e),
+                            }),
+                        );
+                    }
                 }
             }
         }
@@ -305,10 +338,34 @@ pub async fn deliver_to_agent(
         match deliver_via_uds(&socket_path, from, message, summary).await {
             Ok(()) => {
                 info!(agent = %agent_key, socket = %socket_path.display(), "Delivered message via Unix socket");
+                if let Some(log) = event_log {
+                    let _ = log.append(
+                        "message.delivery",
+                        from,
+                        &serde_json::json!({
+                            "recipient": agent_key,
+                            "method": "unix_socket",
+                            "outcome": "success",
+                            "detail": socket_path.to_string_lossy(),
+                        }),
+                    );
+                }
                 return DeliveryResult::Uds;
             }
             Err(e) => {
                 warn!(agent = %agent_key, error = %e, "UDS delivery failed, falling back to tmux");
+                if let Some(log) = event_log {
+                    let _ = log.append(
+                        "message.delivery",
+                        from,
+                        &serde_json::json!({
+                            "recipient": agent_key,
+                            "method": "unix_socket",
+                            "outcome": "failed",
+                            "detail": e.to_string(),
+                        }),
+                    );
+                }
             }
         }
     }
@@ -356,8 +413,24 @@ pub async fn deliver_to_agent(
             chars = message.len(),
             "Injecting message via routing.json"
         );
-        if let Err(e) = tmux_events::inject_input(&target, message).await {
-            warn!(target = %target, error = %e, "tmux inject_input failed (routing.json)");
+        let outcome = match tmux_events::inject_input(&target, message).await {
+            Ok(()) => "success",
+            Err(e) => {
+                warn!(target = %target, error = %e, "tmux inject_input failed (routing.json)");
+                "failed"
+            }
+        };
+        if let Some(log) = event_log {
+            let _ = log.append(
+                "message.delivery",
+                from,
+                &serde_json::json!({
+                    "recipient": agent_key,
+                    "method": "tmux_routing",
+                    "outcome": outcome,
+                    "detail": target,
+                }),
+            );
         }
         return DeliveryResult::Tmux;
     }
@@ -368,8 +441,24 @@ pub async fn deliver_to_agent(
         chars = message.len(),
         "Injecting message into agent pane via tmux"
     );
-    if let Err(e) = tmux_events::inject_input(tmux_target, message).await {
-        warn!(target = %tmux_target, error = %e, "tmux inject_input failed (fallback)");
+    let outcome = match tmux_events::inject_input(tmux_target, message).await {
+        Ok(()) => "success",
+        Err(e) => {
+            warn!(target = %tmux_target, error = %e, "tmux inject_input failed (fallback)");
+            "failed"
+        }
+    };
+    if let Some(log) = event_log {
+        let _ = log.append(
+            "message.delivery",
+            from,
+            &serde_json::json!({
+                "recipient": agent_key,
+                "method": "tmux_fallback",
+                "outcome": outcome,
+                "detail": tmux_target,
+            }),
+        );
     }
     DeliveryResult::Tmux
 }
@@ -418,6 +507,7 @@ mod tests {
     #[tokio::test]
     async fn test_deliver_no_registry_returns_tmux() {
         let result = deliver_to_agent(
+            None,
             None,
             None,
             std::path::Path::new("/tmp/nonexistent"),

--- a/rust/exomonad-core/src/services/event_log.rs
+++ b/rust/exomonad-core/src/services/event_log.rs
@@ -3,7 +3,7 @@
 //! Writes one JSON line per event to `.exo/events.jsonl` for post-hoc
 //! reconstruction of agent runs. Query with DuckDB or jq.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
 /// Append-only JSONL event log.
@@ -12,18 +12,16 @@ use std::sync::Mutex;
 /// The `Mutex` serializes concurrent tokio tasks. `O_APPEND` provides additional
 /// safety at the OS level for writes <4KB.
 pub struct EventLog {
-    path: PathBuf,
+    dir: PathBuf,
     lock: Mutex<()>,
 }
 
 impl EventLog {
-    /// Open (or create) the event log at `path`.
-    pub fn open(path: PathBuf) -> std::io::Result<Self> {
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
+    /// Open (or create) the event log directory at `dir`.
+    pub fn open(dir: PathBuf) -> std::io::Result<Self> {
+        std::fs::create_dir_all(&dir)?;
         Ok(Self {
-            path,
+            dir,
             lock: Mutex::new(()),
         })
     }
@@ -46,21 +44,24 @@ impl EventLog {
             "data": data,
         });
 
+        let sanitized_id = agent_id.replace(['/', '\\', '\0'], "_");
+        let path = self.dir.join(format!("{}.jsonl", sanitized_id));
+
         let _guard = self.lock.lock().unwrap_or_else(|e| e.into_inner());
 
         use std::io::Write;
         let mut file = std::fs::OpenOptions::new()
             .create(true)
             .append(true)
-            .open(&self.path)?;
+            .open(&path)?;
         writeln!(file, "{}", line)?;
 
         Ok(event_id)
     }
 
-    /// Path to the JSONL file.
-    pub fn path(&self) -> &std::path::Path {
-        &self.path
+    /// Path to the log directory.
+    pub fn dir(&self) -> &Path {
+        &self.dir
     }
 }
 
@@ -71,13 +72,13 @@ mod tests {
     #[test]
     fn test_append_and_read_back() {
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("events.jsonl");
-        let log = EventLog::open(path.clone()).unwrap();
+        let log = EventLog::open(dir.path().to_path_buf()).unwrap();
 
         let data = serde_json::json!({"slug": "feature-a", "agent_type": "claude"});
         let id = log.append("agent.spawned", "root", &data).unwrap();
         assert!(!id.is_empty());
 
+        let path = dir.path().join("root.jsonl");
         let content = std::fs::read_to_string(&path).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(content.trim()).unwrap();
         assert_eq!(parsed["type"], "agent.spawned");
@@ -90,14 +91,31 @@ mod tests {
     #[test]
     fn test_multiple_appends() {
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("events.jsonl");
-        let log = EventLog::open(path.clone()).unwrap();
+        let log = EventLog::open(dir.path().to_path_buf()).unwrap();
 
-        log.append("a", "x", &serde_json::json!({})).unwrap();
-        log.append("b", "y", &serde_json::json!({})).unwrap();
+        log.append("a", "agent-x", &serde_json::json!({})).unwrap();
+        log.append("b", "agent-y", &serde_json::json!({})).unwrap();
 
-        let content = std::fs::read_to_string(&path).unwrap();
-        let lines: Vec<&str> = content.trim().lines().collect();
-        assert_eq!(lines.len(), 2);
+        let path_x = dir.path().join("agent-x.jsonl");
+        let path_y = dir.path().join("agent-y.jsonl");
+
+        assert!(path_x.exists());
+        assert!(path_y.exists());
+
+        let content_x = std::fs::read_to_string(&path_x).unwrap();
+        let content_y = std::fs::read_to_string(&path_y).unwrap();
+
+        assert_eq!(content_x.trim().lines().count(), 1);
+        assert_eq!(content_y.trim().lines().count(), 1);
+    }
+
+    #[test]
+    fn test_agent_id_sanitization() {
+        let dir = tempfile::tempdir().unwrap();
+        let log = EventLog::open(dir.path().to_path_buf()).unwrap();
+
+        log.append("a", "feature/bug", &serde_json::json!({})).unwrap();
+        let path = dir.path().join("feature_bug.jsonl");
+        assert!(path.exists());
     }
 }

--- a/rust/exomonad-core/src/services/github_poller.rs
+++ b/rust/exomonad-core/src/services/github_poller.rs
@@ -191,6 +191,23 @@ impl GitHubPoller {
         {
             Ok(action) => {
                 info!("[EventDispatch] handle_event returned: {:?}", action);
+
+                if let Some(ref log) = self.event_log {
+                    let action_str = match action {
+                        EventActionResponse::InjectMessage { .. } => "inject_message",
+                        EventActionResponse::NotifyParent { .. } => "notify_parent",
+                        EventActionResponse::NoAction => "no_action",
+                    };
+                    let _ = log.append(
+                        "event.dispatched",
+                        agent_name,
+                        &serde_json::json!({
+                            "event_type": event_type,
+                            "action": action_str,
+                        }),
+                    );
+                }
+
                 Ok(Some(action))
             }
             Err(e) => {
@@ -198,6 +215,18 @@ impl GitHubPoller {
                     "[EventDispatch] handle_event failed for {}: {}",
                     agent_name, e
                 );
+
+                if let Some(ref log) = self.event_log {
+                    let _ = log.append(
+                        "event.dispatch_failed",
+                        agent_name,
+                        &serde_json::json!({
+                            "event_type": event_type,
+                            "error": e.to_string(),
+                        }),
+                    );
+                }
+
                 Ok(None)
             }
         }
@@ -217,6 +246,7 @@ impl GitHubPoller {
                 crate::services::delivery::deliver_to_agent(
                     self.team_registry.as_deref(),
                     self.acp_registry.as_deref(),
+                    self.event_log.as_deref(),
                     &self.project_dir,
                     branch,
                     &tab_name,
@@ -259,6 +289,7 @@ impl GitHubPoller {
                     "success",
                     &message,
                     Some(&summary),
+                    "event_handler",
                 )
                 .await;
             }

--- a/rust/exomonad/src/main.rs
+++ b/rust/exomonad/src/main.rs
@@ -245,6 +245,7 @@ struct HookState {
     otel: Option<Arc<OtelService>>,
     tmux_session: String,
     default_role: exomonad_core::Role,
+    event_log: Option<Arc<exomonad_core::services::EventLog>>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -487,6 +488,18 @@ async fn handle_hook_inner(
                 StopDecision::Allow => "allow",
                 StopDecision::Block => "block",
             };
+
+            if let Some(ref log) = state.event_log {
+                let _ = log.append(
+                    "hook.stop",
+                    agent_name_for_hook.as_str(),
+                    &serde_json::json!({
+                        "event_type": event_type,
+                        "decision": decision_str,
+                        "reason": internal_output.reason,
+                    }),
+                );
+            }
 
             if let Some(ref otel) = state.otel {
                 let mut extra_attributes = HashMap::new();
@@ -1213,10 +1226,10 @@ async fn main() -> Result<()> {
                 ]);
             // Create structured event log (JSONL)
             let event_log = match exomonad_core::services::EventLog::open(
-                project_dir.join(".exo/events.jsonl"),
+                project_dir.join(".exo/logs"),
             ) {
                 Ok(el) => {
-                    info!(path = %project_dir.join(".exo/events.jsonl").display(), "Event log opened");
+                    info!(path = %project_dir.join(".exo/logs").display(), "Event log opened");
                     Some(Arc::new(el))
                 }
                 Err(e) => {
@@ -1381,6 +1394,7 @@ async fn main() -> Result<()> {
                 let wasm_dir_for_handler = wasm_dir.clone();
                 let wasm_name_for_handler = wasm_name.clone();
                 let wb = worktree_base.clone();
+                let event_log_for_tools = event_log.clone();
                 move |axum::extract::Path((role, name)): axum::extract::Path<(String, String)>,
                       axum::extract::Json(body): axum::extract::Json<ToolCallRequest>| {
                     let plugins = plugins.clone();
@@ -1389,47 +1403,93 @@ async fn main() -> Result<()> {
                     let wasm_dir_for_handler = wasm_dir_for_handler.clone();
                     let wasm_name_for_handler = wasm_name_for_handler.clone();
                     let wb = wb.clone();
+                    let event_log = event_log_for_tools.clone();
                     async move {
                         let wasm_path_for_handler = resolve_wasm_path_for_role(
-                            &wasm_dir_for_handler, &role, &wasm_name_for_handler
-                        ).unwrap_or_else(|| wasm_path_default.clone());
+                            &wasm_dir_for_handler,
+                            &role,
+                            &wasm_name_for_handler,
+                        )
+                        .unwrap_or_else(|| wasm_path_default.clone());
 
                         let plugin = match resolve_plugin(
-                            &plugins, &registry, &wb, &name, &wasm_path_for_handler
-                        ).await {
+                            &plugins,
+                            &registry,
+                            &wb,
+                            &name,
+                            &wasm_path_for_handler,
+                        )
+                        .await
+                        {
                             Ok(p) => p,
                             Err(e) => {
                                 tracing::error!(role = %role, name = %name, error = %e, "Failed to resolve plugin");
                                 return (
                                     axum::http::StatusCode::INTERNAL_SERVER_ERROR,
                                     axum::Json(serde_json::json!({"error": e.to_string()})),
-                                ).into_response();
+                                )
+                                    .into_response();
                             }
                         };
 
                         tracing::info!(tool = %body.name, role = %role, agent = %name, "Executing tool");
 
                         let input = exomonad_core::mcp::tools::MCPCallInput::new(
-                            role, body.name.clone(), body.arguments,
+                            role.clone(),
+                            body.name.clone(),
+                            body.arguments,
                         );
 
-                        let output: exomonad_core::mcp::tools::MCPCallOutput = match plugin.call("handle_mcp_call", &input).await {
+                        let start = std::time::Instant::now();
+                        let result: Result<exomonad_core::mcp::tools::MCPCallOutput, anyhow::Error> = plugin.call("handle_mcp_call", &input).await;
+                        let duration_ms = start.elapsed().as_millis() as u64;
+
+                        let output = match result {
                             Ok(o) => o,
                             Err(e) => {
                                 tracing::error!(tool = %body.name, error = %e, "WASM call failed");
+                                if let Some(ref log) = event_log {
+                                    let _ = log.append(
+                                        "tool.called",
+                                        &name,
+                                        &serde_json::json!({
+                                            "tool_name": body.name,
+                                            "role": role,
+                                            "duration_ms": duration_ms,
+                                            "success": false,
+                                            "error": e.to_string(),
+                                        }),
+                                    );
+                                }
                                 return axum::Json(serde_json::json!({
                                     "success": false,
                                     "result": null,
                                     "error": format!("WASM call failed: {}", e)
-                                })).into_response();
+                                }))
+                                .into_response();
                             }
                         };
+
+                        if let Some(ref log) = event_log {
+                            let _ = log.append(
+                                "tool.called",
+                                &name,
+                                &serde_json::json!({
+                                    "tool_name": body.name,
+                                    "role": role,
+                                    "duration_ms": duration_ms,
+                                    "success": output.success,
+                                    "error": output.error,
+                                }),
+                            );
+                        }
 
                         axum::Json(serde_json::json!({
                             "success": output.success,
                             "result": output.result,
                             "error": output.error,
-                        })).into_response()
+                        }))
+                        .into_response()
                     }
                 }
             };
@@ -1463,6 +1523,7 @@ async fn main() -> Result<()> {
                 otel: OtelService::from_env().ok().map(Arc::new),
                 tmux_session: config.tmux_session.clone(),
                 default_role: config.role,
+                event_log: event_log.clone(),
             };
 
             // Shutdown signal for graceful shutdown via /shutdown endpoint


### PR DESCRIPTION
This PR implements comprehensive observability for the agent tree state machine.

Key changes:
1.  **Directory-based Event Logging**: `EventLog` now writes to `.exo/logs/{agent_id}.jsonl` instead of a single shared file. This allows for cleaner per-agent analysis and prevents file contention.
2.  **Server-side Event Emission**:
    *   `tool.called`: Emitted from the REST tool handler with duration, success status, and error details.
    *   `hook.stop`: Emitted when an agent stop hook is handled, recording the decision and reason.
    *   `event.dispatched`: Emitted from the GitHub poller when events are routed to agents.
3.  **Enhanced Delivery Auditing**:
    *   Added `source` attribution to `notify_parent_delivery` (distinguishing between "agent" and "event_handler").
    *   Implemented `message.delivery` events in `deliver_to_agent` to track the full delivery chain (Teams, ACP, UDS, or Tmux fallback).
4.  **Kaizen Observability Suite**:
    *   Updated `kaizen.sql` to glob per-agent logs and added new views: `agent_tree`, `swarm_timeline`, and `delivery_audit`.
    *   Enhanced `tool_usage` with average duration metrics.
    *   Updated `kaizen` CLI script with shortcuts for the new views.

Verification:
- `cargo test --workspace` (Services and Handlers pass)
- `cargo build -p exomonad` (Succeeds)
- Verified directory creation and sanitized agent ID mapping in `EventLog`.