### PR TITLE
feat: implement phase transitions in notify_parent, shutdown, and file_pr tools

### DIFF
--- a/haskell/wasm-guest/src/ExoMonad/Guest/Tools/Events.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Guest/Tools/Events.hs
@@ -23,6 +23,7 @@ import Effects.Log qualified as Log
 import ExoMonad.Effects.Agent qualified as ProtoAgent
 import ExoMonad.Effects.Events qualified as ProtoEvents
 import ExoMonad.Effects.Log (LogEmitEvent)
+import ExoMonad.Guest.Lifecycle (DevPhase (..), WorkerPhase (..), setDevPhase, setWorkerPhase)
 import ExoMonad.Guest.Tool.Class (MCPCallOutput, MCPTool (..), errorResult, successResult)
 import ExoMonad.Guest.Tool.Schema (JsonSchema (..), genericToolSchemaWith)
 import ExoMonad.Guest.Tool.SuspendEffect (suspendEffect, suspendEffect_)
@@ -129,7 +130,12 @@ instance MCPTool NotifyParent where
                   })
     case result of
       Left err -> pure $ errorResult (T.pack (show err))
-      Right _ -> pure $ successResult $ object ["success" .= True]
+      Right _ -> do
+        -- Set terminal phase based on status
+        case npStatus args of
+          Success -> setDevPhase DevDone
+          Failure -> setDevPhase (DevFailed (npMessage args))
+        pure $ successResult $ object ["success" .= True]
 
 -- | Compose enriched notification message with PR number and task reports.
 composeNotifyMessage :: NotifyParentArgs -> Text
@@ -217,6 +223,7 @@ instance MCPTool Shutdown where
   toolHandlerEff args = do
     let msg = maybe "Shutting down." id (sdMessage args)
     let statusText = "success" :: Text
+    setDevPhase DevDone
     void $ suspendEffect @ProtoEvents.EventsNotifyParent
       (ProtoEvents.NotifyParentRequest
         { ProtoEvents.notifyParentRequestAgentId = "",

--- a/haskell/wasm-guest/src/ExoMonad/Guest/Tools/FilePR.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Guest/Tools/FilePR.hs
@@ -20,6 +20,7 @@ import Effects.FilePr qualified as FP
 import Effects.Log qualified as Log
 import ExoMonad.Effects.FilePR (FilePRFilePr)
 import ExoMonad.Effects.Log (LogEmitEvent, LogError, LogInfo)
+import ExoMonad.Guest.Lifecycle (DevPhase (..), setDevPhase)
 import ExoMonad.Guest.Tool.Class (MCPCallOutput, MCPTool (..), errorResult, successResult)
 import ExoMonad.Guest.Tool.Schema (genericToolSchemaWith)
 import ExoMonad.Guest.Tool.SuspendEffect (suspendEffect, suspendEffect_)
@@ -114,4 +115,5 @@ instance MCPTool FilePR where
             Log.emitEventRequestPayload = eventPayload,
             Log.emitEventRequestTimestamp = 0
           })
+        setDevPhase (DevPRFiled (fpoNumber output))
         pure $ successResult (Aeson.toJSON output)


### PR DESCRIPTION
This PR implements terminal phase transitions for the `notify_parent`, `shutdown`, and `file_pr` tools in the Haskell WASM guest.

Changes:
- `notify_parent`: Sets `DevDone` on success, `DevFailed` on failure.
- `shutdown`: Sets `DevDone` before closing.
- `file_pr`: Sets `DevPRFiled prNumber` on successful PR creation.

Verification:
- `just wasm-all` builds successfully.