### PR TITLE
feat: implement event-driven phase transitions in PRReviewHandler

### DIFF
--- a/.exo/lib/PRReviewHandler.hs
+++ b/.exo/lib/PRReviewHandler.hs
@@ -14,6 +14,7 @@ import Data.Text.Lazy qualified as TL
 import ExoMonad.Effects.Log qualified as Log
 import ExoMonad.Guest.Events (CIStatusEvent (..), EventAction (..), EventHandlerConfig (..), PRReviewEvent (..), SiblingMergedEvent (..), defaultEventHandlers)
 import ExoMonad.Guest.Events.Templates qualified as Tpl
+import ExoMonad.Guest.Lifecycle (DevPhase (..), getDevPhase, setDevPhase)
 import ExoMonad.Guest.Tool.SuspendEffect (suspendEffect_)
 import ExoMonad.Guest.Types (Effects)
 
@@ -31,10 +32,12 @@ prReviewEventHandlers =
 prReviewHandler :: PRReviewEvent -> Eff Effects EventAction
 prReviewHandler (ReviewReceived n comments_) = do
   logHandler $ "Review received on PR #" <> T.pack (show n)
+  setDevPhase (DevChangesRequested n [comments_])
   pure (InjectMessage (Tpl.copilotReviewReceived n comments_))
 
 prReviewHandler (ReviewApproved n) = do
   logHandler $ "PR #" <> T.pack (show n) <> " approved by Copilot"
+  setDevPhase (DevApproved n)
   pure (NotifyParentAction (Tpl.prReady n) n)
 
 prReviewHandler (ReviewTimeout n mins) = do
@@ -43,10 +46,20 @@ prReviewHandler (ReviewTimeout n mins) = do
 
 prReviewHandler (FixesPushed n ci) = do
   logHandler $ "Fixes pushed on PR #" <> T.pack (show n) <> ", CI: " <> ci
+  phase <- getDevPhase
+  let round = case phase of
+        Just (DevUnderReview _ r) -> r + 1
+        _ -> 1
+  setDevPhase (DevUnderReview n round)
   pure (NotifyParentAction (Tpl.fixesPushed n ci) n)
 
 prReviewHandler (CommitsPushed n ci) = do
   logHandler $ "New commits pushed on PR #" <> T.pack (show n) <> ", CI: " <> ci
+  phase <- getDevPhase
+  let round = case phase of
+        Just (DevUnderReview _ r) -> r + 1
+        _ -> 1
+  setDevPhase (DevUnderReview n round)
   pure (NotifyParentAction (Tpl.commitsPushed n ci) n)
 
 -- | Handle sibling merged events.


### PR DESCRIPTION
This PR implements event-driven phase transitions in `.exo/lib/PRReviewHandler.hs`.

Changes:
- Added import for `DevPhase`, `getDevPhase`, and `setDevPhase`.
- Updated `prReviewHandler` to transition phases on:
  - `ReviewReceived` -> `DevChangesRequested`
  - `ReviewApproved` -> `DevApproved`
  - `FixesPushed`/`CommitsPushed` -> `DevUnderReview` (with incrementing round)

Verification:
- `just wasm-all` succeeded.