### PR TITLE
improve shutdown command edge cases

### DIFF
--- a/rust/exomonad/src/main.rs
+++ b/rust/exomonad/src/main.rs
@@ -239,9 +239,33 @@ async fn main() -> Result<()> {
 
         Commands::Shutdown => {
             let socket = uds_client::find_server_socket().context("Cannot find server socket.")?;
+            println!("Socket: {}", socket.display());
+
+            // Read and validate PID file
+            let pid_path = socket.parent().unwrap().join("server.pid");
+            match std::fs::read_to_string(&pid_path) {
+                Ok(content) => {
+                    if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&content) {
+                        if let Some(pid) = parsed.get("pid").and_then(|v| v.as_u64()) {
+                            let alive = std::path::Path::new(&format!("/proc/{}", pid)).exists();
+                            println!("PID: {} ({})", pid, if alive { "running" } else { "not running" });
+                            if !alive {
+                                eprintln!("Warning: server process {} is not running. Stale socket?", pid);
+                            }
+                        }
+                    }
+                }
+                Err(_) => {
+                    eprintln!("Warning: no server.pid found at {}", pid_path.display());
+                }
+            }
+
             let client = uds_client::ServerClient::new(socket);
-            let _ = client.post_json::<serde_json::Value, serde_json::Value>("/shutdown", &serde_json::json!({})).await;
-            println!("Shutdown signal sent");
+            println!("Connecting...");
+            match client.post_json::<serde_json::Value, serde_json::Value>("/shutdown", &serde_json::json!({})).await {
+                Ok(resp) => println!("Server acknowledged shutdown: {}", resp),
+                Err(e) => eprintln!("Shutdown request failed: {}", e),
+            }
         }
     }
 


### PR DESCRIPTION
# shutdown hardening

If you run `exomonad serve` from one directory, then cd into a different one before running `exomonad shutdown`, you would get confusing behavior - no acknowledgement that the shutdown signal had failed. This PR adds a clear statement of what socket is targeted, and shows a shutdown acknowledgement or failure message.

```sh
# exomonad serve started in the ~/Work/exomonad/ directory

~/Work/exomonad/ ❯ exomonad shutdown
Socket: ~/Work/exomonad/.exo/server.sock
PID: 19989 (running)
Connecting...
Server acknowledged shutdown: {"status":"ok"}

# exomonad serve started in the ~/Work/exomonad/ directory

~/Work/exomonad/ ❯ cd ../greenfield/

~/Work/greenfield ❯ exomonad shutdown
Socket: ~/Work/greenfield/.exo/server.sock
PID: 270772 (not running)
Warning: server process 270772 is not running. Stale socket?
Connecting...
Shutdown request failed: Failed to connect to ~/Work/greenfield/.exo/server.sock

~/Work/greenfield ❯ cd ../exomonad/

~/Work/exomonad/ ❯ exomonad shutdown
Socket: ~/Work/exomonad/.exo/server.sock
PID: 20233 (running)
Connecting...
Server acknowledged shutdown: {"status":"ok"}

```
