### PR TITLE
fix: wrap cargo build in nix develop and auto-detect wasm-setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Install Nix if you don't have it:
 
 ```bash
 sh <(curl -L https://nixos.org/nix/install) --daemon
-mkdir -p ~/.config/nix && echo 'experimental-features = nix-command flakes' >> ~/.config/nix/nix.conf
+mkdir -p ~/.config/nix && grep -q 'nix-command flakes' ~/.config/nix/nix.conf 2>/dev/null || echo 'experimental-features = nix-command flakes' >> ~/.config/nix/nix.conf
 ```
 
 Then build and install:

--- a/justfile
+++ b/justfile
@@ -51,7 +51,7 @@ install-hooks:
 
 # Build WASM role and install to .exo/wasm/
 wasm role="tl":
-    @nix develop .#wasm --command bash -c 'if [ ! -d ~/.cabal/packages/hackage.haskell.org ]; then echo ">>> First-time WASM setup (populating cabal package index)..."; wasm32-wasi-cabal update --project-file=cabal.project.wasm; fi'
+    @nix develop .#wasm --command bash -c 'export PATH=$PWD/.gemini/tmp/bin:$PATH; if [ ! -d ~/.cabal/packages/hackage.haskell.org ]; then echo ">>> First-time WASM setup (populating cabal package index)..."; wasm32-wasi-cabal update --project-file=cabal.project.wasm; fi'
     @echo ">>> Building wasm-guest-{{role}}..."
     nix develop .#wasm --command bash -c 'export PATH=$PWD/.gemini/tmp/bin:$PATH; wasm32-wasi-cabal build --project-file=cabal.project.wasm wasm-guest-{{role}}'
     @echo ">>> Installing to .exo/wasm/..."


### PR DESCRIPTION
## Summary

- `_install` recipe now runs `cargo build` via `nix develop --command` so `protoc` is available without a manual nix shell (fixes #722)
- `wasm` recipe auto-runs `wasm32-wasi-cabal update` on first build if the package index hasn't been populated yet
- README Install (Native) section now documents prerequisites (Nix with flakes, tmux, just) and includes Nix install instructions (fixes #721)

Closes #721, closes #722

## Test plan

- [ ] Run `just install-all-dev` from outside a `nix develop` shell — should succeed without manual `protoc` install
- [ ] Run `just wasm-all` without prior `just wasm-setup` — should auto-detect and populate cabal index
- [ ] Verify README renders correctly on GitHub