### PR TITLE
feat: migrate tool + event handlers to StateMachine

### DIFF
--- a/.exo/lib/PRReviewHandler.hs
+++ b/.exo/lib/PRReviewHandler.hs
@@ -14,7 +14,8 @@ import Data.Text.Lazy qualified as TL
 import ExoMonad.Effects.Log qualified as Log
 import ExoMonad.Guest.Events (CIStatusEvent (..), EventAction (..), EventHandlerConfig (..), PRReviewEvent (..), SiblingMergedEvent (..), defaultEventHandlers)
 import ExoMonad.Guest.Events.Templates qualified as Tpl
-import ExoMonad.Guest.Lifecycle.DevTransitions (applyDevEvent, DevEvent (..))
+import ExoMonad.Guest.StateMachine (applyEvent)
+import DevPhase (DevPhase(..), DevEvent(..))
 import ExoMonad.Guest.Tool.SuspendEffect (suspendEffect_)
 import ExoMonad.Guest.Types (Effects)
 
@@ -31,12 +32,12 @@ prReviewEventHandlers =
 prReviewHandler :: PRReviewEvent -> Eff Effects EventAction
 prReviewHandler (ReviewReceived n comments_) = do
   logHandler $ "Review received on PR #" <> T.pack (show n)
-  applyDevEvent (ReviewReceivedEv n comments_)
+  void $ applyEvent @DevPhase @DevEvent DevSpawned (ReviewReceivedEv n comments_)
   pure (InjectMessage (Tpl.copilotReviewReceived n comments_))
 
 prReviewHandler (ReviewApproved n) = do
   logHandler $ "PR #" <> T.pack (show n) <> " approved by Copilot"
-  applyDevEvent (ReviewApprovedEv n)
+  void $ applyEvent @DevPhase @DevEvent DevSpawned (ReviewApprovedEv n)
   pure (NotifyParentAction (Tpl.prReady n) n)
 
 prReviewHandler (ReviewTimeout n mins) = do
@@ -45,12 +46,12 @@ prReviewHandler (ReviewTimeout n mins) = do
 
 prReviewHandler (FixesPushed n ci) = do
   logHandler $ "Fixes pushed on PR #" <> T.pack (show n) <> ", CI: " <> ci
-  applyDevEvent (FixesPushedEv n ci)
+  void $ applyEvent @DevPhase @DevEvent DevSpawned (FixesPushedEv n ci)
   pure (NotifyParentAction (Tpl.fixesPushed n ci) n)
 
 prReviewHandler (CommitsPushed n ci) = do
   logHandler $ "New commits pushed on PR #" <> T.pack (show n) <> ", CI: " <> ci
-  applyDevEvent (CommitsPushedEv n ci)
+  void $ applyEvent @DevPhase @DevEvent DevSpawned (CommitsPushedEv n ci)
   pure (NotifyParentAction (Tpl.commitsPushed n ci) n)
 
 -- | Handle sibling merged events.

--- a/haskell/wasm-guest/src/ExoMonad/Guest/Tools/Events.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Guest/Tools/Events.hs
@@ -23,7 +23,8 @@ import Effects.Log qualified as Log
 import ExoMonad.Effects.Agent qualified as ProtoAgent
 import ExoMonad.Effects.Events qualified as ProtoEvents
 import ExoMonad.Effects.Log (LogEmitEvent)
-import ExoMonad.Guest.Lifecycle.DevTransitions (applyDevEvent, DevEvent (..))
+import ExoMonad.Guest.StateMachine (applyEvent)
+import DevPhase (DevPhase(..), DevEvent(..))
 import ExoMonad.Guest.Tool.Class (MCPCallOutput, MCPTool (..), errorResult, successResult)
 import ExoMonad.Guest.Tool.Schema (JsonSchema (..), genericToolSchemaWith)
 import ExoMonad.Guest.Tool.SuspendEffect (suspendEffect, suspendEffect_)
@@ -133,8 +134,8 @@ instance MCPTool NotifyParent where
       Right _ -> do
         -- Set terminal phase based on status
         case npStatus args of
-          Success -> applyDevEvent (NotifyParentSuccess (npMessage args))
-          Failure -> applyDevEvent (NotifyParentFailure (npMessage args))
+          Success -> void $ applyEvent @DevPhase @DevEvent DevSpawned (NotifyParentSuccess (npMessage args))
+          Failure -> void $ applyEvent @DevPhase @DevEvent DevSpawned (NotifyParentFailure (npMessage args))
         pure $ successResult $ object ["success" .= True]
 
 -- | Compose enriched notification message with PR number and task reports.
@@ -223,7 +224,7 @@ instance MCPTool Shutdown where
   toolHandlerEff args = do
     let msg = maybe "Shutting down." id (sdMessage args)
     let statusText = "success" :: Text
-    applyDevEvent ShutdownRequested
+    void $ applyEvent @DevPhase @DevEvent DevSpawned ShutdownRequested
     void $ suspendEffect @ProtoEvents.EventsNotifyParent
       (ProtoEvents.NotifyParentRequest
         { ProtoEvents.notifyParentRequestAgentId = "",

--- a/haskell/wasm-guest/src/ExoMonad/Guest/Tools/FilePR.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Guest/Tools/FilePR.hs
@@ -24,10 +24,9 @@ import Effects.FilePr qualified as FP
 import Effects.Log qualified as Log
 import ExoMonad.Effects.FilePR (FilePRFilePr)
 import ExoMonad.Effects.Log (LogError, LogInfo)
-import ExoMonad.Guest.Lifecycle.DevState (SomeDevState (..), DevState (..), describeDevPhase)
-import ExoMonad.Guest.Lifecycle.DevTransitions (applyDevEvent, DevEvent (..))
-import ExoMonad.Guest.Lifecycle.PhaseEffect (getDevPhase, setDevPhase, getTLPhase)
-import ExoMonad.Guest.Lifecycle.TLTransitions (applyTLEvent, TLEvent (..))
+import ExoMonad.Guest.StateMachine (applyEvent, getPhase, setPhase, StopCheckResult(..))
+import DevPhase (DevPhase(..), DevEvent(..))
+import TLPhase (TLPhase(..), TLEvent(..))
 import ExoMonad.Guest.Tool.Class (MCPCallOutput, MCPTool (..), errorResult, successResult)
 import ExoMonad.Guest.Tool.Schema (genericToolSchemaWith)
 import ExoMonad.Guest.Tool.SuspendEffect (suspendEffect, suspendEffect_)
@@ -115,25 +114,25 @@ instance MCPTool FilePR where
       ]
   toolHandlerEff args = do
     -- Phase check: log warning for unexpected phases, auto-init if no phase set
-    mState <- getDevPhase
-    mTLState <- getTLPhase
-    case (mState, mTLState) of
+    mDevPhase <- getPhase @DevPhase @DevEvent
+    mTLPhase <- getPhase @TLPhase @TLEvent
+    case (mDevPhase, mTLPhase) of
       (_, Just _) -> pure () -- TL role, skip dev phase check
-      (Just (SomeDevState SWorking), _) -> pure ()
-      (Just (SomeDevState SSpawned), _) -> setDevPhase (SomeDevState SWorking)
+      (Just DevWorking, _) -> pure ()
+      (Just DevSpawned, _) -> setPhase @DevPhase @DevEvent DevWorking
       (Just other, _) ->
         void $ suspendEffect_ @LogInfo (Log.InfoRequest
-          { Log.infoRequestMessage = TL.fromStrict $ "FilePR: unexpected phase " <> describeDevPhase other <> ", proceeding anyway"
+          { Log.infoRequestMessage = TL.fromStrict $ "FilePR: unexpected phase " <> T.pack (show other) <> ", proceeding anyway"
           , Log.infoRequestFields = ""
           })
-      (Nothing, Nothing) -> setDevPhase (SomeDevState SWorking)
+      (Nothing, Nothing) -> setPhase @DevPhase @DevEvent DevWorking
 
     result <- filePRCore args
     case result of
       Left err -> pure $ errorResult err
       Right output -> do
-        mTLStateAfter <- getTLPhase
-        case mTLStateAfter of
-          Just _ -> applyTLEvent (OwnPRFiled (fpoNumber output) (fpoUrl output) (fpoHeadBranch output))
-          Nothing -> applyDevEvent (PRCreated (fpoNumber output) (fpoUrl output) (fpoHeadBranch output))
+        mTLPhaseAfter <- getPhase @TLPhase @TLEvent
+        case mTLPhaseAfter of
+          Just _ -> void $ applyEvent @TLPhase @TLEvent TLPlanning (OwnPRFiled (fpoNumber output) (fpoUrl output) (fpoHeadBranch output))
+          Nothing -> void $ applyEvent @DevPhase @DevEvent DevSpawned (PRCreated (fpoNumber output) (fpoUrl output) (fpoHeadBranch output))
         pure $ successResult (Aeson.toJSON output)


### PR DESCRIPTION
Migrated tool handlers and event handlers from the old GADT-based `Lifecycle` modules to the new `StateMachine` typeclass.

### Changes:
- **Events.hs**: Replaced `applyDevEvent` with `applyEvent` using `DevPhase` and `DevEvent` from `.exo/roles/devswarm/DevPhase.hs`.
- **PRReviewHandler.hs**: Replaced `applyDevEvent` with `applyEvent` using `DevPhase` and `DevEvent`.
- **FilePR.hs**: Replaced old Lifecycle imports with `StateMachine` and used `getPhase`, `setPhase`, and `applyEvent` in the `toolHandlerEff`.

The changes use standard Haskell `@TypeApplication` for the phase and event types.

Note: `just wasm-all` was attempted but failed due to DNS issues connecting to `objects-us-east-1.dream.io`, which is expected according to the task instructions.