### PR TITLE
feat: scaffold-fork-converge TL methodology

### DIFF
--- a/.exo/rules/exomonad.md
+++ b/.exo/rules/exomonad.md
@@ -1,0 +1,102 @@
+---
+description: "ExoMonad agent orchestration rules — loaded into every agent's context in projects using exomonad"
+---
+
+# ExoMonad Agent Rules
+
+## MCP Tools
+
+Use exomonad MCP tools for orchestration. Git and GitHub operations use `git` and `gh` CLI commands, NOT MCP tools.
+
+| Tool | Role | What it does |
+|------|------|-------------|
+| `fork_wave` | tl | Fork N parallel Claude agents (full context inheritance, own worktrees) |
+| `spawn_leaf_subtree` | tl | Fork Gemini agent into worktree + tmux window (spec-only, files PR) |
+| `spawn_workers` | tl | Spawn ephemeral Gemini panes (no branch, no worktree) |
+| `file_pr` | tl, dev | Create/update PR (base branch auto-detected from branch naming) |
+| `merge_pr` | tl | Merge a child's PR |
+| `notify_parent` | all | Send message to parent agent |
+| `send_message` | all | Send message to any exomonad-spawned agent |
+
+## Agent Hierarchy
+
+- **TL (Tech Lead)**: Claude (Opus). Decomposes, specs, scaffolds, spawns, merges. Never implements directly.
+- **Dev (Leaf)**: Gemini. Implements a focused spec, files PR. No spawning.
+- **Worker**: Gemini. Ephemeral pane, no branch. Research or in-place edits.
+
+## The TL Protocol: Scaffold-Fork-Converge
+
+Every TL at every level of the tree follows this protocol:
+
+### 1. Scaffold
+
+Before spawning any children, commit the shared foundation they'll build against:
+
+- **Types and interfaces** that children implement
+- **Test harness and fixtures** children will use
+- **Stub files** showing where children put their code
+- **CLAUDE.md additions** scoping this TL's domain
+
+Commit and push. Children fork from this commit.
+
+### 2. Fork (spawn wave)
+
+Spawn children for wave N. Zero dependencies between siblings in the same wave.
+
+- **Sub-TLs**: `fork_wave` (Claude). They inherit full conversation context — they already know the plan and the scaffolding.
+- **Devs**: `spawn_leaf_subtree` (Gemini). They get a self-contained spec. The CLAUDE.md from the scaffolding commit gives them project context.
+
+### 3. Converge (merge wave)
+
+Wait for children to complete (notifications arrive via Teams inbox). Merge their PRs sequentially. Then write an **integration commit**:
+
+- Wire children's outputs together
+- Run integration tests
+- Fix integration bugs
+
+### 4. Next wave (if any)
+
+Wave N+1 depends on merged wave N. Repeat from step 2.
+
+### 5. PR to parent
+
+After all waves are merged and integrated, file a PR to the parent TL's branch.
+
+## Spec Quality
+
+Specs are self-contained — the leaf has no context from previous attempts. Every spec must include:
+
+1. **Anti-patterns** (FIRST) — known failure modes as explicit DO NOT rules
+2. **Read first** — exact files to read (CLAUDE.md, source files)
+3. **Steps** — numbered, each step = one concrete action with code snippets
+4. **Verify** — exact build/test commands
+5. **Done criteria** — what "done" looks like
+
+Include complete code snippets. Name every file by full path. Include exact commands, not "run the tests."
+
+## Convergence Protocol
+
+The TL does NOT iterate on children's work. Convergence is **leaf + Copilot**, not TL:
+
+1. Leaf implements spec, commits, files PR
+2. Copilot reviews automatically on PR creation
+3. If Copilot requests changes → injected into leaf's pane → leaf fixes → pushes
+4. System notifies parent: `[FIXES PUSHED]`, `[PR READY]`, or `[REVIEW TIMEOUT]`
+5. TL merges when notified
+
+The TL never manually reviews code, never fixes a leaf's implementation.
+
+## Branch Naming
+
+`{parent_branch}.{slug}` (dot separator). PRs target the parent branch, not main. Merged via recursive fold up the tree.
+
+## State Machines
+
+Agent lifecycle is tracked via `StateMachine` typeclass instances. Phase types live in role code (`.exo/roles/`). The framework handles persistence (KV), logging, and stop hook integration. Agents cannot exit during critical phases (e.g., `ChangesRequested`).
+
+## Communication
+
+- `notify_parent` for completion/failure/status updates to parent
+- `send_message` for peer-to-peer messaging between any agents
+- Messages arrive as native `<teammate-message>` via Teams inbox
+- TL idles between spawning and receiving notifications — no polling

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -512,6 +512,31 @@ Since the TL doesn't iterate on specs, the v1 spec must be production-quality. E
 - **Name every file.** Not "update the proto" but "edit `proto/effects/agent.proto` AND `rust/exomonad-proto/proto/effects/agent.proto`".
 - **Specs are self-contained.** The leaf has no context from previous attempts. Every spec must stand alone with complete code snippets and full file paths.
 
+### Scaffold-Fork-Converge
+
+The recursive execution pattern. Every TL at every level follows this protocol:
+
+1. **Scaffold** — Before spawning children, commit the shared foundation:
+   - Types/interfaces that children implement against
+   - Test harness/fixtures children will use
+   - Stub files showing where children put their code
+   - CLAUDE.md additions scoping this TL's domain
+   - Commit and push. Children fork from this commit.
+
+2. **Fork** — Spawn wave N children. Zero deps between siblings in the same wave.
+   - Sub-TLs: `fork_wave` (Claude, full context inheritance) — they already know the plan
+   - Devs: `spawn_leaf_subtree` (Gemini, spec-only) — they get CLAUDE.md from scaffolding
+
+3. **Converge** — Wait for child notifications. Merge their PRs. Write an integration commit:
+   - Wire children's outputs together
+   - Run integration tests, fix integration bugs
+
+4. **Next wave** — If wave N+1 exists, repeat from step 2. Wave N+1 depends on merged wave N.
+
+5. **PR to parent** — After all waves merged and integrated, file PR to parent's branch.
+
+This is recursive — sub-TLs follow the same pattern. A 4-level-deep tree means 4 levels of scaffold-fork-converge, each TL independently managing its subtree.
+
 ### Parallelization
 
 Spawn multiple leaves when tasks are independent (no file conflicts, no ordering dependency). The TL spawns a wave, returns, and gets poked as each leaf completes. Examples:

--- a/haskell/wasm-guest/CLAUDE.md
+++ b/haskell/wasm-guest/CLAUDE.md
@@ -62,7 +62,7 @@ Claude-only permissions system using the `ClaudePermissions` DSL.
 Pure Haskell prompt assembly for worker/leaf agents. Replaces the former template effect round-trip (Haskell → proto → Rust disk I/O → proto → Haskell) with direct string composition.
 
 - Builder monoid: `task`, `boundary`, `steps`, `context`, `verify`, `doneCriteria`, `readFirst`, `raw`
-- Inline profiles: `leafProfile`, `workerProfile`, `researchProfile`, `generalProfile`, `rustProfile`, `haskellProfile`
+- Inline profiles: `tlProfile`, `leafProfile`, `workerProfile`, `researchProfile`, `generalProfile`, `rustProfile`, `haskellProfile`
 
 ### SDK/Role Split
 

--- a/haskell/wasm-guest/src/ExoMonad/Guest/Prompt.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Guest/Prompt.hs
@@ -14,6 +14,7 @@ module ExoMonad.Guest.Prompt
     doneCriteria,
     readFirst,
     raw,
+    tlProfile,
     leafProfile,
     workerProfile,
     researchProfile,
@@ -101,6 +102,44 @@ raw t = Prompt [Raw t]
 -- ============================================================================
 -- Inline profiles (moved from .exo/templates/profiles/*.md)
 -- ============================================================================
+
+-- | Protocol for sub-TL agents (scaffold-fork-converge).
+tlProfile :: Prompt
+tlProfile =
+  Prompt
+    [ Headed "TL Protocol (Scaffold-Fork-Converge)" $
+        T.intercalate
+          "\n"
+          [ "You are a **sub-TL** in your own git worktree. You decompose, scaffold, spawn, and merge. You never implement directly.",
+            "",
+            "Your protocol at every level:",
+            "",
+            "**1. Scaffold** \x2014 Before spawning children, commit the shared foundation:",
+            "   - Types/interfaces children implement against",
+            "   - Test harness/fixtures children will use",
+            "   - Stub files showing where children put their code",
+            "   - CLAUDE.md additions scoping your domain",
+            "   - Commit and push. Children fork from this commit.",
+            "",
+            "**2. Fork** \x2014 Spawn wave N children. Zero deps between siblings in the same wave.",
+            "   - Sub-TLs: `fork_wave` (Claude, full context inheritance)",
+            "   - Devs: `spawn_leaf_subtree` (Gemini, spec-only)",
+            "",
+            "**3. Converge** \x2014 Wait for child notifications. Merge their PRs. Write an integration commit:",
+            "   - Wire children's outputs together",
+            "   - Run integration tests, fix integration bugs",
+            "",
+            "**4. Next wave** \x2014 If wave N+1 exists, repeat from step 2. Wave N+1 depends on merged wave N.",
+            "",
+            "**5. PR to parent** \x2014 After all waves merged and integrated, file PR to your parent's branch.",
+            "",
+            "**DO NOT:**",
+            "- Implement code yourself (spawn a Dev for that)",
+            "- Manually review children's code (Copilot reviews, children iterate)",
+            "- Wait or poll for children (notifications arrive via Teams inbox)",
+            "- Iterate on a child's spec (if it fails 3+ times, re-decompose)"
+          ]
+    ]
 
 -- | Completion protocol for leaf subtree agents.
 leafProfile :: Prompt


### PR DESCRIPTION
## Summary
- Add `.exo/rules/exomonad.md` — agent rules template copied to consuming projects via `exomonad init`. Encodes the recursive TL protocol (scaffold → fork wave → converge → next wave → PR to parent), MCP tool reference, agent hierarchy, spec quality rules, and convergence protocol.
- Add `tlProfile` to prompt builder (`ExoMonad.Guest.Prompt`) — scaffold-fork-converge protocol for sub-TL agent prompts, alongside existing `leafProfile`, `workerProfile`, `researchProfile`.
- Add Scaffold-Fork-Converge section to CLAUDE.md Tech Lead Praxis — documents the recursive pattern that every TL at every level follows.

## Files
- `.exo/rules/exomonad.md` (new) — rules template for consuming projects
- `haskell/wasm-guest/src/ExoMonad/Guest/Prompt.hs` — add `tlProfile` export
- `CLAUDE.md` — add Scaffold-Fork-Converge subsection to Tech Lead Praxis
- `haskell/wasm-guest/CLAUDE.md` — document `tlProfile` in prompt builder profiles list