### PR TITLE
feat: add `exomonad new` command for project bootstrap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,9 @@ if !status.success() {
 
 ### Session Entry Point
 
-**`exomonad init` is THE entry point for development sessions.** It creates a tmux session with:
+**`exomonad new` is the one-time project bootstrap.** It creates `.exo/config.toml`, `.gitignore`, and copies WASM plugins and rules templates.
+
+**`exomonad init` is the idempotent entry point for development sessions.** It creates a tmux session with:
 - **Server window**: Runs `exomonad serve` (the MCP server, binds to `.exo/server.sock`)
 - **TL window**: Runs `nix develop` (where you launch `claude` or work directly)
 
@@ -83,12 +85,18 @@ The server must be running before Claude Code or Gemini can use MCP tools. Witho
 
 ```bash
 cd exomonad/                  # Run from the project root
+exomonad new                  # One-time setup: creates config, WASM, rules
 exomonad init                 # Creates tmux session, starts server
 # Then in the TL window:
 claude                        # MCP tools available immediately
 ```
 
 Use `--recreate` to tear down and rebuild the session (e.g., after binary updates).
+
+**Project setup:**
+```bash
+exomonad new                     # Bootstrap new project (.exo/config.toml, WASM, rules)
+```
 
 **Server management:**
 ```bash
@@ -109,14 +117,11 @@ After running `just install-all` (which installs WASM to `~/.exo/wasm/`), any pr
 
 ```bash
 cd ~/new-project && git init
-exomonad init
-# → Bootstraps .exo/config.toml (empty, all defaults)
-# → Copies WASM from ~/.exo/wasm/ (global install)
-# → Starts server, registers Claude MCP via .mcp.json
-# → Creates tmux session
+exomonad new                  # Creates .exo/config.toml, copies WASM from ~/.exo/wasm/
+exomonad init                 # Starts server, registers Claude MCP, creates tmux session
 ```
 
-For custom roles, copy `.exo/roles/` and `.exo/lib/` from exomonad and `exomonad init` will build WASM from source instead.
+For custom roles, copy `.exo/roles/` and `.exo/lib/` from exomonad and `exomonad new` will build WASM from source instead.
 
 ### Building
 
@@ -156,7 +161,7 @@ cargo build -p exomonad
 
 ### Configuration
 
-**Bootstrap:** `exomonad init` auto-creates `.exo/config.toml` (empty, all defaults) and `.gitignore` entries if missing. Works in any project directory. All fields are optional — auto-detection handles the common case. **Claude rules:** `exomonad init` copies `.exo/rules/exomonad.md` → `.claude/rules/exomonad.md` (if the template exists and the destination doesn't). Template resolution: project-local `.exo/rules/` → global `~/.exo/rules/`. This gives fresh Claude instances automatic knowledge of exomonad MCP tools.
+**Bootstrap:** `exomonad new` auto-creates `.exo/config.toml` (empty, all defaults) and `.gitignore` entries if missing. Works in any project directory. All fields are optional — auto-detection handles the common case. **Claude rules:** `exomonad new` copies `.exo/rules/exomonad.md` → `.claude/rules/exomonad.md` (if the template exists and the destination doesn't). Template resolution: project-local `.exo/rules/` → global `~/.exo/rules/`. This gives fresh Claude instances automatic knowledge of exomonad MCP tools.
 
 ```toml
 # All fields below are optional — shown with their auto-detected defaults

--- a/rust/exomonad/CLAUDE.md
+++ b/rust/exomonad/CLAUDE.md
@@ -25,6 +25,7 @@ exomonad hook pre-tool-use        # Handle Claude Code hook
 exomonad mcp-stdio                # Stdio MCP server (single agent)
 exomonad serve                    # UDS MCP server (multi-agent, hot reload)
 exomonad recompile [--role ROLE]  # Build WASM from Haskell source
+exomonad new                      # Initialize new project (.exo/config.toml, WASM, rules)
 exomonad init [--session NAME]    # Initialize tmux session (Server window + TL window)
 exomonad reload                   # Clear WASM plugin cache (hot reload)
 exomonad shutdown                 # Gracefully shut down the running server
@@ -32,11 +33,17 @@ exomonad shutdown                 # Gracefully shut down the running server
 
 **Observability:** Structured OTel spans via axum middleware. Every agent request (`/agents/{role}/{name}/...`) gets an `agent_request` span with `agent_id`, `agent.role`, `agent.parent`, and `swarm.run_id` — no per-call-site annotation needed. `swarm.run_id` is persisted to `.exo/run_id` and set as an OTel resource attribute; child processes inherit it via `EXOMONAD_SWARM_RUN_ID` env var. Query all spans in a run: `resource.swarm.run_id = '{id}'`. Reconstruct spawn tree: `groupBy agent.parent, agent_id`.
 
+### New Command
+
+`exomonad new` is the project bootstrap command. It auto-creates `.exo/config.toml` (empty, all defaults) and `.gitignore` entries if missing. It also copies WASM plugins from `~/.exo/wasm/` and rules templates to `.claude/rules/`. Works in any project directory.
+
 ### Init Command
 
 `exomonad init` creates a two-window tmux session:
 - **Server window**: Runs `exomonad serve` (binds .exo/server.sock)
 - **TL window**: Runs the configured shell command (focused by default)
+
+`exomonad init` requires `exomonad new` to have been run first to bootstrap the project configuration and WASM plugins.
 
 Claude MCP is auto-registered during init. For Gemini, register manually (`gemini mcp add ...`).
 
@@ -52,7 +59,7 @@ wasm_dir = ".exo/wasm"        # project-local default
 wasm_name = "devswarm"        # auto-detected from .exo/roles/ if exactly one exists
 ```
 
-**Bootstrap:** `exomonad init` auto-creates `.exo/config.toml` (empty, all defaults) and `.gitignore` entries if missing. Works in any project directory.
+**Bootstrap:** `exomonad new` auto-creates `.exo/config.toml` (empty, all defaults) and `.gitignore` entries if missing.
 
 **WASM resolution:** project `.exo/wasm/` → build from `.exo/roles/` → copy from `~/.exo/wasm/` (global install via `just install-all`).
 

--- a/rust/exomonad/src/init.rs
+++ b/rust/exomonad/src/init.rs
@@ -10,19 +10,10 @@ pub async fn run(session_override: Option<String>, recreate: bool) -> Result<()>
     use exomonad_core::services::tmux_ipc::TmuxIpc;
     use exomonad_core::services::AgentType;
 
-    // Bootstrap: create .exo/config.toml if missing
     let cwd = std::env::current_dir()?;
     let config_path = cwd.join(".exo/config.toml");
     if !config_path.exists() {
-        info!("Bootstrapping .exo/config.toml");
-        std::fs::create_dir_all(cwd.join(".exo"))?;
-        std::fs::write(
-            &config_path,
-            "# ExoMonad project config\n# All fields are optional — see docs for overrides\n",
-        )?;
-
-        // Add gitignore entries
-        ensure_gitignore(&cwd)?;
+        anyhow::bail!("No exomonad project found. Run `exomonad new` first.");
     }
 
     // Resolve config

--- a/rust/exomonad/src/main.rs
+++ b/rust/exomonad/src/main.rs
@@ -8,6 +8,7 @@
 
 mod app_state;
 mod init;
+mod new;
 mod logging;
 mod mcp_stdio;
 mod serve;
@@ -63,6 +64,14 @@ enum Commands {
         /// Delete existing session and create fresh (use after binary/layout updates)
         #[arg(long)]
         recreate: bool,
+    },
+
+    /// Initialize a new exomonad project in the current directory.
+    /// Creates .exo/config.toml, .gitignore entries, copies WASM, and rules template.
+    New {
+        /// Project name (unused, reserved for future)
+        #[arg(long)]
+        name: Option<String>,
     },
 
     /// Recompile WASM plugin from Haskell source
@@ -215,6 +224,10 @@ async fn main() -> Result<()> {
 
         Commands::Init { session, recreate } => {
             init::run(session, recreate).await?;
+        }
+
+        Commands::New { name } => {
+            new::run(name).await?;
         }
 
         Commands::Reply { id, payload, cancel } => {

--- a/rust/exomonad/src/new.rs
+++ b/rust/exomonad/src/new.rs
@@ -1,0 +1,105 @@
+use exomonad::config::Config;
+use anyhow::{Context, Result};
+use std::path::PathBuf;
+use tracing::{info, warn};
+
+/// Initialize a new exomonad project in the current directory.
+/// Creates .exo/config.toml, .gitignore entries, copies WASM, and rules template.
+pub async fn run(_name: Option<String>) -> Result<()> {
+    let cwd = std::env::current_dir()?;
+    let config_path = cwd.join(".exo/config.toml");
+
+    if config_path.exists() {
+        anyhow::bail!("ExoMonad project already exists (found .exo/config.toml)");
+    }
+
+    info!("Initializing new ExoMonad project");
+    std::fs::create_dir_all(cwd.join(".exo"))?;
+    std::fs::write(
+        &config_path,
+        "# ExoMonad project config
+# All fields are optional — see docs for overrides
+",
+    )?;
+
+    // Add gitignore entries
+    crate::init::ensure_gitignore(&cwd)?;
+
+    // Resolve config
+    let config = Config::discover()?;
+
+    // Copy WASM if it doesn't exist yet (same logic as init.rs)
+    let wasm_filename = format!("wasm-guest-{}.wasm", config.wasm_name);
+    let wasm_path = config.wasm_dir.join(&wasm_filename);
+    if !wasm_path.exists() {
+        let roles_dir = cwd.join(".exo/roles");
+        if roles_dir.is_dir() {
+            info!(path = %wasm_path.display(), "WASM not found, building...");
+            exomonad::recompile::run_recompile(
+                &config.wasm_name,
+                &cwd,
+                config.flake_ref.as_deref(),
+            )
+            .await?;
+        } else if let Ok(home) = std::env::var("HOME") {
+            let home = PathBuf::from(home);
+            // Fall back to globally installed WASM from ~/.exo/wasm/
+            let global_wasm = home.join(".exo/wasm").join(&wasm_filename);
+            if global_wasm.exists() {
+                info!(
+                    src = %global_wasm.display(),
+                    dst = %wasm_path.display(),
+                    "Copying WASM from global install"
+                );
+                std::fs::create_dir_all(&config.wasm_dir)?;
+                std::fs::copy(&global_wasm, &wasm_path)?;
+            } else {
+                warn!(
+                    path = %wasm_path.display(),
+                    "No WASM found locally or at ~/.exo/wasm/. Run 'just install-all' in the exomonad repo, or copy roles: cp -r /path/to/exomonad/.exo/roles .exo/roles"
+                );
+            }
+        } else {
+            warn!(
+                path = %wasm_path.display(),
+                "No WASM found locally or at ~/.exo/wasm/. Run 'just install-all' in the exomonad repo, or copy roles: cp -r /path/to/exomonad/.exo/roles .exo/roles"
+            );
+        }
+    }
+
+    // Write hook configuration
+    let binary_path = exomonad_core::find_exomonad_binary();
+    exomonad_core::hooks::HookConfig::write_persistent(&cwd, &binary_path, None)
+        .context("Failed to write hook configuration")?;
+    info!("Hook configuration written to .claude/settings.local.json");
+
+    // Copy Claude rules template if available and not already present (same logic as init.rs)
+    {
+        let rules_dest = cwd.join(".claude/rules/exomonad.md");
+        if !rules_dest.exists() {
+            // Resolution: project-local .exo/rules/ → global ~/.exo/rules/
+            let local_template = cwd.join(".exo/rules/exomonad.md");
+            let global_template = std::env::var("HOME")
+                .ok()
+                .map(|h| PathBuf::from(h).join(".exo/rules/exomonad.md"));
+
+            let source = if local_template.exists() {
+                Some(local_template)
+            } else {
+                global_template.filter(|p| p.exists())
+            };
+
+            if let Some(src) = source {
+                std::fs::create_dir_all(cwd.join(".claude/rules"))?;
+                std::fs::copy(&src, &rules_dest)?;
+                info!(
+                    src = %src.display(),
+                    "Copied Claude rules to .claude/rules/exomonad.md"
+                );
+            }
+        }
+    }
+
+    info!("Project initialized. Run `exomonad init` to start a session.");
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Separates one-time project setup from session management:

- **`exomonad new`**: Creates `.exo/config.toml`, `.gitignore` entries, copies WASM plugins, and rules templates. Fails if project already initialized.
- **`exomonad init`**: Now requires `exomonad new` first. Focuses purely on tmux session lifecycle (server, TL window, `.mcp.json`).

## Changes

- `rust/exomonad/src/new.rs` — New file with bootstrap logic extracted from init
- `rust/exomonad/src/init.rs` — Bootstrap block replaced with guard bail
- `rust/exomonad/src/main.rs` — Added `mod new`, `Commands::New` variant, match arm
- `CLAUDE.md` — Updated Getting Started, Zero-Config, Configuration sections
- `rust/exomonad/CLAUDE.md` — Added New Command section, updated CLI Usage

## Test plan

- [x] `cargo build -p exomonad` succeeds
- [x] `cargo test --workspace` passes