### PR TITLE
fix(rust): correct Gemini leaf subtree window cleanup bug

### DIFF
--- a/rust/exomonad-core/src/services/agent_control.rs
+++ b/rust/exomonad-core/src/services/agent_control.rs
@@ -1504,17 +1504,27 @@ impl AgentControlService {
         );
 
         // Reconstruct names for paths and exact window matching.
-        // If agent not found, assume gemini worker (Phase 1 convention).
-        let (agent_type, display_name) = match agent {
+        // Invariant: identifier can be a clean slug ("my-feature") or an internal name ("my-feature-gemini").
+        // We must derive the clean slug for window matching (e.g. "💎 my-feature") and
+        // the internal_name for config directory lookup and worker cleanup.
+        // This prevents suffix doubling (e.g. "my-feature-gemini-gemini") if called with the internal name.
+        let (agent_type, slug) = match agent {
             Some(a) => {
                 let at = a.agent_type.unwrap_or(AgentType::Gemini);
-                let emoji = at.emoji();
-                (at, Some(format!("{} {}", emoji, identifier)))
+                let s = a.slug.as_ref().map(|s| s.as_str()).unwrap_or(identifier);
+                // If slug still contains suffix, strip it to get the clean slug for window name
+                let suffix = format!("-{}", at.suffix());
+                (at, s.strip_suffix(&suffix).unwrap_or(s).to_string())
             }
-            None => (AgentType::Gemini, None),
+            None => {
+                let at = AgentType::from_dir_name(identifier);
+                let suffix = format!("-{}", at.suffix());
+                (at, identifier.strip_suffix(&suffix).unwrap_or(identifier).to_string())
+            }
         };
 
-        let internal_name = format!("{}-{}", identifier, agent_type.suffix());
+        let internal_name = format!("{}-{}", slug, agent_type.suffix());
+        let display_name = Some(format!("{} {}", agent_type.emoji(), slug));
 
         // Remove per-agent config directory (.exo/agents/{name}/)
         let agent_config_dir = self
@@ -1735,16 +1745,18 @@ impl AgentControlService {
                         } else {
                             AgentType::Gemini
                         };
-                        let display_name = format!("{} {}", agent_type.emoji(), name);
+                        let suffix = format!("-{}", agent_type.suffix());
+                        let slug_str = name.strip_suffix(&suffix).unwrap_or(name);
+                        let display_name = format!("{} {}", agent_type.emoji(), slug_str);
 
                         let has_tab = windows.iter().any(|t| t == &display_name);
 
                         agents.push(AgentInfo {
-                            issue_id: name.to_string(),
+                            issue_id: slug_str.to_string(),
                             has_tab,
                             topology: Topology::WorktreePerAgent,
                             agent_dir: Some(path.clone()),
-                            slug: Some(AgentName::from(name)),
+                            slug: Some(AgentName::from(slug_str)),
                             agent_type: Some(agent_type),
                             pr: None,
                         });
@@ -1786,6 +1798,16 @@ impl AgentControlService {
                 // Workers are currently Gemini-only
                 if name.ends_with("-gemini") {
                     let base_name = name.strip_suffix("-gemini").unwrap_or(name);
+
+                    // Skip if this is actually a worktree-based agent (leaf subtree or teammate)
+                    // found by the worktree scan.
+                    if agents
+                        .iter()
+                        .any(|a| a.slug.as_ref().map(|s| s.as_str()) == Some(base_name))
+                    {
+                        continue;
+                    }
+
                     let display_name = format!("{} {}", AgentType::Gemini.emoji(), base_name);
 
                     // Liveness: for workers, they might be panes in a window.


### PR DESCRIPTION
This PR fixes a bug in `exomonad-core` where Gemini leaf subtree window cleanup was failing due to incorrect identifier reconstruction in `cleanup_agent`.

### Root Cause
1. `list_agents()` was double-listing leaf subtree agents because they appear both as isolated worktrees and as metadata directories in `.exo/agents/`.
2. The metadata entry (found by `scan_workers`) used the internal name (e.g., "my-feature-gemini") as the `issue_id`, while the worktree entry used the slug ("my-feature").
3. When `AgentCleanup` was called with the internal name, `cleanup_agent` blindly appended the suffix again, resulting in `internal_name = "my-feature-gemini-gemini"` and `display_name = "💎 my-feature-gemini"`.
4. This caused `routing.json` lookup to fail and the window name to not match, skipping the window kill.

### Fix
- **Robust Identifier Handling**: Modified `cleanup_agent` to robustly derive the "clean" slug by stripping the agent type suffix if it's already present. This ensures that even if called with the internal name, it correctly identifies the window name and config directory.
- **Improved Discovery**: Updated `list_agents` to:
  - Strip suffixes from worktree names to get a clean `issue_id` and `slug`.
  - Avoid double-listing agents in `scan_workers` if they've already been found via their worktrees.

### Verification
- `cargo build -p exomonad-core` succeeds.
- Manual trace confirms that suffix doubling is now prevented and window names are correctly derived.
- Log message in `cleanup_agent` now correctly documents the identifier invariants.

Fixes window cleanup for Gemini leaf subtrees.
