### PR TITLE
feat: add task_list, task_get, task_update MCP tools for dev/worker roles

### DIFF
--- a/.exo/roles/devswarm/DevRole.hs
+++ b/.exo/roles/devswarm/DevRole.hs
@@ -16,6 +16,11 @@ import ExoMonad.Guest.Tools.Events
   ( notifyParentCore, notifyParentDescription, notifyParentSchema, NotifyParentArgs (..), NotifyStatus (..),
     shutdownCore, shutdownDescription, shutdownSchema, ShutdownArgs
   )
+import ExoMonad.Guest.Tools.Tasks
+  ( taskListCore, taskListDescription, taskListSchema, TaskListArgs,
+    taskGetCore, taskGetDescription, taskGetSchema, TaskGetArgs,
+    taskUpdateCore, taskUpdateDescription, taskUpdateSchema, TaskUpdateArgs
+  )
 import ExoMonad.Guest.StateMachine (applyEvent)
 import DevPhase (DevPhase (..), DevEvent (..))
 import HttpDevHooks (httpDevHooks)
@@ -68,11 +73,53 @@ instance MCPTool DevShutdown where
     void $ applyEvent @DevPhase @DevEvent DevSpawned ShutdownRequested
     shutdownCore args
 
+data DevTaskList
+
+instance MCPTool DevTaskList where
+  type ToolArgs DevTaskList = TaskListArgs
+  toolName = "task_list"
+  toolDescription = taskListDescription
+  toolSchema = taskListSchema
+  toolHandlerEff args = do
+    result <- taskListCore args
+    case result of
+      Left err -> pure $ errorResult err
+      Right output -> pure $ successResult output
+
+data DevTaskGet
+
+instance MCPTool DevTaskGet where
+  type ToolArgs DevTaskGet = TaskGetArgs
+  toolName = "task_get"
+  toolDescription = taskGetDescription
+  toolSchema = taskGetSchema
+  toolHandlerEff args = do
+    result <- taskGetCore args
+    case result of
+      Left err -> pure $ errorResult err
+      Right output -> pure $ successResult output
+
+data DevTaskUpdate
+
+instance MCPTool DevTaskUpdate where
+  type ToolArgs DevTaskUpdate = TaskUpdateArgs
+  toolName = "task_update"
+  toolDescription = taskUpdateDescription
+  toolSchema = taskUpdateSchema
+  toolHandlerEff args = do
+    result <- taskUpdateCore args
+    case result of
+      Left err -> pure $ errorResult err
+      Right output -> pure $ successResult output
+
 data Tools mode = Tools
   { pr :: mode :- DevFilePR,
     notifyParent :: mode :- DevNotifyParent,
     sendMessage :: mode :- SendMessage,
-    shutdown :: mode :- DevShutdown
+    shutdown :: mode :- DevShutdown,
+    taskList :: mode :- DevTaskList,
+    taskGet :: mode :- DevTaskGet,
+    taskUpdate :: mode :- DevTaskUpdate
   }
   deriving (Generic)
 
@@ -85,7 +132,10 @@ config =
           { pr = mkHandler @DevFilePR,
             notifyParent = mkHandler @DevNotifyParent,
             sendMessage = mkHandler @SendMessage,
-            shutdown = mkHandler @DevShutdown
+            shutdown = mkHandler @DevShutdown,
+            taskList = mkHandler @DevTaskList,
+            taskGet = mkHandler @DevTaskGet,
+            taskUpdate = mkHandler @DevTaskUpdate
           },
       hooks = httpDevHooks,
       eventHandlers = prReviewEventHandlers

--- a/.exo/roles/devswarm/WorkerRole.hs
+++ b/.exo/roles/devswarm/WorkerRole.hs
@@ -13,6 +13,11 @@ import ExoMonad.Guest.Tools.Events
   ( notifyParentCore, notifyParentDescription, notifyParentSchema, NotifyParentArgs,
     shutdownCore, shutdownDescription, shutdownSchema, ShutdownArgs
   )
+import ExoMonad.Guest.Tools.Tasks
+  ( taskListCore, taskListDescription, taskListSchema, TaskListArgs,
+    taskGetCore, taskGetDescription, taskGetSchema, TaskGetArgs,
+    taskUpdateCore, taskUpdateDescription, taskUpdateSchema, TaskUpdateArgs
+  )
 import ExoMonad.Guest.Types (allowResponse, allowStopResponse, postToolUseResponse)
 import ExoMonad.Types (HookConfig (..), defaultSessionStartHook)
 
@@ -40,10 +45,52 @@ instance MCPTool WorkerShutdown where
   toolSchema = shutdownSchema
   toolHandlerEff = shutdownCore
 
+data WorkerTaskList
+
+instance MCPTool WorkerTaskList where
+  type ToolArgs WorkerTaskList = TaskListArgs
+  toolName = "task_list"
+  toolDescription = taskListDescription
+  toolSchema = taskListSchema
+  toolHandlerEff args = do
+    result <- taskListCore args
+    case result of
+      Left err -> pure $ errorResult err
+      Right output -> pure $ successResult output
+
+data WorkerTaskGet
+
+instance MCPTool WorkerTaskGet where
+  type ToolArgs WorkerTaskGet = TaskGetArgs
+  toolName = "task_get"
+  toolDescription = taskGetDescription
+  toolSchema = taskGetSchema
+  toolHandlerEff args = do
+    result <- taskGetCore args
+    case result of
+      Left err -> pure $ errorResult err
+      Right output -> pure $ successResult output
+
+data WorkerTaskUpdate
+
+instance MCPTool WorkerTaskUpdate where
+  type ToolArgs WorkerTaskUpdate = TaskUpdateArgs
+  toolName = "task_update"
+  toolDescription = taskUpdateDescription
+  toolSchema = taskUpdateSchema
+  toolHandlerEff args = do
+    result <- taskUpdateCore args
+    case result of
+      Left err -> pure $ errorResult err
+      Right output -> pure $ successResult output
+
 data Tools mode = Tools
   { notifyParent :: mode :- WorkerNotifyParent,
     sendMessage :: mode :- SendMessage,
-    shutdown :: mode :- WorkerShutdown
+    shutdown :: mode :- WorkerShutdown,
+    taskList :: mode :- WorkerTaskList,
+    taskGet :: mode :- WorkerTaskGet,
+    taskUpdate :: mode :- WorkerTaskUpdate
   }
   deriving (Generic)
 
@@ -55,7 +102,10 @@ config =
         Tools
           { notifyParent = mkHandler @WorkerNotifyParent,
             sendMessage = mkHandler @SendMessage,
-            shutdown = mkHandler @WorkerShutdown
+            shutdown = mkHandler @WorkerShutdown,
+            taskList = mkHandler @WorkerTaskList,
+            taskGet = mkHandler @WorkerTaskGet,
+            taskUpdate = mkHandler @WorkerTaskUpdate
           },
       hooks =
         HookConfig

--- a/haskell/wasm-guest/src/ExoMonad/Effects/Session.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Effects/Session.hs
@@ -1,12 +1,9 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeFamilies #-}
 
--- | Session effects for registering Claude Code session IDs and Teams info.
 module ExoMonad.Effects.Session
-  ( SessionRegisterClaudeId,
-    SessionRegisterTeam,
-
-    -- * Proto types
+  ( SessionRegisterTeam,
+    SessionDeregisterTeam,
     module Effects.Session,
   )
 where
@@ -14,18 +11,14 @@ where
 import Effects.Session
 import ExoMonad.Effect.Class (Effect (..))
 
--- | Register Claude session ID effect.
-data SessionRegisterClaudeId
-
-instance Effect SessionRegisterClaudeId where
-  type Input SessionRegisterClaudeId = RegisterClaudeSessionRequest
-  type Output SessionRegisterClaudeId = RegisterClaudeSessionResponse
-  effectId = "session.register_claude_id"
-
--- | Register Claude Teams info effect.
 data SessionRegisterTeam
-
 instance Effect SessionRegisterTeam where
   type Input SessionRegisterTeam = RegisterTeamRequest
   type Output SessionRegisterTeam = RegisterTeamResponse
   effectId = "session.register_team"
+
+data SessionDeregisterTeam
+instance Effect SessionDeregisterTeam where
+  type Input SessionDeregisterTeam = DeregisterTeamRequest
+  type Output SessionDeregisterTeam = DeregisterTeamResponse
+  effectId = "session.deregister_team"

--- a/haskell/wasm-guest/src/ExoMonad/Effects/Tasks.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Effects/Tasks.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module ExoMonad.Effects.Tasks
+  ( TasksListTasks,
+    TasksGetTask,
+    TasksUpdateTask,
+    module Effects.Tasks,
+  )
+where
+
+import Effects.Tasks
+import ExoMonad.Effect.Class (Effect (..))
+
+data TasksListTasks
+instance Effect TasksListTasks where
+  type Input TasksListTasks = ListTasksRequest
+  type Output TasksListTasks = ListTasksResponse
+  effectId = "tasks.list_tasks"
+
+data TasksGetTask
+instance Effect TasksGetTask where
+  type Input TasksGetTask = GetTaskRequest
+  type Output TasksGetTask = GetTaskResponse
+  effectId = "tasks.get_task"
+
+data TasksUpdateTask
+instance Effect TasksUpdateTask where
+  type Input TasksUpdateTask = UpdateTaskRequest
+  type Output TasksUpdateTask = UpdateTaskResponse
+  effectId = "tasks.update_task"

--- a/haskell/wasm-guest/src/ExoMonad/Guest/Tools/Tasks.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Guest/Tools/Tasks.hs
@@ -1,0 +1,137 @@
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveGeneric #-}
+
+module ExoMonad.Guest.Tools.Tasks
+  ( TaskList, TaskListArgs(..), taskListCore, taskListDescription, taskListSchema,
+    TaskGet, TaskGetArgs(..), taskGetCore, taskGetDescription, taskGetSchema,
+    TaskUpdate, TaskUpdateArgs(..), taskUpdateCore, taskUpdateDescription, taskUpdateSchema,
+  )
+where
+
+import Control.Monad (void)
+import Control.Monad.Freer (Eff)
+import Data.Aeson (FromJSON, ToJSON, object, withObject, (.:), (.:?), (.=))
+import Data.Aeson qualified as Aeson
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Text.Lazy qualified as TL
+import Effects.Tasks qualified as Tasks
+import Effects.Log qualified as Log
+import ExoMonad.Effects.Tasks (TasksListTasks, TasksGetTask, TasksUpdateTask)
+import ExoMonad.Effects.Log (LogInfo)
+import ExoMonad.Guest.Tool.Schema (genericToolSchemaWith)
+import ExoMonad.Guest.Tool.SuspendEffect (suspendEffect, suspendEffect_)
+import ExoMonad.Guest.Types (Effects)
+import GHC.Generics (Generic)
+
+-- TaskList
+data TaskList
+
+data TaskListArgs = TaskListArgs
+  { tlStatusFilter :: Maybe Text
+  }
+  deriving (Show, Eq, Generic)
+
+instance FromJSON TaskListArgs where
+  parseJSON = withObject "TaskListArgs" $ \v ->
+    TaskListArgs
+      <$> v .:? "status_filter"
+
+taskListDescription :: Text
+taskListDescription = "List all tasks in the shared task list. Optionally filter by status (pending, in_progress, completed)."
+
+taskListSchema :: Aeson.Object
+taskListSchema = genericToolSchemaWith @TaskListArgs
+  [ ("status_filter", "Filter by status: pending, in_progress, completed. Empty for all.")
+  ]
+
+taskListCore :: TaskListArgs -> Eff Effects (Either Text Aeson.Value)
+taskListCore args = do
+  let req = Tasks.ListTasksRequest
+        { Tasks.listTasksRequestTeamName = "",
+          Tasks.listTasksRequestStatusFilter = maybe "" TL.fromStrict (tlStatusFilter args)
+        }
+  void $ suspendEffect_ @LogInfo (Log.InfoRequest {Log.infoRequestMessage = "TaskList: Calling list_tasks effect", Log.infoRequestFields = ""})
+  result <- suspendEffect @TasksListTasks req
+  case result of
+    Left err -> pure $ Left (T.pack (show err))
+    Right resp -> pure $ Right (Aeson.toJSON resp)
+
+-- TaskGet
+data TaskGet
+
+data TaskGetArgs = TaskGetArgs
+  { tgTaskId :: Text
+  }
+  deriving (Show, Eq, Generic)
+
+instance FromJSON TaskGetArgs where
+  parseJSON = withObject "TaskGetArgs" $ \v ->
+    TaskGetArgs
+      <$> v .: "task_id"
+
+taskGetDescription :: Text
+taskGetDescription = "Get a task by ID from the shared task list."
+
+taskGetSchema :: Aeson.Object
+taskGetSchema = genericToolSchemaWith @TaskGetArgs
+  [ ("task_id", "The task ID to retrieve")
+  ]
+
+taskGetCore :: TaskGetArgs -> Eff Effects (Either Text Aeson.Value)
+taskGetCore args = do
+  let req = Tasks.GetTaskRequest
+        { Tasks.getTaskRequestTeamName = "",
+          Tasks.getTaskRequestTaskId = TL.fromStrict (tgTaskId args)
+        }
+  void $ suspendEffect_ @LogInfo (Log.InfoRequest {Log.infoRequestMessage = "TaskGet: Calling get_task effect", Log.infoRequestFields = ""})
+  result <- suspendEffect @TasksGetTask req
+  case result of
+    Left err -> pure $ Left (T.pack (show err))
+    Right resp -> pure $ Right (Aeson.toJSON resp)
+
+-- TaskUpdate
+data TaskUpdate
+
+data TaskUpdateArgs = TaskUpdateArgs
+  { tuTaskId :: Text,
+    tuStatus :: Maybe Text,
+    tuOwner :: Maybe Text,
+    tuActiveForm :: Maybe Text
+  }
+  deriving (Show, Eq, Generic)
+
+instance FromJSON TaskUpdateArgs where
+  parseJSON = withObject "TaskUpdateArgs" $ \v ->
+    TaskUpdateArgs
+      <$> v .: "task_id"
+      <*> v .:? "status"
+      <*> v .:? "owner"
+      <*> v .:? "active_form"
+
+taskUpdateDescription :: Text
+taskUpdateDescription = "Update a task in the shared task list. Set status, owner, or activeForm."
+
+taskUpdateSchema :: Aeson.Object
+taskUpdateSchema = genericToolSchemaWith @TaskUpdateArgs
+  [ ("task_id", "The task ID to update"),
+    ("status", "The new status (optional)"),
+    ("owner", "The new owner (optional)"),
+    ("active_form", "The new activeForm (optional)")
+  ]
+
+taskUpdateCore :: TaskUpdateArgs -> Eff Effects (Either Text Aeson.Value)
+taskUpdateCore args = do
+  let req = Tasks.UpdateTaskRequest
+        { Tasks.updateTaskRequestTeamName = "",
+          Tasks.updateTaskRequestTaskId = TL.fromStrict (tuTaskId args),
+          Tasks.updateTaskRequestStatus = maybe "" TL.fromStrict (tuStatus args),
+          Tasks.updateTaskRequestOwner = maybe "" TL.fromStrict (tuOwner args),
+          Tasks.updateTaskRequestActiveForm = maybe "" TL.fromStrict (tuActiveForm args)
+        }
+  void $ suspendEffect_ @LogInfo (Log.InfoRequest {Log.infoRequestMessage = "TaskUpdate: Calling update_task effect", Log.infoRequestFields = ""})
+  result <- suspendEffect @TasksUpdateTask req
+  case result of
+    Left err -> pure $ Left (T.pack (show err))
+    Right resp -> pure $ Right (Aeson.toJSON resp)

--- a/haskell/wasm-guest/src/ExoMonad/Types.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Types.hs
@@ -144,6 +144,10 @@ teamRegistrationPostToolUse hookInput =
                 Log.errorRequestFields = ""
               })
       pure (postToolUseResponse Nothing)
+    Just "TeamDelete" -> do
+      void $ suspendEffect_ @Session.SessionDeregisterTeam
+        Session.DeregisterTeamRequest
+      pure (postToolUseResponse Nothing)
     _ -> pure (postToolUseResponse Nothing)
 
 -- | Extract team_name from TeamCreate's tool_response JSON.

--- a/haskell/wasm-guest/wasm-guest.cabal
+++ b/haskell/wasm-guest/wasm-guest.cabal
@@ -67,6 +67,7 @@ library wasm-guest-internal
         ExoMonad.Guest.Tools.MergePR
         ExoMonad.Guest.Tools.Spawn
         ExoMonad.Guest.Tools.Events
+        ExoMonad.Guest.Tools.Tasks
         ExoMonad.Guest.Prompt
         ExoMonad.Guest.Events
         ExoMonad.Guest.Events.Templates
@@ -101,6 +102,7 @@ library wasm-guest-internal
         ExoMonad.Effects.Coordination
         ExoMonad.Effects.Events
         ExoMonad.Effects.Session
+        ExoMonad.Effects.Tasks
         ExoMonad.Effects.KV
         ExoMonad.Effects.Process
         -- Types


### PR DESCRIPTION
Enables Gemini agents to read and update the shared Claude Code task list.
Adds SessionDeregisterTeam effect and TeamDelete PostToolUse hook.