### PR TITLE
fix: init refreshes stale WASM from global install

### DIFF
--- a/rust/exomonad/CLAUDE.md
+++ b/rust/exomonad/CLAUDE.md
@@ -45,6 +45,8 @@ exomonad shutdown                 # Gracefully shut down the running server
 
 `exomonad init` requires `exomonad new` to have been run first to bootstrap the project configuration and WASM plugins.
 
+Init also refreshes project-local WASM from `~/.exo/wasm/` if the global copy is newer (consuming projects only, not source projects with `.exo/roles/`).
+
 Claude MCP is auto-registered during init. For Gemini, register manually (`gemini mcp add ...`).
 
 Use `--recreate` to delete an existing session and create fresh (e.g., after binary updates).

--- a/rust/exomonad/src/init.rs
+++ b/rust/exomonad/src/init.rs
@@ -3,7 +3,7 @@ use crate::uds_client;
 use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 /// Run the init command: create or attach to tmux session.
 pub async fn run(session_override: Option<String>, recreate: bool) -> Result<()> {
@@ -74,9 +74,11 @@ pub async fn run(session_override: Option<String>, recreate: bool) -> Result<()>
     // Auto-build or copy WASM if it doesn't exist yet
     let wasm_filename = format!("wasm-guest-{}.wasm", config.wasm_name);
     let wasm_path = config.wasm_dir.join(&wasm_filename);
+    let roles_dir = cwd.join(".exo/roles");
+    let has_roles = roles_dir.is_dir();
+
     if !wasm_path.exists() {
-        let roles_dir = cwd.join(".exo/roles");
-        if roles_dir.is_dir() {
+        if has_roles {
             info!(path = %wasm_path.display(), "WASM not found, building...");
             exomonad::recompile::run_recompile(
                 &config.wasm_name,
@@ -107,6 +109,32 @@ pub async fn run(session_override: Option<String>, recreate: bool) -> Result<()>
                 path = %wasm_path.display(),
                 "No WASM found locally or at ~/.exo/wasm/. Run 'just install-all' in the exomonad repo, or copy roles: cp -r /path/to/exomonad/.exo/roles .exo/roles"
             );
+        }
+    } else if !has_roles {
+        // Refresh stale WASM from global install if it's newer
+        if let Ok(home) = std::env::var("HOME") {
+            let global_wasm = PathBuf::from(home).join(".exo/wasm").join(&wasm_filename);
+            if global_wasm.exists() {
+                let local_mtime = std::fs::metadata(&wasm_path).and_then(|m| m.modified());
+                let global_mtime = std::fs::metadata(&global_wasm).and_then(|m| m.modified());
+
+                match (local_mtime, global_mtime) {
+                    (Ok(local), Ok(global)) if global > local => {
+                        info!(
+                            src = %global_wasm.display(),
+                            dst = %wasm_path.display(),
+                            local_mtime = ?local,
+                            global_mtime = ?global,
+                            "Refreshing project WASM from global install (global is newer)"
+                        );
+                        std::fs::copy(&global_wasm, &wasm_path)?;
+                    }
+                    (Err(e), _) | (_, Err(e)) => {
+                        debug!(error = %e, "Failed to compare WASM mtimes, skipping refresh");
+                    }
+                    _ => {}
+                }
+            }
         }
     }
 


### PR DESCRIPTION
This PR updates `exomonad init` to refresh project-local WASM from `~/.exo/wasm/` when the global copy is newer.

Changes:
- In `rust/exomonad/src/init.rs`, added logic to check for updates from the global install if the project-local WASM exists and no `.exo/roles/` directory is present.
- Added `info!` logging when refreshing WASM: 'Refreshing project WASM from global install (global is newer)' with `src`, `dst`, `local_mtime`, and `global_mtime` fields.
- Silently skip refresh if mtime comparison fails (logged at `debug` level).
- Updated `rust/exomonad/CLAUDE.md` to document this behavior.

Verification:
- `cargo check -p exomonad` passed.
- `cargo test -p exomonad` passed.