### PR TITLE
feat: thread domain newtypes (BranchName, PRNumber, TeamName) through core services

### DIFF
--- a/rust/exomonad-core/src/handlers/agent.rs
+++ b/rust/exomonad-core/src/handlers/agent.rs
@@ -2,7 +2,7 @@
 //!
 //! Uses proto-generated types from `exomonad_proto::effects::agent`.
 
-use crate::domain::{AgentName, AgentPermissions, BirthBranch, ClaudeSessionUuid};
+use crate::domain::{AgentName, AgentPermissions, BirthBranch, ClaudeSessionUuid, TeamName};
 use crate::effects::{
     dispatch_agent_effect, AgentEffects, EffectError, EffectHandler, EffectResult, ResultExt,
     ResultExtPreserve,
@@ -437,7 +437,7 @@ impl AgentEffects for AgentHandler {
         registry.register(agent_name.clone(), conn).await;
 
         // Register as synthetic team member for Teams inbox delivery
-        let team_name = format!("exo-{}", ctx.birth_branch);
+        let team_name = TeamName::from(format!("exo-{}", ctx.birth_branch).as_str());
         if let Err(e) = crate::services::synthetic_members::register_synthetic_member(
             &team_name,
             agent_name,

--- a/rust/exomonad-core/src/handlers/file_pr.rs
+++ b/rust/exomonad-core/src/handlers/file_pr.rs
@@ -3,6 +3,7 @@
 //! Uses proto-generated types from `exomonad_proto::effects::file_pr`.
 
 use super::non_empty;
+use crate::domain::BranchName;
 use crate::effects::{
     dispatch_file_pr_effect, EffectHandler, EffectResult, FilePrEffects, ResultExt,
 };
@@ -62,7 +63,7 @@ impl FilePrEffects for FilePRHandler {
         ctx: &crate::effects::EffectContext,
     ) -> EffectResult<FilePrResponse> {
         tracing::info!(title = %req.title, "[FilePR] file_pr starting");
-        let base_branch = non_empty(req.base_branch);
+        let base_branch = non_empty(req.base_branch).map(|s| BranchName::from(s.as_str()));
 
         let working_dir = ctx.working_dir.clone();
 
@@ -108,8 +109,8 @@ impl FilePrEffects for FilePRHandler {
                 &serde_json::json!({
                     "pr_number": output.pr_number.as_u64(),
                     "pr_url": output.pr_url,
-                    "head_branch": output.head_branch,
-                    "base_branch": output.base_branch,
+                    "head_branch": output.head_branch.to_string(),
+                    "base_branch": output.base_branch.to_string(),
                     "created": output.created,
                     "title": input.title,
                 }),
@@ -121,8 +122,8 @@ impl FilePrEffects for FilePRHandler {
         Ok(FilePrResponse {
             pr_url: output.pr_url,
             pr_number: output.pr_number.as_u64() as i64,
-            head_branch: output.head_branch,
-            base_branch: output.base_branch,
+            head_branch: output.head_branch.to_string(),
+            base_branch: output.base_branch.to_string(),
             created: output.created,
         })
     }

--- a/rust/exomonad-core/src/services/agent_control.rs
+++ b/rust/exomonad-core/src/services/agent_control.rs
@@ -7,7 +7,7 @@
 
 use crate::common::TimeoutError;
 use crate::domain::{
-    AgentName, AgentPermissions, BirthBranch, ClaudeSessionUuid, ItemState, RoutingInfo,
+    AgentName, AgentPermissions, BirthBranch, ClaudeSessionUuid, ItemState, RoutingInfo, TeamName,
 };
 use crate::effects::EffectError;
 use crate::ffi::FFIBoundary;
@@ -1143,7 +1143,7 @@ impl AgentControlService {
                 .await?;
 
             // Register as synthetic team member for Claude Teams messaging
-            let team_name = format!("exo-{}", self.effective_birth_branch(Some(&ctx.birth_branch)));
+            let team_name = TeamName::from(format!("exo-{}", self.effective_birth_branch(Some(&ctx.birth_branch))).as_str());
             if let Err(e) = crate::services::synthetic_members::register_synthetic_member(
                 &team_name, &slug, "gemini-worker",
             ) {
@@ -1462,7 +1462,7 @@ impl AgentControlService {
                 .await?;
 
             // Register as synthetic team member for Claude Teams messaging
-            let team_name = format!("exo-{}", effective_birth);
+            let team_name = TeamName::from(format!("exo-{}", effective_birth).as_str());
             if let Err(e) = crate::services::synthetic_members::register_synthetic_member(
                 &team_name, &slug, "gemini-leaf",
             ) {
@@ -1529,7 +1529,7 @@ impl AgentControlService {
         };
 
         // Remove synthetic team member registration (non-fatal if not registered)
-        let team_name = format!("exo-{}", self.birth_branch);
+        let team_name = TeamName::from(format!("exo-{}", self.birth_branch).as_str());
         if let Err(e) =
             crate::services::synthetic_members::remove_synthetic_member(&team_name, &slug)
         {

--- a/rust/exomonad-core/src/services/file_pr.rs
+++ b/rust/exomonad-core/src/services/file_pr.rs
@@ -3,7 +3,7 @@
 // Shells out to `gh` for PR operations. `gh` handles auth, fork awareness,
 // and provides clear error messages. Octocrab stays for other GitHub operations.
 
-use crate::domain::PRNumber;
+use crate::domain::{BranchName, PRNumber};
 use crate::services::git;
 use crate::services::git_worktree::GitWorktreeService;
 use anyhow::{Context, Result};
@@ -22,7 +22,7 @@ use super::tmux_events;
 pub struct FilePRInput {
     pub title: String,
     pub body: String,
-    pub base_branch: Option<String>,
+    pub base_branch: Option<BranchName>,
     pub working_dir: Option<String>,
 }
 
@@ -30,8 +30,8 @@ pub struct FilePRInput {
 pub struct FilePROutput {
     pub pr_url: String,
     pub pr_number: PRNumber,
-    pub head_branch: String,
-    pub base_branch: String,
+    pub head_branch: BranchName,
+    pub base_branch: BranchName,
     pub created: bool,
 }
 
@@ -41,8 +41,8 @@ pub struct FilePROutput {
 struct GhPr {
     number: u64,
     url: String,
-    head_ref_name: String,
-    base_ref_name: String,
+    head_ref_name: BranchName,
+    base_ref_name: BranchName,
 }
 
 /// Structured errors for file_pr operations.
@@ -151,8 +151,8 @@ fn create_pr(
     Ok(GhPr {
         number,
         url,
-        head_ref_name: head.to_string(),
-        base_ref_name: base.to_string(),
+        head_ref_name: BranchName::from(head),
+        base_ref_name: BranchName::from(base),
     })
 }
 
@@ -181,14 +181,14 @@ pub async fn file_pr_async(
         .context("Failed to get workspace bookmark")?
         .ok_or_else(|| anyhow::anyhow!("No bookmark found for workspace at {}", dir))?;
 
-    let base = detect_base_branch(&head, input.base_branch.as_deref());
+    let base = BranchName::from(detect_base_branch(&head, input.base_branch.as_ref().map(|b| b.as_str())).as_str());
 
     info!("[FilePR] head={} base={} dir={}", head, base, dir);
 
     // Push first
     {
         let dir_path = std::path::PathBuf::from(dir);
-        let bookmark = crate::domain::BranchName::from(head.as_str());
+        let bookmark = BranchName::from(head.as_str());
         let git_wt_clone = git_wt.clone();
         tokio::task::spawn_blocking(move || git_wt_clone.push_bookmark(&dir_path, &bookmark))
             .await
@@ -225,7 +225,7 @@ pub async fn file_pr_async(
     let (title, body, base_clone, head_clone, dir_string) = (
         input.title.clone(),
         input.body.clone(),
-        base.clone(),
+        base.to_string(),
         head.clone(),
         dir.to_string(),
     );
@@ -242,7 +242,7 @@ pub async fn file_pr_async(
                 Ok(agent_id) => {
                     let event = crate::ui_protocol::AgentEvent::PrFiled {
                         agent_id,
-                        pr_number: pr.number,
+                        pr_number: PRNumber::new(pr.number),
                         timestamp: tmux_events::now_iso8601(),
                     };
                     if let Err(e) = tmux_events::emit_event(&session, &event) {

--- a/rust/exomonad-core/src/services/synthetic_members.rs
+++ b/rust/exomonad-core/src/services/synthetic_members.rs
@@ -1,3 +1,4 @@
+use crate::domain::TeamName;
 use anyhow::{Context, Result};
 use serde_json::Value;
 use std::path::PathBuf;
@@ -7,7 +8,7 @@ use tracing::info;
 ///
 /// Reads the existing config, appends to the members array, writes back atomically.
 pub fn register_synthetic_member(
-    team_name: &str,
+    team_name: &TeamName,
     member_name: &str,
     agent_type: &str,
 ) -> Result<()> {
@@ -17,7 +18,7 @@ pub fn register_synthetic_member(
 
 fn register_synthetic_member_at_path(
     config_path: &PathBuf,
-    team_name: &str,
+    team_name: &TeamName,
     member_name: &str,
     agent_type: &str,
 ) -> Result<()> {
@@ -71,14 +72,14 @@ fn register_synthetic_member_at_path(
 }
 
 /// Remove a synthetic member from a Claude Teams config.json.
-pub fn remove_synthetic_member(team_name: &str, member_name: &str) -> Result<()> {
+pub fn remove_synthetic_member(team_name: &TeamName, member_name: &str) -> Result<()> {
     let config_path = team_config_path(team_name)?;
     remove_synthetic_member_at_path(&config_path, team_name, member_name)
 }
 
 fn remove_synthetic_member_at_path(
     config_path: &PathBuf,
-    team_name: &str,
+    team_name: &TeamName,
     member_name: &str,
 ) -> Result<()> {
     let content = std::fs::read_to_string(config_path)
@@ -99,12 +100,12 @@ fn remove_synthetic_member_at_path(
     Ok(())
 }
 
-fn team_config_path(team_name: &str) -> Result<PathBuf> {
+fn team_config_path(team_name: &TeamName) -> Result<PathBuf> {
     let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("HOME directory not found"))?;
     Ok(home
         .join(".claude")
         .join("teams")
-        .join(team_name)
+        .join(team_name.as_str())
         .join("config.json"))
 }
 
@@ -117,7 +118,7 @@ mod tests {
     #[test]
     fn test_synthetic_member_lifecycle() -> Result<()> {
         let dir = tempdir()?;
-        let team_name = "test-team";
+        let team_name = TeamName::from("test-team");
         let config_path = dir.path().join("config.json");
 
         let initial_config = serde_json::json!({
@@ -132,7 +133,7 @@ mod tests {
         fs::write(&config_path, serde_json::to_string_pretty(&initial_config)?)?;
 
         // Register new member
-        register_synthetic_member_at_path(&config_path, team_name, "gemini-1", "gemini-worker")?;
+        register_synthetic_member_at_path(&config_path, &team_name, "gemini-1", "gemini-worker")?;
 
         let content = fs::read_to_string(&config_path)?;
         let config: Value = serde_json::from_str(&content)?;
@@ -141,13 +142,13 @@ mod tests {
         assert!(members.iter().any(|m| m["name"] == "gemini-1"));
 
         // Idempotent registration
-        register_synthetic_member_at_path(&config_path, team_name, "gemini-1", "gemini-worker")?;
+        register_synthetic_member_at_path(&config_path, &team_name, "gemini-1", "gemini-worker")?;
         let content = fs::read_to_string(&config_path)?;
         let config: Value = serde_json::from_str(&content)?;
         assert_eq!(config["members"].as_array().unwrap().len(), 2);
 
         // Remove member
-        remove_synthetic_member_at_path(&config_path, team_name, "gemini-1")?;
+        remove_synthetic_member_at_path(&config_path, &team_name, "gemini-1")?;
         let content = fs::read_to_string(&config_path)?;
         let config: Value = serde_json::from_str(&content)?;
         let members = config["members"].as_array().unwrap();

--- a/rust/exomonad-core/src/ui_protocol.rs
+++ b/rust/exomonad-core/src/ui_protocol.rs
@@ -6,6 +6,7 @@
 //! - **Telemetry**: Real-time progress and logs
 //! - **Control**: Commands for agent lifecycle management
 
+use crate::domain::PRNumber;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -70,7 +71,7 @@ pub enum AgentEvent {
     #[serde(rename = "pr:filed")]
     PrFiled {
         agent_id: AgentId,
-        pr_number: u64,
+        pr_number: PRNumber,
         timestamp: String,
     },
     #[serde(rename = "copilot:reviewed")]


### PR DESCRIPTION
This PR threads `BranchName`, `PRNumber`, and `TeamName` newtypes from `domain.rs` through the following files in `exomonad-core`:

- `rust/exomonad-core/src/services/file_pr.rs`
- `rust/exomonad-core/src/services/agent_control.rs`
- `rust/exomonad-core/src/services/synthetic_members.rs`
- `rust/exomonad-core/src/handlers/file_pr.rs`
- `rust/exomonad-core/src/handlers/agent.rs` (to maintain compilation)
- `rust/exomonad-core/src/ui_protocol.rs`

Key changes:
- `FilePROutput`, `GhPr`, and `FilePRInput` now use `BranchName` for branch fields.
- `AgentEvent::PrFiled` now uses `PRNumber` instead of `u64`.
- `register_synthetic_member` and `remove_synthetic_member` now take `&TeamName` instead of `&str`.
- Updated all call sites and tests to reflect these changes.

Verified with `cargo check -p exomonad-core` and library tests.