### PR TITLE
fix: support fresh repositories and headless initialization

### DIFF
--- a/rust/exomonad-core/src/domain.rs
+++ b/rust/exomonad-core/src/domain.rs
@@ -152,19 +152,19 @@ impl BirthBranch {
     /// Returns an error if git is not available or HEAD is detached.
     pub fn root() -> std::result::Result<Self, anyhow::Error> {
         let output = std::process::Command::new("git")
-            .args(["rev-parse", "--abbrev-ref", "HEAD"])
+            .args(["branch", "--show-current"])
             .output()
-            .map_err(|e| anyhow::anyhow!("Failed to execute git rev-parse: {}", e))?;
+            .map_err(|e| anyhow::anyhow!("Failed to execute git branch: {}", e))?;
 
         if !output.status.success() {
             anyhow::bail!(
-                "git rev-parse failed: {}",
+                "git branch --show-current failed: {}",
                 String::from_utf8_lossy(&output.stderr)
             );
         }
 
         let branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        if branch.is_empty() || branch == "HEAD" {
+        if branch.is_empty() {
             anyhow::bail!("HEAD is detached or branch name is empty");
         }
 

--- a/rust/exomonad-core/src/services/git.rs
+++ b/rust/exomonad-core/src/services/git.rs
@@ -134,7 +134,7 @@ impl GitService {
     #[tracing::instrument(skip(self))]
     pub async fn get_branch(&self, dir: &str) -> Result<String> {
         let output = self
-            .exec_git(dir, &["rev-parse", "--abbrev-ref", "HEAD"])
+            .exec_git(dir, &["branch", "--show-current"])
             .await?;
         Ok(output.trim().to_string())
     }

--- a/rust/exomonad-core/src/services/git_worktree.rs
+++ b/rust/exomonad-core/src/services/git_worktree.rs
@@ -195,7 +195,7 @@ impl GitWorktreeService {
         workspace_path: &Path,
     ) -> Result<Option<String>, WorktreeError> {
         let output = std::process::Command::new("git")
-            .args(["rev-parse", "--abbrev-ref", "HEAD"])
+            .args(["branch", "--show-current"])
             .current_dir(workspace_path)
             .output()
             .map_err(|e| WorktreeError::GitError {
@@ -336,7 +336,7 @@ mod tests {
 
     fn get_default_branch(repo_dir: &std::path::Path) -> String {
         let output = Command::new("git")
-            .args(["rev-parse", "--abbrev-ref", "HEAD"])
+            .args(["branch", "--show-current"])
             .current_dir(repo_dir)
             .output()
             .expect("failed to get default branch");

--- a/rust/exomonad/src/init.rs
+++ b/rust/exomonad/src/init.rs
@@ -7,9 +7,9 @@ use tracing::{debug, info, warn};
 
 /// Run the init command: create or attach to tmux session.
 pub async fn run(session_override: Option<String>, recreate: bool) -> Result<()> {
-    use exomonad_core::services::tmux_ipc::TmuxIpc;
-    use exomonad_core::services::AgentType;
-
+use exomonad_core::services::tmux_ipc::TmuxIpc;
+use exomonad_core::services::AgentType;
+use std::io::{IsTerminal, Write};
     let cwd = std::env::current_dir()?;
     let config_path = cwd.join(".exo/config.toml");
     if !config_path.exists() {
@@ -48,8 +48,12 @@ pub async fn run(session_override: Option<String>, recreate: bool) -> Result<()>
 
             if reachable {
                 info!(endpoint = %endpoint, "OTel endpoint reachable");
+            } else if config.yolo || !std::io::stdin().is_terminal() {
+                warn!(
+                    endpoint = %endpoint,
+                    "OTel endpoint unreachable — proceeding without tracing (YOLO or headless)"
+                );
             } else {
-                use std::io::Write;
                 eprint!(
                     "OTel endpoint {} unreachable — continue without tracing? [y/N] ",
                     endpoint

--- a/rust/exomonad/src/serve.rs
+++ b/rust/exomonad/src/serve.rs
@@ -158,15 +158,17 @@ pub async fn resolve_agent_birth_branch(
     // 1. Try worktree (subtrees have their own git branch)
     let worktree_path = worktree_base.join(slug);
     match tokio::process::Command::new("git")
-        .args(["rev-parse", "--abbrev-ref", "HEAD"])
+        .args(["branch", "--show-current"])
         .current_dir(&worktree_path)
         .output()
         .await
     {
         Ok(output) if output.status.success() => {
             let branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            tracing::debug!(agent = %agent_name, branch = %branch, "Resolved agent birth branch from worktree");
-            return Ok(BirthBranch::from(branch.as_str()));
+            if !branch.is_empty() {
+                tracing::debug!(agent = %agent_name, branch = %branch, "Resolved agent birth branch from worktree");
+                return Ok(BirthBranch::from(branch.as_str()));
+            }
         }
         _ => {}
     }


### PR DESCRIPTION
## Summary
The `exomonad` server fails to start in a newly initialized git repository that has no commits. Additionally, `exomonad init` hangs in headless/non-interactive environments due to an OTel reachability prompt.

## Fixes
1. **Robust Branch Resolution:** Replaced `git rev-parse --abbrev-ref HEAD` with `git branch --show-current` across the codebase.
2. **Non-Interactive Init:** Modified the OTel reachability check in `exomonad init` to bypass the confirmation prompt if `yolo = true` is set in `config.toml` or if the process is running in a non-interactive (non-TTY) environment.

## Verification
- Reproduced the crash in a fresh git repository.
- Verified that `git branch --show-current` correctly returns `main` in a commit-less repo.
- Rebuilt and verified `exomonad init --recreate` in a headless environment.
- Confirmed the server starts and binds to the Unix socket successfully.
- Verified the server is healthy via `curl --unix-socket`.