### PR TITLE
Refactor GitHub operations to use octocrab API instead of gh CLI

### DIFF
--- a/rust/exomonad-core/src/services/file_pr.rs
+++ b/rust/exomonad-core/src/services/file_pr.rs
@@ -1,13 +1,14 @@
-// File PR service - creates/updates GitHub PRs using `gh` CLI
+// File PR service - creates/updates GitHub PRs using GitHub API via octocrab
 //
-// Shells out to `gh` for PR operations. `gh` handles auth, fork awareness,
-// and provides clear error messages. Octocrab stays for other GitHub operations.
+// Replaces `gh` CLI subprocess calls with octocrab typed API.
 
 use crate::domain::{BranchName, PRNumber};
 use crate::services::git;
 use crate::services::git_worktree::GitWorktreeService;
+use crate::services::github::{build_octocrab, map_octo_err};
+use crate::services::repo;
 use anyhow::{Context, Result};
-use duct::cmd;
+use octocrab::params;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tracing::{info, warn};
@@ -35,7 +36,7 @@ pub struct FilePROutput {
     pub created: bool,
 }
 
-/// Parsed from `gh pr list/create/view --json` output.
+/// Parsed from GitHub API response.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct GhPr {
@@ -51,13 +52,13 @@ enum FilePrError {
     #[error("push failed: {0}")]
     Push(String),
 
-    #[error("gh pr create failed: {0}")]
+    #[error("GitHub PR create failed: {0}")]
     Create(String),
 
-    #[error("gh pr edit failed: {0}")]
+    #[error("GitHub PR edit failed: {0}")]
     Update(String),
 
-    #[error("gh pr list failed: {0}")]
+    #[error("GitHub PR list failed: {0}")]
     List(String),
 }
 
@@ -85,92 +86,89 @@ fn detect_base_branch(head: &str, explicit: Option<&str>) -> String {
 }
 
 // ============================================================================
-// `gh` CLI operations
+// Octocrab operations
 // ============================================================================
 
-fn find_existing_pr(head_branch: &str, dir: &str) -> Result<Option<GhPr>, FilePrError> {
-    let json = cmd!(
-        "gh",
-        "pr",
-        "list",
-        "--head",
-        head_branch,
-        "--state",
-        "open",
-        "--json",
-        "number,url,headRefName,baseRefName",
-        "--limit",
-        "1"
-    )
-    .dir(dir)
-    .read()
-    .map_err(|e| FilePrError::List(e.to_string()))?;
+async fn find_existing_pr(
+    octo: &octocrab::Octocrab,
+    owner: &str,
+    repo: &str,
+    head_branch: &str,
+) -> Result<Option<GhPr>, FilePrError> {
+    let page = octo
+        .pulls(owner, repo)
+        .list()
+        .head(head_branch)
+        .state(params::State::Open)
+        .per_page(1)
+        .send()
+        .await
+        .map_err(|e| FilePrError::List(map_octo_err(e)))?;
 
-    let prs: Vec<GhPr> =
-        serde_json::from_str(&json).map_err(|e| FilePrError::List(format!("JSON parse: {e}")))?;
-    Ok(prs.into_iter().next())
+    let pr = page.into_iter().next().map(|p| GhPr {
+        number: p.number,
+        url: p.html_url.map(|u| u.to_string()).unwrap_or_default(),
+        head_ref_name: BranchName::from(p.head.ref_field.as_str()),
+        base_ref_name: BranchName::from(p.base.ref_field.as_str()),
+    });
+    Ok(pr)
 }
 
-fn update_pr(number: PRNumber, title: &str, body: &str, dir: &str) -> Result<(), FilePrError> {
-    cmd!(
-        "gh",
-        "pr",
-        "edit",
-        number.to_string(),
-        "--title",
-        title,
-        "--body",
-        body
-    )
-    .dir(dir)
-    .read()
-    .map_err(|e| FilePrError::Update(e.to_string()))?;
+async fn update_pr(
+    octo: &octocrab::Octocrab,
+    owner: &str,
+    repo: &str,
+    number: PRNumber,
+    title: &str,
+    body: &str,
+) -> Result<(), FilePrError> {
+    octo.pulls(owner, repo)
+        .update(number.as_u64())
+        .title(title)
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| FilePrError::Update(map_octo_err(e)))?;
     Ok(())
 }
 
-fn create_pr(
+async fn create_pr(
+    octo: &octocrab::Octocrab,
+    owner: &str,
+    repo: &str,
     title: &str,
     body: &str,
     base: &str,
     head: &str,
-    dir: &str,
 ) -> Result<GhPr, FilePrError> {
-    // gh pr create outputs the PR URL to stdout (no --json support)
-    let url = cmd!(
-        "gh", "pr", "create", "--title", title, "--body", body, "--base", base, "--head", head
-    )
-    .dir(dir)
-    .read()
-    .map_err(|e| FilePrError::Create(e.to_string()))?;
-    let url = url.trim().to_string();
-    info!("[FilePR] Created PR: {}", url);
-
-    let number = parse_pr_number_from_url(&url)
-        .ok_or_else(|| FilePrError::Create(format!("could not parse PR number from URL: {url}")))?;
+    let pr = octo
+        .pulls(owner, repo)
+        .create(title, head, base)
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| FilePrError::Create(map_octo_err(e)))?;
 
     Ok(GhPr {
-        number,
-        url,
-        head_ref_name: BranchName::from(head),
-        base_ref_name: BranchName::from(base),
+        number: pr.number,
+        url: pr.html_url.map(|u| u.to_string()).unwrap_or_default(),
+        head_ref_name: BranchName::from(pr.head.ref_field.as_str()),
+        base_ref_name: BranchName::from(pr.base.ref_field.as_str()),
     })
-}
-
-/// Parse a PR number from a GitHub PR URL (e.g., "https://github.com/.../pull/123" → 123).
-fn parse_pr_number_from_url(url: &str) -> Option<u64> {
-    url.rsplit('/').next().and_then(|s| s.parse().ok())
 }
 
 // ============================================================================
 // Main implementation
 // ============================================================================
 
-/// File a PR using `gh` CLI. Pushes the branch, creates or updates the PR.
+/// File a PR using GitHub API. Pushes the branch, creates or updates the PR.
 pub async fn file_pr_async(
     input: &FilePRInput,
     git_wt: Arc<GitWorktreeService>,
 ) -> Result<FilePROutput> {
     let dir = input.working_dir.as_deref().unwrap_or(".");
+    let octo = build_octocrab()?;
+    let repo_info = repo::get_repo_info(dir).await?;
 
     // Get branch from the agent's working directory, not server CWD
     let dir_path = std::path::PathBuf::from(dir);
@@ -200,18 +198,19 @@ pub async fn file_pr_async(
     }
 
     // Check for existing PR
-    let head_clone = head.clone();
-    let dir_string = dir.to_string();
-    let existing = tokio::task::spawn_blocking(move || find_existing_pr(&head_clone, &dir_string))
-        .await
-        .context("spawn_blocking failed")??;
+    let existing = find_existing_pr(&octo, &repo_info.owner, &repo_info.repo, &head).await?;
     if let Some(pr) = existing {
         let pr_number = PRNumber::new(pr.number);
         info!("[FilePR] Updating existing PR #{}", pr_number);
-        let (title, body, dir_s) = (input.title.clone(), input.body.clone(), dir.to_string());
-        tokio::task::spawn_blocking(move || update_pr(pr_number, &title, &body, &dir_s))
-            .await
-            .context("spawn_blocking failed")??;
+        update_pr(
+            &octo,
+            &repo_info.owner,
+            &repo_info.repo,
+            pr_number,
+            &input.title,
+            &input.body,
+        )
+        .await?;
         info!("[FilePR] Updated PR #{}: {}", pr_number, pr.url);
         return Ok(FilePROutput {
             pr_url: pr.url,
@@ -224,18 +223,16 @@ pub async fn file_pr_async(
 
     // Create new PR
     info!("[FilePR] Creating PR: {}", input.title);
-    let (title, body, base_clone, head_clone, dir_string) = (
-        input.title.clone(),
-        input.body.clone(),
-        base.to_string(),
-        head.clone(),
-        dir.to_string(),
-    );
-    let pr = tokio::task::spawn_blocking(move || {
-        create_pr(&title, &body, &base_clone, &head_clone, &dir_string)
-    })
-    .await
-    .context("spawn_blocking failed")??;
+    let pr = create_pr(
+        &octo,
+        &repo_info.owner,
+        &repo_info.repo,
+        &input.title,
+        &input.body,
+        base.as_str(),
+        &head,
+    )
+    .await?;
 
     // Emit pr:filed event (only if in tmux session)
     if let Ok(session) = std::env::var("EXOMONAD_TMUX_SESSION") {
@@ -273,24 +270,6 @@ pub async fn file_pr_async(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_parse_pr_number_from_url() {
-        assert_eq!(
-            parse_pr_number_from_url("https://github.com/owner/repo/pull/123"),
-            Some(123)
-        );
-        assert_eq!(
-            parse_pr_number_from_url("https://github.com/owner/repo/pull/1"),
-            Some(1)
-        );
-        assert_eq!(parse_pr_number_from_url("not-a-url"), None);
-        assert_eq!(parse_pr_number_from_url(""), None);
-        assert_eq!(
-            parse_pr_number_from_url("https://github.com/owner/repo/pull/abc"),
-            None
-        );
-    }
 
     #[test]
     fn test_detect_base_branch_explicit() {
@@ -379,19 +358,16 @@ mod tests {
         let dir = temp_dir.path();
 
         // 1. Init git repo
-        cmd!("git", "init", "-b", "main").dir(dir).read()?;
-        cmd!("git", "config", "user.email", "test@example.com")
-            .dir(dir)
-            .read()?;
-        cmd!("git", "config", "user.name", "Test").dir(dir).read()?;
+        use std::process::Command;
+        Command::new("git").args(["init", "-b", "main"]).current_dir(dir).status()?;
+        Command::new("git").args(["config", "user.email", "test@example.com"]).current_dir(dir).status()?;
+        Command::new("git").args(["config", "user.name", "Test"]).current_dir(dir).status()?;
         std::fs::write(dir.join("README.md"), "test")?;
-        cmd!("git", "add", "README.md").dir(dir).read()?;
-        cmd!("git", "commit", "-m", "init").dir(dir).read()?;
+        Command::new("git").args(["add", "README.md"]).current_dir(dir).status()?;
+        Command::new("git").args(["commit", "-m", "init"]).current_dir(dir).status()?;
 
         // 2. Create a feature branch
-        cmd!("git", "checkout", "-b", "feature-branch")
-            .dir(dir)
-            .read()?;
+        Command::new("git").args(["checkout", "-b", "feature-branch"]).current_dir(dir).status()?;
         let git_wt = Arc::new(GitWorktreeService::new(dir.to_path_buf()));
 
         let input = FilePRInput {

--- a/rust/exomonad-core/src/services/github.rs
+++ b/rust/exomonad-core/src/services/github.rs
@@ -2,13 +2,45 @@ use crate::domain::{
     BranchName, CommitSha, IssueNumber, ItemState, PRNumber, ReviewState as DomainReviewState,
 };
 use crate::{FFIBoundary, GithubOwner, GithubRepo};
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use octocrab::{models, params, Octocrab, OctocrabBuilder};
 use serde::{Deserialize, Serialize};
 use tokio::time::{timeout, Duration};
 use tracing::info;
 
 const API_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Build an Octocrab client from GITHUB_TOKEN environment variable.
+///
+/// Returns actionable error messages if the token is missing.
+pub fn build_octocrab() -> Result<Octocrab> {
+    let token = std::env::var("GITHUB_TOKEN").map_err(|_| {
+        anyhow!("GitHub token required. Set GITHUB_TOKEN environment variable or run `gh auth login` to authenticate.")
+    })?;
+
+    if token.is_empty() {
+        return Err(anyhow!("GitHub token is empty. Set GITHUB_TOKEN environment variable or run `gh auth login` to authenticate."));
+    }
+
+    let client = OctocrabBuilder::new()
+        .personal_token(token)
+        .build()
+        .context("Failed to build Octocrab client")?;
+
+    Ok(client)
+}
+
+/// Map octocrab errors to user-friendly messages for GitHub API operations.
+pub fn map_octo_err(e: octocrab::Error) -> String {
+    if let octocrab::Error::GitHub { source, .. } = &e {
+        match source.status_code.as_u16() {
+            401 => return "GitHub authentication failed. Token may be expired. Run `gh auth login` to refresh, or set a valid GITHUB_TOKEN.".to_string(),
+            403 => return "GitHub token lacks required permissions. Ensure your token has `repo` scope.".to_string(),
+            _ => {}
+        }
+    }
+    e.to_string()
+}
 
 fn octocrab_issue_state(state: models::IssueState) -> ItemState {
     match state {
@@ -654,6 +686,23 @@ mod tests {
     use super::*;
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[test]
+    fn test_build_octocrab_missing_token() {
+        // Ensure GITHUB_TOKEN is not set for this test
+        let old_token = std::env::var("GITHUB_TOKEN").ok();
+        std::env::remove_var("GITHUB_TOKEN");
+        
+        let result = build_octocrab();
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("GitHub token required"));
+        
+        // Restore token if it was set
+        if let Some(t) = old_token {
+            std::env::set_var("GITHUB_TOKEN", t);
+        }
+    }
 
     async fn create_mock_service() -> (GitHubService, MockServer) {
         let mock_server = MockServer::start().await;

--- a/rust/exomonad-core/src/services/github_poller.rs
+++ b/rust/exomonad-core/src/services/github_poller.rs
@@ -3,10 +3,12 @@ use crate::plugin_manager::PluginManager;
 use crate::services::acp_registry::AcpRegistry;
 use crate::services::agent_control::AgentType;
 use crate::services::event_queue::EventQueue;
+use crate::services::github::{build_octocrab, map_octo_err};
 use crate::services::repo;
-use anyhow::{Context, Result};
+use anyhow::Result;
 use claude_teams_bridge::TeamRegistry;
 use exomonad_proto::effects::events::{event::EventType, AgentMessage, Event};
+use octocrab::{params, Octocrab};
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -28,6 +30,7 @@ pub struct GitHubPoller {
     acp_registry: Option<Arc<AcpRegistry>>,
     plugins: Option<PluginMap>,
     event_log: Option<Arc<super::event_log::EventLog>>,
+    octo: Option<Octocrab>,
 }
 
 /// A Copilot review comment with optional file context.
@@ -71,11 +74,6 @@ enum PendingAction {
         comments: Option<Vec<CopilotComment>>,
         reviews: Option<Vec<CopilotReview>>,
     },
-}
-
-#[derive(Deserialize)]
-struct GitHubUser {
-    login: String,
 }
 
 #[derive(Debug, Clone)]
@@ -285,6 +283,7 @@ impl GitHubPoller {
             acp_registry: None,
             plugins: None,
             event_log: None,
+            octo: build_octocrab().ok(),
         }
     }
 
@@ -522,45 +521,47 @@ impl GitHubPoller {
         }
 
         // 2. Fetch all open PRs
-        let endpoint = format!("/repos/{}/{}/pulls?state=open&per_page=100", owner, repo);
-        let output = Command::new("gh").args(["api", &endpoint]).output().await?;
+        let octo = match &self.octo {
+            Some(o) => o,
+            None => {
+                tracing::debug!("GitHubPoller: no octocrab client, skipping cycle");
+                return Ok(());
+            }
+        };
 
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            warn!("Failed to fetch PRs: {}", stderr.trim());
-            return Ok(());
-        }
+        let prs_page = octo
+            .pulls(&owner, &repo)
+            .list()
+            .state(params::State::Open)
+            .per_page(100)
+            .send()
+            .await;
 
-        #[derive(Deserialize)]
-        struct PR {
-            number: u64,
-            head: Head,
-        }
-        #[derive(Deserialize)]
-        struct Head {
-            sha: String,
-            #[serde(rename = "ref")]
-            ref_name: String,
-        }
-
-        let prs: Vec<PR> =
-            serde_json::from_slice(&output.stdout).context("Failed to parse PRs JSON")?;
+        let prs = match prs_page {
+            Ok(page) => page.into_iter().collect::<Vec<_>>(),
+            Err(e) => {
+                warn!("Failed to fetch PRs via Octocrab: {}", map_octo_err(e));
+                return Ok(());
+            }
+        };
 
         let mut pr_map = HashMap::new();
         for pr in prs {
-            pr_map.insert(pr.head.ref_name.clone(), pr);
+            let ref_name = pr.head.ref_field.clone();
+            let sha = pr.head.sha.clone();
+            pr_map.insert(ref_name, (pr.number, sha));
         }
 
         // 3. Match branches to PRs
         for wb in branches {
-            if let Some(pr) = pr_map.get(wb.branch.as_str()) {
+            if let Some((pr_number, pr_sha)) = pr_map.get(wb.branch.as_str()) {
                 if let Err(e) = self
                     .process_pr(
                         &owner,
                         &repo,
                         wb.branch.as_str(),
-                        PRNumber::new(pr.number),
-                        &pr.head.sha,
+                        PRNumber::new(*pr_number),
+                        pr_sha,
                         wb.agent_type,
                     )
                     .await
@@ -803,71 +804,63 @@ impl GitHubPoller {
         Ok(())
     }
 
-    /// Fetch Copilot review activity on a PR.
-    ///
-    /// Returns (inline_comments, review_bodies) where inline comments include
-    /// file path and diff hunk context for actionable feedback.
     async fn fetch_copilot_activity(
         &self,
         owner: &str,
         repo: &str,
         pr_number: PRNumber,
     ) -> Result<(Vec<CopilotComment>, Vec<CopilotReview>)> {
+        let octo = match &self.octo {
+            Some(o) => o,
+            None => return Ok((Vec::new(), Vec::new())),
+        };
+
         // Inline comments (with file context)
-        let endpoint = format!("/repos/{}/{}/pulls/{}/comments", owner, repo, pr_number);
-        let output = Command::new("gh").args(["api", &endpoint]).output().await?;
         let mut inline_comments = Vec::new();
+        let comments_page = octo
+            .pulls(owner, repo)
+            .list_comments(Some(pr_number.as_u64()))
+            .send()
+            .await;
 
-        if output.status.success() {
-            #[derive(Deserialize)]
-            struct Comment {
-                body: String,
-                user: GitHubUser,
-                path: Option<String>,
-                diff_hunk: Option<String>,
-            }
-
-            if let Ok(comments) = serde_json::from_slice::<Vec<Comment>>(&output.stdout) {
-                for c in comments {
-                    if c.user.login.to_lowercase().contains("copilot") {
-                        inline_comments.push(CopilotComment {
-                            body: c.body,
-                            path: c.path,
-                            diff_hunk: c.diff_hunk,
-                        });
-                    }
+        if let Ok(page) = comments_page {
+            for c in page {
+                let user_login = c.user.as_ref().map(|u| u.login.clone()).unwrap_or_default();
+                if user_login.to_lowercase().contains("copilot") {
+                    inline_comments.push(CopilotComment {
+                        body: c.body,
+                        path: Some(c.path),
+                        diff_hunk: Some(c.diff_hunk),
+                    });
                 }
             }
         }
 
         // Reviews (with body text and state)
-        let endpoint_reviews = format!("/repos/{}/{}/pulls/{}/reviews", owner, repo, pr_number);
-        let output_reviews = Command::new("gh")
-            .args(["api", &endpoint_reviews])
-            .output()
-            .await?;
         let mut copilot_reviews = Vec::new();
+        let reviews_page = octo
+            .pulls(owner, repo)
+            .list_reviews(pr_number.as_u64())
+            .send()
+            .await;
 
-        if output_reviews.status.success() {
-            #[derive(Deserialize)]
-            struct Review {
-                body: Option<String>,
-                state: String,
-                user: GitHubUser,
-            }
-            if let Ok(reviews) = serde_json::from_slice::<Vec<Review>>(&output_reviews.stdout) {
-                for r in reviews {
-                    if r.user.login.to_lowercase().contains("copilot") {
-                        let state = match r.state.as_str() {
-                            "APPROVED" => ReviewState::Approved,
-                            "CHANGES_REQUESTED" => ReviewState::ChangesRequested,
-                            _ => ReviewState::None,
-                        };
-                        copilot_reviews.push(CopilotReview {
-                            body: r.body.unwrap_or_default(),
-                            state,
-                        });
-                    }
+        if let Ok(page) = reviews_page {
+            for r in page {
+                let user_login = r.user.as_ref().map(|u| u.login.clone()).unwrap_or_default();
+                if user_login.to_lowercase().contains("copilot") {
+                    let state = match r.state {
+                        Some(octocrab::models::pulls::ReviewState::Approved) => {
+                            ReviewState::Approved
+                        }
+                        Some(octocrab::models::pulls::ReviewState::ChangesRequested) => {
+                            ReviewState::ChangesRequested
+                        }
+                        _ => ReviewState::None,
+                    };
+                    copilot_reviews.push(CopilotReview {
+                        body: r.body.unwrap_or_default(),
+                        state,
+                    });
                 }
             }
         }
@@ -876,25 +869,20 @@ impl GitHubPoller {
     }
 
     async fn fetch_ci_status(&self, owner: &str, repo: &str, sha: &str) -> Result<String> {
-        // gh api repos/{owner}/{repo}/commits/{sha}/check-runs
-        let endpoint = format!("/repos/{}/{}/commits/{}/check-runs", owner, repo, sha);
-        let output = Command::new("gh").args(["api", &endpoint]).output().await?;
+        let octo = match &self.octo {
+            Some(o) => o,
+            None => return Ok("unknown".to_string()),
+        };
 
-        if !output.status.success() {
-            return Ok("unknown".to_string());
-        }
-
-        #[derive(Deserialize)]
-        struct CheckRuns {
-            check_runs: Vec<CheckRun>,
-        }
-        #[derive(Deserialize)]
-        struct CheckRun {
-            conclusion: Option<String>,
-            status: String,
-        }
-
-        let runs: CheckRuns = serde_json::from_slice(&output.stdout)?;
+        let runs = match octo
+            .checks(owner, repo)
+            .list_check_runs_for_git_ref(octocrab::params::repos::Commitish(sha.to_string()))
+            .send()
+            .await
+        {
+            Ok(runs) => runs,
+            Err(_) => return Ok("unknown".to_string()),
+        };
 
         // Simplified logic: if any failure -> failure. If all success -> success. Else pending.
         let mut any_failure = false;
@@ -912,7 +900,7 @@ impl GitHubPoller {
                 _ => {
                     // Pending, skipped, neutral, etc.
                     // If it's not success or failure, it means we are not 'all_success'.
-                    if run.status == "in_progress" || run.status == "queued" {
+                    if run.completed_at.is_none() {
                         all_success = false;
                     }
                     // For now, if skipped, we treat as neutral (don't break all_success?)

--- a/rust/exomonad-core/src/services/merge_pr.rs
+++ b/rust/exomonad-core/src/services/merge_pr.rs
@@ -1,11 +1,12 @@
 use crate::domain::PRNumber;
-use anyhow::{Context, Result};
+use crate::services::git_worktree::GitWorktreeService;
+use crate::services::github::{build_octocrab, map_octo_err};
+use crate::services::repo;
+use anyhow::Result;
+use octocrab::params::pulls::MergeMethod;
 use std::sync::Arc;
-use tokio::process::Command;
 use tokio::time::Duration;
 use tracing::{error, info};
-
-use crate::services::git_worktree::GitWorktreeService;
 
 const MERGE_TIMEOUT: Duration = Duration::from_secs(120);
 
@@ -40,60 +41,67 @@ pub async fn merge_pr_async(
         "Merging PR"
     );
 
-    // Get branch name before merge to identify potential worktree
-    let branch_output = tokio::time::timeout(
-        Duration::from_secs(10),
-        Command::new("gh")
-            .args([
-                "pr",
-                "view",
-                &pr_number.to_string(),
-                "--json",
-                "headRefName",
-                "-q",
-                ".headRefName",
-            ])
-            .current_dir(dir)
-            .output(),
-    )
-    .await;
+    let octo = build_octocrab()?;
+    let repo_info = repo::get_repo_info(dir).await?;
 
-    let branch_name = match branch_output {
-        Ok(Ok(output)) if output.status.success() => {
-            String::from_utf8_lossy(&output.stdout).trim().to_string()
-        }
-        _ => String::new(),
+    // Get branch name before merge to identify potential worktree
+    let pr = match tokio::time::timeout(
+        Duration::from_secs(10),
+        octo.pulls(&repo_info.owner, &repo_info.repo)
+            .get(pr_number.as_u64()),
+    )
+    .await
+    {
+        Ok(Ok(pr)) => Some(pr),
+        _ => None,
     };
+
+    let branch_name = pr
+        .as_ref()
+        .map(|p| p.head.ref_field.clone())
+        .unwrap_or_default();
 
     if !branch_name.is_empty() {
         info!(branch_name = %branch_name, "PR branch name identified");
     }
 
-    // Step 1: gh pr merge
-    let strategy_flag = format!("--{}", strat);
-    let output = tokio::time::timeout(
-        MERGE_TIMEOUT,
-        Command::new("gh")
-            .args(["pr", "merge", &pr_number.to_string(), &strategy_flag])
-            .current_dir(dir)
-            .output(),
-    )
-    .await
-    .map_err(|_| anyhow::anyhow!("gh pr merge timed out after {}s", MERGE_TIMEOUT.as_secs()))?
-    .context("Failed to run gh pr merge")?;
+    // Step 1: merge PR
+    let merge_method = match strat {
+        "merge" => MergeMethod::Merge,
+        "squash" => MergeMethod::Squash,
+        "rebase" => MergeMethod::Rebase,
+        _ => MergeMethod::Squash,
+    };
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        error!(stderr = %stderr, "gh pr merge failed");
+    let result = tokio::time::timeout(
+        MERGE_TIMEOUT,
+        octo.pulls(&repo_info.owner, &repo_info.repo)
+            .merge(pr_number.as_u64())
+            .method(merge_method)
+            .send(),
+    )
+    .await;
+
+    let merge_res = match result {
+        Ok(Ok(res)) => Ok(res),
+        Ok(Err(e)) => Err(anyhow::anyhow!("GitHub merge failed: {}", map_octo_err(e))),
+        Err(_) => Err(anyhow::anyhow!(
+            "GitHub merge timed out after {}s",
+            MERGE_TIMEOUT.as_secs()
+        )),
+    };
+
+    if let Err(e) = merge_res {
+        error!(error = %e, "GitHub merge failed");
         return Ok(MergePROutput {
             success: false,
-            message: format!("gh pr merge failed: {}", stderr),
+            message: e.to_string(),
             git_fetched: false,
             branch_name,
         });
     }
 
-    let merge_msg = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let merge_res = merge_res.unwrap();
     info!(pr_number = pr_number.as_u64(), "PR merged successfully");
 
     // Step 2: git fetch (best-effort, pulls merged changes)
@@ -118,10 +126,14 @@ pub async fn merge_pr_async(
 
     Ok(MergePROutput {
         success: true,
-        message: if merge_msg.is_empty() {
-            format!("PR #{} merged via {}", pr_number, strat)
+        message: if let Some(msg) = merge_res.message {
+            if msg.is_empty() {
+                format!("PR #{} merged via {}", pr_number, strat)
+            } else {
+                msg
+            }
         } else {
-            merge_msg
+            format!("PR #{} merged via {}", pr_number, strat)
         },
         git_fetched,
         branch_name,


### PR DESCRIPTION
This PR replaces subprocess calls to the `gh` CLI with the typed `octocrab` API in `file_pr.rs`, `merge_pr.rs`, and `github_poller.rs`.

Key changes:
- Created `build_octocrab()` and `map_octo_err()` in `github.rs` for shared use.
- Replaced `duct::cmd!("gh", ...)` calls in `file_pr.rs` with asynchronous `octocrab` pull request operations.
- Replaced `tokio::process::Command::new("gh")` calls in `merge_pr.rs` with `octocrab` view and merge operations.
- Updated `github_poller.rs` to use `octocrab` for polling PRs, comments, reviews, and check runs.
- Added clear user-facing token validation error messages (401/403 support).
- Removed unused `gh` CLI dependency and related helper functions.
- Fixed 3 compile errors in `github_poller.rs` related to `Commitish` and `CheckRun` fields in `octocrab` 0.38.

All unit tests pass. CI status detection now correctly handles pending status by checking the absence of `completed_at`.