### PR TITLE
docs: ADR for octocrab migration

### DIFF
--- a/docs/decisions/use-octocrab-instead-of-gh-cli.md
+++ b/docs/decisions/use-octocrab-instead-of-gh-cli.md
@@ -4,7 +4,7 @@
 
 ## Context
 
-ExoMonad previously relied on shelling out to the `gh` CLI for all GitHub operations, including pull request creation (`file_pr`), merging (`merge_pr`), and status polling (`github_poller`). This approach had several drawbacks:
+ExoMonad previously relied on shelling out to the `gh` CLI for most GitHub operations, including pull request creation (`file_pr`), merging (`merge_pr`), and status polling (`github_poller`). This approach had several drawbacks:
 
 1.  **Fragility**: Parsing unstructured text or JSON output from a CLI tool is error-prone and sensitive to version changes.
 2.  **Subprocess Overhead**: Frequent subprocess spawning adds latency and resource consumption, especially in the background poller.
@@ -13,18 +13,20 @@ ExoMonad previously relied on shelling out to the `gh` CLI for all GitHub operat
 
 ## Decision
 
-Migrate all GitHub API operations within the ExoMonad server code from the `gh` CLI to [octocrab](https://github.com/XAMPPRocky/octocrab), a high-level, async GitHub API client for Rust.
+Migrate core GitHub API operations within the ExoMonad server code from the `gh` CLI to [octocrab](https://github.com/XAMPPRocky/octocrab), a high-level, async GitHub API client for Rust.
 
 The migration covers:
 *   **PR Management**: `file_pr` and `merge_pr` now use octocrab for all API calls.
 *   **Status Polling**: The `github_poller` background service uses octocrab to check PR review status and CI results.
-*   **Authentication**: The server now requires a `GITHUB_TOKEN` environment variable for authentication, moving away from the implicit `gh auth` state.
+*   **Authentication**: These operations now require a `GITHUB_TOKEN` environment variable for authentication, moving away from the implicit `gh auth` state.
+
+Note: Some specialized operations, such as the `copilot_review` service (which handles synchronous waiting for Copilot comments), still use the `gh` CLI as an interim measure until they can be fully ported to octocrab.
 
 ## Consequences
 
-*   **Type Safety**: All API requests and responses are now type-checked at compile time, reducing runtime parsing errors.
-*   **Proper Error Handling**: GitHub API errors are captured as structured `octocrab::Error` types, allowing for more granular error reporting in effect responses.
-*   **Async I/O**: Operations are fully integrated with the `tokio` async runtime, eliminating the need for `spawn_blocking` when interacting with GitHub.
-*   **No Subprocess Overhead**: API calls are made directly via `hyper` (used by octocrab), reducing resource usage.
-*   **Hybrid Tooling**: The `gh` CLI remains the primary tool for human operators and Claude Code's native GitHub tools. ExoMonad's server code uses octocrab exclusively, but it still interacts with the same git repository and GitHub state.
+*   **Type Safety**: API requests and responses for migrated paths are now type-checked at compile time, reducing runtime parsing errors.
+*   **Proper Error Handling**: GitHub API errors in migrated paths are captured as structured `octocrab::Error` types, allowing for more granular error reporting.
+*   **Async I/O**: Migrated operations are fully integrated with the `tokio` async runtime, eliminating `spawn_blocking` for those paths.
+*   **Reduced Subprocess Overhead**: API calls for PR management and polling are made directly via `hyper` (used by octocrab), reducing resource usage.
+*   **Hybrid Tooling**: The `gh` CLI remains a prerequisite for the ExoMonad server (validated at startup) and is still used by the `copilot_review` service. It also remains the primary tool for human operators and Claude Code's native GitHub tools.
 *   **Zero Logic in Rust**: In accordance with the project's core mandates, the *logic* of when to call these operations remains in Haskell WASM. Rust merely provides the I/O implementation for the GitHub effect namespace.


### PR DESCRIPTION
This PR adds an Architecture Decision Record documenting the migration from `gh` CLI to `octocrab` for GitHub API operations.

This decision was implemented in commit ca10eee4 to improve type safety, error handling, and performance by eliminating subprocess overhead and moving to async I/O for the core PR management and polling paths.

Updates in this version:
- Scoped "all GitHub operations" to core operations (PR management and poller).
- Acknowledged that the `copilot_review` service still uses the `gh` CLI as an interim measure.
- Clarified that the `gh` CLI is still a server prerequisite validated at startup.