### PR TITLE
feat: add kv.cleanup_stale_phases effect for dead branch cleanup

### DIFF
--- a/haskell/proto/src/Effects/Kv.hs
+++ b/haskell/proto/src/Effects/Kv.hs
@@ -241,3 +241,90 @@ instance (HsJSONPB.ToJSON SetResponse) where
   toEncoding = HsJSONPB.toAesonEncoding
 instance (HsJSONPB.FromJSON SetResponse) where
   parseJSON = HsJSONPB.parseJSONPB
+data CleanupStalePhasesRequest
+  = CleanupStalePhasesRequest {}
+  deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)
+instance (Hs.NFData CleanupStalePhasesRequest)
+instance (HsProtobuf.Named CleanupStalePhasesRequest) where
+  nameOf _ = Hs.fromString "CleanupStalePhasesRequest"
+instance (HsProtobuf.HasDefault CleanupStalePhasesRequest)
+instance (HsProtobuf.Message CleanupStalePhasesRequest) where
+  encodeMessage _ CleanupStalePhasesRequest {} = Hs.mempty
+  decodeMessage _ = Hs.pure CleanupStalePhasesRequest
+  dotProto _ = []
+instance (HsJSONPB.ToJSONPB CleanupStalePhasesRequest) where
+  toJSONPB CleanupStalePhasesRequest = HsJSONPB.object []
+  toEncodingPB CleanupStalePhasesRequest = HsJSONPB.pairs []
+instance (HsJSONPB.FromJSONPB CleanupStalePhasesRequest) where
+  parseJSONPB
+    = HsJSONPB.withObject
+        "CleanupStalePhasesRequest"
+        (\ obj -> Hs.pure CleanupStalePhasesRequest)
+instance (HsJSONPB.ToJSON CleanupStalePhasesRequest) where
+  toJSON = HsJSONPB.toAesonValue
+  toEncoding = HsJSONPB.toAesonEncoding
+instance (HsJSONPB.FromJSON CleanupStalePhasesRequest) where
+  parseJSON = HsJSONPB.parseJSONPB
+newtype CleanupStalePhasesResponse
+  = CleanupStalePhasesResponse {cleanupStalePhasesResponseDeletedKeys :: (Hs.Vector Hs.Text)}
+  deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic)
+instance (Hs.NFData CleanupStalePhasesResponse)
+instance (HsProtobuf.Named CleanupStalePhasesResponse) where
+  nameOf _ = Hs.fromString "CleanupStalePhasesResponse"
+instance (HsProtobuf.HasDefault CleanupStalePhasesResponse)
+instance (HsProtobuf.Message CleanupStalePhasesResponse) where
+  encodeMessage
+    _
+    CleanupStalePhasesResponse {cleanupStalePhasesResponseDeletedKeys}
+    = (HsProtobuf.encodeMessageField
+         (HsProtobuf.FieldNumber 1)
+         ((Hs.coerce
+             @(Hs.Vector Hs.Text)
+             @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)))
+            cleanupStalePhasesResponseDeletedKeys))
+  decodeMessage _
+    = Hs.pure CleanupStalePhasesResponse
+        <*>
+          ((HsProtobuf.coerceOver
+              @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text))
+              @(Hs.Vector Hs.Text))
+             (HsProtobuf.at
+                HsProtobuf.decodeMessageField (HsProtobuf.FieldNumber 1)))
+  dotProto _
+    = [HsProtobufAST.DotProtoField
+         (HsProtobuf.FieldNumber 1)
+         (HsProtobufAST.Repeated HsProtobufAST.String)
+         (HsProtobufAST.Single "deleted_keys") [] ""]
+instance (HsJSONPB.ToJSONPB CleanupStalePhasesResponse) where
+  toJSONPB (CleanupStalePhasesResponse f1)
+    = HsJSONPB.object
+        ["deleted_keys"
+           .=
+             ((Hs.coerce
+                 @(Hs.Vector Hs.Text)
+                 @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)))
+                f1)]
+  toEncodingPB (CleanupStalePhasesResponse f1)
+    = HsJSONPB.pairs
+        ["deleted_keys"
+           .=
+             ((Hs.coerce
+                 @(Hs.Vector Hs.Text)
+                 @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text)))
+                f1)]
+instance (HsJSONPB.FromJSONPB CleanupStalePhasesResponse) where
+  parseJSONPB
+    = HsJSONPB.withObject
+        "CleanupStalePhasesResponse"
+        (\ obj
+           -> Hs.pure CleanupStalePhasesResponse
+                <*>
+                  ((HsProtobuf.coerceOver
+                      @(HsProtobuf.UnpackedVec (HsProtobuf.String Hs.Text))
+                      @(Hs.Vector Hs.Text))
+                     (obj .: "deleted_keys")))
+instance (HsJSONPB.ToJSON CleanupStalePhasesResponse) where
+  toJSON = HsJSONPB.toAesonValue
+  toEncoding = HsJSONPB.toAesonEncoding
+instance (HsJSONPB.FromJSON CleanupStalePhasesResponse) where
+  parseJSON = HsJSONPB.parseJSONPB

--- a/haskell/wasm-guest/src/ExoMonad/Effects/KV.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Effects/KV.hs
@@ -21,6 +21,7 @@ module ExoMonad.Effects.KV
   ( -- * Effect Types
     KVGet,
     KVSet,
+    KVCleanupStalePhases,
 
     -- * Re-exported proto types
     module Effects.Kv,
@@ -48,3 +49,10 @@ instance Effect KVSet where
   type Input KVSet = SetRequest
   type Output KVSet = SetResponse
   effectId = "kv.set"
+
+data KVCleanupStalePhases
+
+instance Effect KVCleanupStalePhases where
+  type Input KVCleanupStalePhases = CleanupStalePhasesRequest
+  type Output KVCleanupStalePhases = CleanupStalePhasesResponse
+  effectId = "kv.cleanup_stale_phases"

--- a/haskell/wasm-guest/src/ExoMonad/Types.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Types.hs
@@ -26,6 +26,7 @@ import Data.Text qualified as T
 import Data.Text.Lazy qualified as TL
 import ExoMonad.Effects.Log (LogError, LogInfo)
 import ExoMonad.Effects.Log qualified as Log
+import ExoMonad.Effects.KV (KVCleanupStalePhases, CleanupStalePhasesRequest (..))
 import ExoMonad.Effects.Session qualified as Session
 import ExoMonad.Guest.Tool.SuspendEffect (suspendEffect, suspendEffect_)
 import ExoMonad.Guest.Events (EventHandlerConfig, defaultEventHandlers)
@@ -92,6 +93,7 @@ defaultSessionStartHook hookInput = do
         Nothing -> hiSessionId hookInput
   void $ suspendEffect_ @Session.SessionRegisterClaudeId
     (Session.RegisterClaudeSessionRequest { Session.registerClaudeSessionRequestClaudeSessionId = TL.fromStrict claudeUuid })
+  void $ suspendEffect_ @KVCleanupStalePhases (CleanupStalePhasesRequest {})
   let instruction = "Create a team using TeamCreate before proceeding."
   pure $
     HookOutput

--- a/proto/effects/kv.proto
+++ b/proto/effects/kv.proto
@@ -37,10 +37,22 @@ message SetResponse {
 }
 
 // ============================================================================
+// Cleanup - Remove KV files for dead branches
+// ============================================================================
+
+message CleanupStalePhasesRequest {}
+
+message CleanupStalePhasesResponse {
+  // List of keys (filenames without .json) that were deleted.
+  repeated string deleted_keys = 1;
+}
+
+// ============================================================================
 // Service definition (for schema generation, not gRPC)
 // ============================================================================
 
 service KvEffects {
   rpc Get(GetRequest) returns (GetResponse);
   rpc Set(SetRequest) returns (SetResponse);
+  rpc CleanupStalePhases(CleanupStalePhasesRequest) returns (CleanupStalePhasesResponse);
 }

--- a/rust/exomonad-core/src/handlers/kv.rs
+++ b/rust/exomonad-core/src/handlers/kv.rs
@@ -119,6 +119,75 @@ impl KvEffects for KvHandler {
         tracing::info!(key = %req.key, "kv.set: success");
         Ok(SetResponse { success: true })
     }
+
+    async fn cleanup_stale_phases(
+        &self,
+        _req: CleanupStalePhasesRequest,
+        _ctx: &crate::effects::EffectContext,
+    ) -> EffectResult<CleanupStalePhasesResponse> {
+        let dir = self.kv_dir();
+        let mut deleted_keys = Vec::new();
+
+        if !dir.exists() {
+            return Ok(CleanupStalePhasesResponse { deleted_keys });
+        }
+
+        let mut entries = tokio::fs::read_dir(&dir).await.map_err(|e| {
+            EffectError::custom("kv_error", format!("Failed to read kv directory: {}", e))
+        })?;
+
+        while let Ok(Some(entry)) = entries.next_entry().await {
+            let path = entry.path();
+            let file_name = match path.file_name().and_then(|s| s.to_str()) {
+                Some(s) => s,
+                None => continue,
+            };
+
+            if !file_name.starts_with("phase-") || !file_name.ends_with(".json") {
+                continue;
+            }
+
+            let key = &file_name[..file_name.len() - 5]; // Remove .json
+
+            // Determine if it should be deleted
+            let should_delete = if let Some(pos) = key.find("--") {
+                let sanitized_branch = &key[pos + 2..];
+                let branch = sanitized_branch.replace("--", ".");
+
+                // Check if branch exists
+                let output = tokio::process::Command::new("git")
+                    .current_dir(&self.project_dir)
+                    .args(["branch", "--list", &branch])
+                    .output()
+                    .await;
+
+                match output {
+                    Ok(out) => {
+                        let exists = !String::from_utf8_lossy(&out.stdout).trim().is_empty();
+                        !exists
+                    }
+                    Err(e) => {
+                        tracing::error!(error = %e, branch = %branch, "kv.cleanup: git branch check failed");
+                        false // Don't delete if we can't check
+                    }
+                }
+            } else {
+                // Legacy unscoped phase file (no -- branch suffix)
+                true
+            };
+
+            if should_delete {
+                tracing::info!(key = %key, path = %path.display(), "kv.cleanup: deleting stale phase file");
+                if let Err(e) = tokio::fs::remove_file(&path).await {
+                    tracing::error!(path = %path.display(), error = %e, "kv.cleanup: failed to delete file");
+                } else {
+                    deleted_keys.push(key.to_string());
+                }
+            }
+        }
+
+        Ok(CleanupStalePhasesResponse { deleted_keys })
+    }
 }
 
 #[cfg(test)]
@@ -238,6 +307,90 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.value, "v2");
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_stale_phases() {
+        let dir = tempfile::tempdir().unwrap();
+        let kv_dir = dir.path().join(".exo").join("kv");
+        tokio::fs::create_dir_all(&kv_dir).await.unwrap();
+
+        // Initialize git repo so we can check branches
+        tokio::process::Command::new("git")
+            .arg("init")
+            .current_dir(dir.path())
+            .output()
+            .await
+            .unwrap();
+
+        // Configure git so we can commit
+        tokio::process::Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(dir.path())
+            .output()
+            .await
+            .unwrap();
+        tokio::process::Command::new("git")
+            .args(["config", "user.name", "test"])
+            .current_dir(dir.path())
+            .output()
+            .await
+            .unwrap();
+
+        // Create main branch
+        tokio::fs::write(dir.path().join("file"), "").await.unwrap();
+        tokio::process::Command::new("git")
+            .args(["add", "file"])
+            .current_dir(dir.path())
+            .output()
+            .await
+            .unwrap();
+        tokio::process::Command::new("git")
+            .args(["commit", "-m", "init"])
+            .current_dir(dir.path())
+            .output()
+            .await
+            .unwrap();
+        tokio::process::Command::new("git")
+            .args(["branch", "-m", "main"])
+            .current_dir(dir.path())
+            .output()
+            .await
+            .unwrap();
+
+        let handler = KvHandler::new(dir.path().to_path_buf());
+        let ctx = test_ctx();
+
+        // Create some files
+        // 1. Valid branch "main"
+        tokio::fs::write(kv_dir.join("phase-tl--main.json"), "{}")
+            .await
+            .unwrap();
+        // 2. Dead branch
+        tokio::fs::write(kv_dir.join("phase-tl--dead--branch.json"), "{}")
+            .await
+            .unwrap();
+        // 3. Legacy file
+        tokio::fs::write(kv_dir.join("phase-tl.json"), "{}")
+            .await
+            .unwrap();
+        // 4. Non-phase file (should be ignored)
+        tokio::fs::write(kv_dir.join("other.json"), "{}")
+            .await
+            .unwrap();
+
+        let resp = handler
+            .cleanup_stale_phases(CleanupStalePhasesRequest {}, &ctx)
+            .await
+            .unwrap();
+
+        // Should have deleted: phase-tl--dead--branch and phase-tl
+        assert!(resp.deleted_keys.contains(&"phase-tl--dead--branch".to_string()));
+        assert!(resp.deleted_keys.contains(&"phase-tl".to_string()));
+        assert_eq!(resp.deleted_keys.len(), 2);
+
+        assert!(kv_dir.join("phase-tl--main.json").exists());
+        assert!(kv_dir.join("other.json").exists());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Adds `kv.cleanup_stale_phases` effect (proto, Rust handler, Haskell effect type)
- On SessionStart, scans `.exo/kv/phase-*.json`, checks if the branch still exists locally, deletes stale files
- Cleans up both scoped keys (`phase-tl--dev--auth.json`) and legacy unscoped keys (`phase-tl.json`)

## Test plan
- [ ] `cargo test -p exomonad-core --lib handlers::kv` passes
- [ ] `just wasm-all` builds successfully
- [ ] Manual: leave stale KV files from dead branch, restart session, verify cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)