### PR TITLE
feat: companion auto-spawn in exomonad init (Rust side)

### DIFF
--- a/haskell/wasm-guest/src/ExoMonad/Guest/Effects/AgentControl.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Guest/Effects/AgentControl.hs
@@ -57,17 +57,19 @@ import Proto3.Suite.Types (Enumerated (..))
 -- ============================================================================
 
 -- | Agent type for spawned agents.
-data AgentType = Claude | Gemini
+data AgentType = Claude | Gemini | Shoal
   deriving (Show, Eq, Generic)
 
 instance ToJSON AgentType where
   toJSON Claude = "claude"
   toJSON Gemini = "gemini"
+  toJSON Shoal = "shoal"
 
 instance FromJSON AgentType where
   parseJSON = withText "AgentType" $ \case
     "claude" -> pure Claude
     "gemini" -> pure Gemini
+    "shoal" -> pure Shoal
     other -> fail $ "Invalid agent type: " <> T.unpack other
 
 -- | Result of spawning an agent.
@@ -264,6 +266,7 @@ runAgentControlSuspend = interpret $ \case
 toProtoAgentType :: AgentType -> PA.AgentType
 toProtoAgentType Claude = PA.AgentTypeAGENT_TYPE_CLAUDE
 toProtoAgentType Gemini = PA.AgentTypeAGENT_TYPE_GEMINI
+toProtoAgentType Shoal = PA.AgentTypeAGENT_TYPE_SHOAL
 
 permissionsToProto :: ClaudePermissions -> PA.Permissions
 permissionsToProto perms =
@@ -282,5 +285,6 @@ protoAgentInfoToSpawnResult info =
       agentTypeResult = case PA.agentInfoAgentType info of
         Enumerated (Right PA.AgentTypeAGENT_TYPE_CLAUDE) -> "claude"
         Enumerated (Right PA.AgentTypeAGENT_TYPE_GEMINI) -> "gemini"
+        Enumerated (Right PA.AgentTypeAGENT_TYPE_SHOAL) -> "shoal"
         _ -> "unknown"
     }


### PR DESCRIPTION
This PR adds companion auto-spawn to `exomonad init`, enabling the simultaneous launch of multiple agents alongside the main Task Lead.

**Key Changes:**
-   **Config Enhancements (`rust/exomonad/src/config.rs`):**
    -   Added `CompanionConfig` struct for companion agent definitions (name, role, command, task).
    -   Updated `RawConfig` and `Config` to include a `companions` vector.
    -   Implemented resolution logic in `Config::discover()` to merge global and local companion settings (local overrides).
    -   Added unit tests for companion configuration parsing.
-   **Initialization Logic (`rust/exomonad/src/init.rs`):**
    -   Integrated a new spawning loop into the `run` function, executed after the server socket becomes healthy.
    -   For each companion:
        -   Creates a dedicated agent identity directory under `.exo/agents/`.
        -   Generates a `.birth_branch` identity file based on the current git branch.
        -   Writes an agent-specific `.mcp.json` pointing back to the `exomonad mcp-stdio` host.
        -   Configures persistent hook settings using `HookConfig::write_persistent`.
        -   Spawns a new tmux window for the companion using `TmuxIpc::new_window`.
        -   Records the tmux window ID in `routing.json` within the agent directory.

**Verification:**
-   Confirmed that `cargo test -p exomonad -- config` passes with the new `test_raw_config_parse_companions` test case.
-   Verified the project builds successfully with `cargo build -p exomonad`.
