### PR TITLE
feat: companion auto-spawn in exomonad init (Rust side)

### DIFF
--- a/rust/exomonad/src/config.rs
+++ b/rust/exomonad/src/config.rs
@@ -17,6 +17,24 @@ pub struct McpServerConfig {
     pub headers: std::collections::HashMap<String, String>,
 }
 
+/// Companion agent spawned alongside the TL during init.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CompanionConfig {
+    /// Agent name (used for tmux window, identity files).
+    pub name: String,
+    /// WASM role for MCP tools (default: "worker").
+    #[serde(default = "default_companion_role")]
+    pub role: String,
+    /// Command to launch (e.g., "claude --dangerously-skip-permissions -c").
+    pub command: String,
+    /// Task/prompt passed as positional arg to the command.
+    pub task: String,
+}
+
+fn default_companion_role() -> String {
+    "worker".to_string()
+}
+
 /// Raw configuration from file (supports both config.toml and config.local.toml fields).
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct RawConfig {
@@ -61,6 +79,10 @@ pub struct RawConfig {
     #[serde(default)]
     pub yolo: bool,
 
+    /// Companion agents to spawn alongside the TL.
+    #[serde(default)]
+    pub companions: Vec<CompanionConfig>,
+
     /// OTLP gRPC endpoint (e.g. "http://localhost:4317").
     /// If absent, OTel export is disabled (fmt-only tracing).
     pub otlp_endpoint: Option<String>,
@@ -91,6 +113,8 @@ pub struct Config {
     pub initial_prompt: Option<String>,
     /// When true, spawned Gemini agents receive `--yolo` flag.
     pub yolo: bool,
+    /// Companion agents to spawn alongside the TL.
+    pub companions: Vec<CompanionConfig>,
     /// OTLP gRPC endpoint (e.g. "http://localhost:4317").
     /// If absent, OTel export is disabled (fmt-only tracing).
     pub otlp_endpoint: Option<String>,
@@ -210,6 +234,12 @@ impl Config {
         // Resolve yolo: local > global > false
         let yolo = local_raw.yolo || global_raw.yolo;
 
+        let companions = if !local_raw.companions.is_empty() {
+            local_raw.companions
+        } else {
+            global_raw.companions
+        };
+
         // Resolve otlp_endpoint: local > global
         let otlp_endpoint = local_raw.otlp_endpoint.or(global_raw.otlp_endpoint);
 
@@ -226,6 +256,7 @@ impl Config {
             extra_mcp_servers,
             initial_prompt,
             yolo,
+            companions,
             otlp_endpoint,
         })
     }
@@ -257,6 +288,7 @@ impl Default for Config {
             extra_mcp_servers: std::collections::HashMap::new(),
             initial_prompt: None,
             yolo: false,
+            companions: Vec::new(),
             otlp_endpoint: None,
         }
     }
@@ -379,5 +411,19 @@ mod tests {
         "#;
         let raw: RawConfig = toml::from_str(content).unwrap();
         assert_eq!(raw.tmux_session, Some("exomonad".to_string()));
+    }
+
+    #[test]
+    fn test_raw_config_parse_companions() {
+        let content = r#"
+            [[companions]]
+            name = "sleeptime"
+            command = "claude -c"
+            task = "You are sleeptime"
+        "#;
+        let raw: RawConfig = toml::from_str(content).unwrap();
+        assert_eq!(raw.companions.len(), 1);
+        assert_eq!(raw.companions[0].name, "sleeptime");
+        assert_eq!(raw.companions[0].role, "worker");
     }
 }

--- a/rust/exomonad/src/init.rs
+++ b/rust/exomonad/src/init.rs
@@ -386,7 +386,66 @@ use std::io::{IsTerminal, Write};
     // 4. Poll for server socket
     wait_for_server_socket(&cwd).await?;
 
-    // 5. Attach
+    // 5. Spawn companion agents
+    for companion in &config.companions {
+        info!(name = %companion.name, role = %companion.role, "Spawning companion agent");
+
+        // Create agent identity directory
+        let agent_dir = cwd.join(".exo/agents").join(&companion.name);
+        std::fs::create_dir_all(&agent_dir)?;
+
+        // Write birth_branch identity
+        let birth_branch = format!(
+            "{}.{}",
+            std::process::Command::new("git")
+                .args(["branch", "--show-current"])
+                .current_dir(&cwd)
+                .output()
+                .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+                .unwrap_or_else(|_| "main".to_string()),
+            companion.name
+        );
+        std::fs::write(agent_dir.join(".birth_branch"), &birth_branch)?;
+
+        // Write .mcp.json for companion
+        let companion_mcp = serde_json::json!({
+            "mcpServers": {
+                "exomonad": {
+                    "type": "stdio",
+                    "command": "exomonad",
+                    "args": ["mcp-stdio", "--role", &companion.role, "--name", &companion.name]
+                }
+            }
+        });
+        std::fs::write(
+            agent_dir.join(".mcp.json"),
+            serde_json::to_string_pretty(&companion_mcp)?,
+        )?;
+
+        // Write hook config for companion
+        exomonad_core::hooks::HookConfig::write_persistent(&agent_dir, &binary_path, None)
+            .context("Failed to write companion hook configuration")?;
+
+        // Create tmux window for companion
+        let window_id = ipc.new_window(&companion.name, &cwd, &shell, &format!(
+            "{} '{}'",
+            companion.command,
+            companion.task.replace('\'', "'\\''")
+        )).await?;
+
+        // Write routing.json with window_id
+        let routing = serde_json::json!({
+            "window_id": window_id.as_str()
+        });
+        std::fs::write(
+            agent_dir.join("routing.json"),
+            serde_json::to_string_pretty(&routing)?,
+        )?;
+
+        info!(name = %companion.name, window = %window_id.as_str(), "Companion agent spawned");
+    }
+
+    // 6. Attach
     info!(session = %session, "Attaching to session");
     TmuxIpc::attach_session(&session).await
 }


### PR DESCRIPTION
This PR adds companion auto-spawn to `exomonad init`, enabling the simultaneous launch of multiple agents alongside the main Task Lead.

**Key Changes:**
-   **Config Enhancements (`rust/exomonad/src/config.rs`):**
    -   Added `CompanionConfig` struct for companion agent definitions (name, role, command, task).
    -   Updated `RawConfig` and `Config` to include a `companions` vector.
    -   Implemented resolution logic in `Config::discover()` to merge global and local companion settings (local overrides).
    -   Added unit tests for companion configuration parsing.
-   **Initialization Logic (`rust/exomonad/src/init.rs`):**
    -   Integrated a new spawning loop into the `run` function, executed after the server socket becomes healthy.
    -   For each companion:
        -   Creates a dedicated agent identity directory under `.exo/agents/`.
        -   Generates a `.birth_branch` identity file based on the current git branch.
        -   Writes an agent-specific `.mcp.json` pointing back to the `exomonad mcp-stdio` host.
        -   Configures persistent hook settings using `HookConfig::write_persistent`.
        -   Spawns a new tmux window for the companion using `TmuxIpc::new_window`.
        -   Records the tmux window ID in `routing.json` within the agent directory.

**Verification:**
-   Confirmed that `cargo test -p exomonad -- config` passes with the new `test_raw_config_parse_companions` test case.
-   Verified the project builds successfully with `cargo build -p exomonad`.