### PR TITLE
fix: target canonical paths in claudeMdExcludes for symlink resolution

### DIFF
--- a/rust/exomonad-core/src/hooks.rs
+++ b/rust/exomonad-core/src/hooks.rs
@@ -148,15 +148,25 @@ impl HookConfig {
         }
 
         // Exclude parent project's context files from worktree children.
-        // Without this, Claude Code's upward directory walk loads the parent's
-        // CLAUDE.md and rules alongside the child's own copies.
+        // Claude Code's boundary detection bug (CC #16600) causes worktrees
+        // nested inside a parent repo to inherit the parent's project root
+        // (it looks for .git/ directories, not .git files). This means the
+        // parent's CLAUDE.md and .claude/rules/ are loaded into the child.
+        //
+        // claudeMdExcludes matches against CANONICAL (realpath-resolved) paths,
+        // not logical symlink paths. The parent's .claude/rules/exomonad_role.md
+        // is a symlink to .exo/roles/{wasm}/context/{role}.md — we must exclude
+        // the canonical target path, not just .claude/rules/**.
         if let Some(parent_dir) = parent_project_dir {
             let canonical = parent_dir.canonicalize().unwrap_or(parent_dir.to_path_buf());
             let parent = canonical.to_string_lossy();
             settings["claudeMdExcludes"] = json!([
                 format!("{}/CLAUDE.md", parent),
                 format!("{}/CLAUDE.local.md", parent),
+                // Non-symlinked rules (canonical path matches logical path)
                 format!("{}/.claude/rules/**", parent),
+                // Symlinked role context files (canonical path after realpath resolution)
+                format!("{}/.exo/roles/**/context/**", parent),
             ]);
         }
 


### PR DESCRIPTION
## Summary
- Claude Code resolves symlinks via `realpath` before evaluating `claudeMdExcludes` patterns
- The parent's `.claude/rules/exomonad_role.md` symlink canonicalizes to `.exo/roles/{wasm}/context/{role}.md`
- The old pattern `.claude/rules/**` never matched the resolved canonical path
- Added `.exo/roles/**/context/**` to catch symlinked role context files at their canonical location

## Context
Research confirmed CC's boundary detection bug (CC #16600): worktrees nested inside a parent repo inherit the parent's project root because CC looks for `.git/` directories, not `.git` files. Combined with unconditional symlink canonicalization, `claudeMdExcludes` patterns must target the realpath-resolved paths, not the logical symlink paths.

## Test plan
- [ ] Restart server with new binary
- [ ] Spawn a TL child via `fork_wave`
- [ ] Verify child sees only `tl.md` role context, NOT `root.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)