### PR TITLE
feat: implement TestHarness for E2E testing

### DIFF
--- a/rust/exomonad/Cargo.toml
+++ b/rust/exomonad/Cargo.toml
@@ -14,6 +14,10 @@ autobins = false
 name = "exomonad"
 path = "src/main.rs"
 
+[[test]]
+name = "e2e"
+path = "../../tests/e2e/mod.rs"
+
 [dependencies]
 exomonad-core = { path = "../exomonad-core", version = "0.1.0" }
 claude-teams-bridge = { path = "../claude-teams-bridge", version = "0.1.0" }

--- a/tests/e2e/harness.rs
+++ b/tests/e2e/harness.rs
@@ -1,0 +1,207 @@
+use std::fs;
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use tempfile::TempDir;
+use anyhow::{Result, anyhow};
+
+pub struct TestHarness {
+    pub tmpdir: TempDir,
+    pub project_dir: PathBuf,
+    pub mock_github_process: Child,
+    pub mock_github_port: u16,
+    pub mock_gh_path: PathBuf,
+    pub tmux_session: String,
+}
+
+impl TestHarness {
+    pub fn build() -> Result<Self> {
+        let tmpdir = TempDir::new()?;
+        let tmpdir_path = tmpdir.path().to_path_buf();
+
+        // 1. Create bare git remote
+        let remote_dir = tmpdir_path.join("remote.git");
+        fs::create_dir_all(&remote_dir)?;
+        let status = Command::new("git")
+            .arg("init")
+            .arg("--bare")
+            .arg("-q")
+            .current_dir(&remote_dir)
+            .status()?;
+        if !status.success() {
+            return Err(anyhow!("Failed to init bare remote git repo"));
+        }
+
+        // 2. Create project repo
+        let project_dir = tmpdir_path.join("project");
+        fs::create_dir_all(&project_dir)?;
+        let status = Command::new("git")
+            .arg("init")
+            .arg("-q")
+            .current_dir(&project_dir)
+            .status()?;
+        if !status.success() {
+            return Err(anyhow!("Failed to init project git repo"));
+        }
+
+        Command::new("git")
+            .args(["remote", "add", "origin", "../remote.git"])
+            .current_dir(&project_dir)
+            .status()?;
+
+        // Initial commit
+        fs::write(project_dir.join("README.md"), "# Test Project")?;
+        Command::new("git").args(["add", "README.md"]).current_dir(&project_dir).status()?;
+        Command::new("git")
+            .args(["-c", "user.name=Test", "-c", "user.email=test@test.com", "commit", "-m", "initial commit", "-q"])
+            .current_dir(&project_dir)
+            .status()?;
+
+        // 3. Copy WASM
+        let mut workspace_root = std::env::var("CARGO_MANIFEST_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| PathBuf::from("."));
+
+        while workspace_root.parent().is_some() && !workspace_root.join("justfile").exists() {
+            workspace_root = workspace_root.parent().unwrap().to_path_buf();
+        }
+
+        let wasm_src = workspace_root.join(".exo/wasm");
+        let wasm_dest = project_dir.join(".exo/wasm");
+        if wasm_src.exists() {
+            fs::create_dir_all(&wasm_dest)?;
+            for entry in fs::read_dir(wasm_src)? {
+                let entry = entry?;
+                if entry.file_type()?.is_file() {
+                    fs::copy(entry.path(), wasm_dest.join(entry.file_name()))?;
+                }
+            }
+        }
+
+        // 4. Write minimal config.toml
+        let config_path = project_dir.join(".exo/config.toml");
+        fs::create_dir_all(project_dir.join(".exo"))?;
+        fs::write(config_path, "default_role = \"tl\"\nproject_dir = \".\"\n")?;
+
+        // 5. Copy mock_gh
+        let mock_gh_src = workspace_root.join("tests/e2e/mock_gh");
+        let mock_gh_dest = tmpdir_path.join("mock_gh");
+        fs::copy(&mock_gh_src, &mock_gh_dest)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs::metadata(&mock_gh_dest)?.permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(&mock_gh_dest, perms)?;
+        }
+
+        // 6. Start mock_github.py on a random port
+        let port = {
+            let listener = std::net::TcpListener::bind("127.0.0.1:0")?;
+            listener.local_addr()?.port()
+        };
+        let mock_github_src = workspace_root.join("tests/e2e/mock_github.py");
+
+        let mock_github_process = Command::new("python3")
+            .arg(&mock_github_src)
+            .arg("--port")
+            .arg(port.to_string())
+            .stderr(Stdio::null())
+            .spawn()?;
+
+        // 7. Generate unique tmux session name
+        let tmux_session = format!("exo-test-{}", std::process::id());
+
+        Ok(TestHarness {
+            tmpdir,
+            project_dir,
+            mock_github_process,
+            mock_github_port: port,
+            mock_gh_path: mock_gh_dest,
+            tmux_session,
+        })
+    }
+
+    pub fn mock_github_port(&self) -> u16 {
+        self.mock_github_port
+    }
+
+    pub fn tmux_list_windows(&self) -> Vec<String> {
+        let output = Command::new("tmux")
+            .args(["list-windows", "-t", &self.tmux_session])
+            .output();
+        
+        match output {
+            Ok(out) if out.status.success() => {
+                String::from_utf8_lossy(&out.stdout)
+                    .lines()
+                    .map(|s| s.to_string())
+                    .collect()
+            }
+            _ => Vec::new(),
+        }
+    }
+
+    pub fn git_branches(&self) -> Vec<String> {
+        let output = Command::new("git")
+            .arg("branch")
+            .current_dir(&self.project_dir)
+            .output();
+
+        match output {
+            Ok(out) if out.status.success() => {
+                String::from_utf8_lossy(&out.stdout)
+                    .lines()
+                    .map(|s| s.trim().trim_start_matches('*').trim().to_string())
+                    .collect()
+            }
+            _ => Vec::new(),
+        }
+    }
+
+    pub fn file_exists(&self, path: &str) -> bool {
+        self.project_dir.join(path).exists()
+    }
+}
+
+impl Drop for TestHarness {
+    fn drop(&mut self) {
+        // Kill tmux session
+        let _ = Command::new("tmux")
+            .args(["kill-session", "-t", &self.tmux_session])
+            .status();
+
+        // Kill mock_github process
+        let _ = self.mock_github_process.kill();
+        let _ = self.mock_github_process.wait();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+    use std::net::TcpStream;
+
+    #[tokio::test]
+    async fn test_harness_setup() -> Result<(), Box<dyn std::error::Error>> {
+        let harness = TestHarness::build()?;
+        
+        // Verify project dir exists
+        assert!(harness.project_dir.exists());
+        assert!(harness.project_dir.join(".git").exists());
+        assert!(harness.project_dir.join(".exo/config.toml").exists());
+
+        // Wait a bit for mock_github to start
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        // Verify mock_github responds (port is open)
+        let addr = format!("127.0.0.1:{}", harness.mock_github_port);
+        let stream = TcpStream::connect(addr)?;
+        drop(stream);
+
+        // Verify mock_gh exists and is executable
+        assert!(harness.mock_gh_path.exists());
+        
+        Ok(())
+    }
+}

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -1,0 +1,1 @@
+pub mod harness;


### PR DESCRIPTION
## Summary
- Implements `TestHarness` struct in `tests/e2e/harness.rs` with isolated project setup, mock GitHub server, and mock gh CLI
- Setup: tmpdir with bare git remote, project repo, mock services
- Probe helpers: tmux_list_windows, git_branches, file_exists
- Drop impl for cleanup

## Test plan
- [x] `cargo check --tests` passes
- [x] Harness setup test verifies project dir and mock services

🤖 Generated with [Claude Code](https://claude.com/claude-code)