### PR TITLE
type-safety: EventLog::append uses &AgentName

### DIFF
--- a/rust/exomonad-core/src/handlers/agent.rs
+++ b/rust/exomonad-core/src/handlers/agent.rs
@@ -238,7 +238,7 @@ impl AgentEffects for AgentHandler {
         if let Some(ref log) = self.event_log {
             let _ = log.append(
                 "agent.spawned",
-                ctx.agent_name.as_ref(),
+                &ctx.agent_name,
                 &serde_json::json!({
                     "child_agent": agent_info.id, "agent_type": "gemini", "spawn_type": "worker",
                     "branch": agent_info.branch_name,
@@ -329,7 +329,7 @@ impl AgentEffects for AgentHandler {
         if let Some(ref log) = self.event_log {
             let _ = log.append(
                 "agent.spawned",
-                ctx.agent_name.as_ref(),
+                &ctx.agent_name,
                 &serde_json::json!({
                     "child_agent": agent_info.id, "agent_type": "claude", "spawn_type": "subtree",
                     "branch": agent_info.branch_name,
@@ -378,7 +378,7 @@ impl AgentEffects for AgentHandler {
             "[event] agent.spawned"
         );
         if let Some(ref log) = self.event_log {
-            let _ = log.append("agent.spawned", ctx.agent_name.as_ref(), &serde_json::json!({
+            let _ = log.append("agent.spawned", &ctx.agent_name, &serde_json::json!({
                 "child_agent": agent_info.id, "agent_type": "gemini", "spawn_type": "leaf_subtree",
                 "branch": agent_info.branch_name,
             }));
@@ -484,7 +484,7 @@ impl AgentEffects for AgentHandler {
         if let Some(ref log) = self.event_log {
             let _ = log.append(
                 "agent.spawned",
-                ctx.agent_name.as_ref(),
+                &ctx.agent_name,
                 &serde_json::json!({
                     "child_agent": agent_info.id, "agent_type": "gemini", "spawn_type": "acp",
                     "branch": agent_info.branch_name,

--- a/rust/exomonad-core/src/handlers/file_pr.rs
+++ b/rust/exomonad-core/src/handlers/file_pr.rs
@@ -105,7 +105,7 @@ impl FilePrEffects for FilePRHandler {
         if let Some(ref log) = self.event_log {
             if let Err(e) = log.append(
                 event_type,
-                ctx.agent_name.as_ref(),
+                &ctx.agent_name,
                 &serde_json::json!({
                     "pr_number": output.pr_number.as_u64(),
                     "pr_url": output.pr_url,

--- a/rust/exomonad-core/src/handlers/log.rs
+++ b/rust/exomonad-core/src/handlers/log.rs
@@ -163,8 +163,7 @@ impl LogEffects for LogHandler {
                 serde_json::from_slice(&req.payload)
                     .unwrap_or(serde_json::json!({"raw": payload_str}))
             };
-            let agent_id = ctx.agent_name.to_string();
-            if let Err(e) = log.append(&req.event_type, &agent_id, &data) {
+            if let Err(e) = log.append(&req.event_type, &ctx.agent_name, &data) {
                 tracing::warn!(error = %e, "Failed to write event to JSONL log");
             }
         }

--- a/rust/exomonad-core/src/handlers/merge_pr.rs
+++ b/rust/exomonad-core/src/handlers/merge_pr.rs
@@ -63,7 +63,7 @@ impl MergePrEffects for MergePRHandler {
             if let Some(ref log) = self.event_log {
                 let _ = log.append(
                     "pr.merged",
-                    ctx.agent_name.as_ref(),
+                    &ctx.agent_name,
                     &serde_json::json!({
                         "pr_number": pr_number.as_u64(),
                         "strategy": req.strategy,
@@ -81,7 +81,7 @@ impl MergePrEffects for MergePRHandler {
             if let Some(ref log) = self.event_log {
                 let _ = log.append(
                     "pr.merge_failed",
-                    ctx.agent_name.as_ref(),
+                    &ctx.agent_name,
                     &serde_json::json!({
                         "pr_number": pr_number.as_u64(),
                         "error": &result.message,

--- a/rust/exomonad-core/src/services/delivery.rs
+++ b/rust/exomonad-core/src/services/delivery.rs
@@ -1,3 +1,4 @@
+use crate::domain::AgentName;
 use crate::services::acp_registry::AcpRegistry;
 use crate::services::event_queue::EventQueue;
 use crate::services::tmux_events;
@@ -79,7 +80,7 @@ pub async fn notify_parent_delivery(
     if let Some(log) = event_log {
         let _ = log.append(
             "agent.notify_parent",
-            agent_id,
+            &AgentName::from(agent_id),
             &serde_json::json!({
                 "parent": parent_session_id,
                 "status": status,

--- a/rust/exomonad-core/src/services/event_log.rs
+++ b/rust/exomonad-core/src/services/event_log.rs
@@ -3,6 +3,7 @@
 //! Writes one JSON line per event to `.exo/events.jsonl` for post-hoc
 //! reconstruction of agent runs. Query with DuckDB or jq.
 
+use crate::domain::AgentName;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
@@ -30,7 +31,7 @@ impl EventLog {
     pub fn append(
         &self,
         event_type: &str,
-        agent_id: &str,
+        agent_id: &AgentName,
         data: &serde_json::Value,
     ) -> std::io::Result<String> {
         let event_id = uuid::Uuid::new_v4().to_string();
@@ -40,11 +41,11 @@ impl EventLog {
             "ts": ts,
             "id": event_id,
             "type": event_type,
-            "agent_id": agent_id,
+            "agent_id": agent_id.as_ref(),
             "data": data,
         });
 
-        let sanitized_id = agent_id.replace(['/', '\\', '\0'], "_");
+        let sanitized_id = agent_id.as_ref().replace(['/', '\\', '\0'], "_");
         let path = self.dir.join(format!("{}.jsonl", sanitized_id));
 
         let _guard = self.lock.lock().unwrap_or_else(|e| e.into_inner());
@@ -75,7 +76,9 @@ mod tests {
         let log = EventLog::open(dir.path().to_path_buf()).unwrap();
 
         let data = serde_json::json!({"slug": "feature-a", "agent_type": "claude"});
-        let id = log.append("agent.spawned", "root", &data).unwrap();
+        let id = log
+            .append("agent.spawned", &AgentName::from("root"), &data)
+            .unwrap();
         assert!(!id.is_empty());
 
         let path = dir.path().join("root.jsonl");
@@ -93,8 +96,18 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let log = EventLog::open(dir.path().to_path_buf()).unwrap();
 
-        log.append("a", "agent-x", &serde_json::json!({})).unwrap();
-        log.append("b", "agent-y", &serde_json::json!({})).unwrap();
+        log.append(
+            "a",
+            &AgentName::from("agent-x"),
+            &serde_json::json!({}),
+        )
+        .unwrap();
+        log.append(
+            "b",
+            &AgentName::from("agent-y"),
+            &serde_json::json!({}),
+        )
+        .unwrap();
 
         let path_x = dir.path().join("agent-x.jsonl");
         let path_y = dir.path().join("agent-y.jsonl");
@@ -114,7 +127,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let log = EventLog::open(dir.path().to_path_buf()).unwrap();
 
-        log.append("a", "feature/bug", &serde_json::json!({}))
+        log.append("a", &AgentName::from("feature/bug"), &serde_json::json!({}))
             .unwrap();
         let path = dir.path().join("feature_bug.jsonl");
         assert!(path.exists());

--- a/rust/exomonad-core/src/services/github_poller.rs
+++ b/rust/exomonad-core/src/services/github_poller.rs
@@ -1,4 +1,4 @@
-use crate::domain::{BranchName, CommitSha, PRNumber};
+use crate::domain::{AgentName, BranchName, CommitSha, PRNumber};
 use crate::plugin_manager::PluginManager;
 use crate::services::acp_registry::AcpRegistry;
 use crate::services::agent_control::AgentType;
@@ -404,7 +404,7 @@ impl GitHubPoller {
                 if let Some(ref log) = self.event_log {
                     let _ = log.append(
                         "event.dispatched",
-                        agent_name,
+                        &AgentName::from(agent_name),
                         &serde_json::json!({
                             "event_type": event_type,
                             "action": action_str,
@@ -430,7 +430,7 @@ impl GitHubPoller {
                 if let Some(ref log) = self.event_log {
                     let _ = log.append(
                         "event.dispatch_failed",
-                        agent_name,
+                        &AgentName::from(agent_name),
                         &serde_json::json!({
                             "event_type": event_type,
                             "error": e.to_string(),
@@ -634,7 +634,7 @@ impl GitHubPoller {
                     if let Some(ref log) = self.event_log {
                         let _ = log.append(
                             "agent.sibling_merged",
-                            branch.as_str(),
+                            &AgentName::from(branch.as_str()),
                             &serde_json::json!({
                                 "pr_number": pr_num.as_u64(),
                                 "branch": branch.as_str(),
@@ -1033,7 +1033,7 @@ impl GitHubPoller {
         if let Some(ref log) = self.event_log {
             let _ = log.append(
                 event_name,
-                branch,
+                &AgentName::from(branch),
                 &serde_json::json!({
                     "branch": branch,
                     "status": status,

--- a/rust/exomonad/src/serve.rs
+++ b/rust/exomonad/src/serve.rs
@@ -438,7 +438,7 @@ pub async fn handle_hook_inner(
             if let Some(ref log) = state.event_log {
                 let _ = log.append(
                     "hook.stop",
-                    agent_name_for_hook.as_str(),
+                    &agent_name_for_hook,
                     &serde_json::json!({
                         "event_type": format!("{:?}", event_type),
                         "decision": decision_str,
@@ -604,7 +604,7 @@ pub async fn call_tool(
             if let Some(ref log) = state.event_log {
                 let _ = log.append(
                     "tool.called",
-                    &name,
+                    &AgentName::from(name.as_str()),
                     &serde_json::json!({
                         "tool_name": body.name,
                         "role": role,
@@ -634,7 +634,7 @@ pub async fn call_tool(
     if let Some(ref log) = state.event_log {
         let _ = log.append(
             "tool.called",
-            &name,
+            &AgentName::from(name.as_str()),
             &serde_json::json!({
                 "tool_name": body.name,
                 "role": role,


### PR DESCRIPTION
## Summary
- Change `EventLog::append` `agent_id` parameter from `&str` to `&AgentName`
- Update all callers in delivery.rs, github_poller.rs, and handlers

## Verification
- `cargo test --workspace --lib` ✅
- `cargo clippy --workspace -- -D warnings` ✅