### PR TITLE
feat: add inbox compaction for bounded inbox growth

### DIFF
--- a/rust/claude-teams-bridge/src/inbox.rs
+++ b/rust/claude-teams-bridge/src/inbox.rs
@@ -88,7 +88,88 @@ pub(crate) fn write_to_inbox_at_base(
     }
 
     debug!(bytes = json.len(), "Teams inbox write complete");
+
+    let msg_count = messages.len();
+    drop(_lock);
+
+    // Trigger compaction when inbox grows large
+    if msg_count > 1000 {
+        if let Err(e) = compact_inbox_at_base(base, team, recipient) {
+            debug!(error = %e, "Inbox compaction failed (non-fatal)");
+        }
+    }
+
     Ok(timestamp)
+}
+
+/// Compact an inbox file to keep it at a manageable size.
+pub fn compact_inbox(team: &str, recipient: &str) -> io::Result<()> {
+    let home = dirs::home_dir()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "HOME directory not found"))?;
+    compact_inbox_at_base(&home, team, recipient)
+}
+
+pub(crate) fn compact_inbox_at_base(base: &Path, team: &str, recipient: &str) -> io::Result<()> {
+    let inbox_dir = paths::inbox_dir_at(base, team);
+    let inbox_file = inbox_dir.join(format!("{}.json", recipient));
+    if !inbox_file.exists() {
+        return Ok(());
+    }
+
+    let _lock = FileLock::acquire(&inbox_file, Duration::from_secs(30))?;
+
+    let content = std::fs::read_to_string(&inbox_file)?;
+    let messages: Vec<TeamsMessage> = serde_json::from_str(&content).unwrap_or_default();
+
+    let mut compacted = Vec::new();
+    // Always keep unread messages
+    let (unread, read): (Vec<_>, Vec<_>) = messages.into_iter().partition(|m| !m.read);
+    compacted.extend(unread);
+
+    // For read messages: keep last 500
+    let read_len = read.len();
+    let read_to_keep: Vec<TeamsMessage> = if read_len > 500 {
+        read.into_iter().skip(read_len - 500).collect()
+    } else {
+        read
+    };
+
+    // For idle notifications among kept read messages: keep only last 10 per sender
+    let (idle, non_idle): (Vec<_>, Vec<_>) = read_to_keep.into_iter().partition(is_idle_notification);
+    compacted.extend(non_idle);
+
+    // Group idle by sender, keep last 10 each
+    let mut idle_by_sender: std::collections::HashMap<String, Vec<TeamsMessage>> = std::collections::HashMap::new();
+    for msg in idle {
+        idle_by_sender.entry(msg.from.clone()).or_default().push(msg);
+    }
+    for (_sender, mut msgs) in idle_by_sender {
+        let len = msgs.len();
+        if len > 10 {
+            msgs.drain(..len - 10);
+        }
+        compacted.extend(msgs);
+    }
+
+    // Sort by timestamp to maintain order
+    compacted.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
+
+    let json = serde_json::to_string_pretty(&compacted)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+    let tmp_file = inbox_dir.join(format!(".{}.compact.json.tmp", recipient));
+    std::fs::write(&tmp_file, &json)?;
+    std::fs::rename(&tmp_file, &inbox_file)?;
+    if let Err(e) = fsync_dir(&inbox_dir) {
+        debug!(error = %e, "fsync on inbox dir failed during compaction");
+    }
+
+    info!(team = %team, recipient = %recipient, before = read_len, after = compacted.len(), "Inbox compacted");
+    Ok(())
+}
+
+fn is_idle_notification(msg: &TeamsMessage) -> bool {
+    msg.summary.to_lowercase().contains("idle")
+        || msg.text.to_lowercase().contains("idle")
 }
 
 /// Read all messages from an inbox.
@@ -245,5 +326,97 @@ mod tests {
             let msg_exists = messages.iter().any(|m| m.text == format!("message-{}", i));
             assert!(msg_exists, "Message {} missing", i);
         }
+    }
+
+    #[test]
+    fn test_compact_inbox_preserves_unread() {
+        let tmp = tempdir().unwrap();
+        let base = tmp.path();
+        let team = "t";
+        let recipient = "r";
+        let inbox_dir = paths::inbox_dir_at(base, team);
+        std::fs::create_dir_all(&inbox_dir).unwrap();
+
+        // Create 5 unread + 5 read messages
+        let mut messages = Vec::new();
+        for i in 0..10 {
+            messages.push(TeamsMessage {
+                from: "agent".to_string(),
+                text: format!("msg{}", i),
+                summary: "sum".to_string(),
+                timestamp: format!("2026-03-24T12:00:0{:02}Z", i),
+                read: i >= 5,
+            });
+        }
+        let inbox_file = inbox_dir.join(format!("{}.json", recipient));
+        std::fs::write(&inbox_file, serde_json::to_string(&messages).unwrap()).unwrap();
+
+        compact_inbox_at_base(base, team, recipient).unwrap();
+
+        let content = std::fs::read_to_string(&inbox_file).unwrap();
+        let compacted: Vec<TeamsMessage> = serde_json::from_str(&content).unwrap();
+        assert_eq!(compacted.len(), 10);
+    }
+
+    #[test]
+    fn test_compact_inbox_trims_read_messages() {
+        let tmp = tempdir().unwrap();
+        let base = tmp.path();
+        let team = "t";
+        let recipient = "r";
+        let inbox_dir = paths::inbox_dir_at(base, team);
+        std::fs::create_dir_all(&inbox_dir).unwrap();
+
+        // Create 600 read messages
+        let mut messages = Vec::new();
+        for i in 0..600 {
+            messages.push(TeamsMessage {
+                from: "agent".to_string(),
+                text: format!("msg{}", i),
+                summary: "sum".to_string(),
+                timestamp: format!("2026-03-24T12:00:0{:03}Z", i),
+                read: true,
+            });
+        }
+        let inbox_file = inbox_dir.join(format!("{}.json", recipient));
+        std::fs::write(&inbox_file, serde_json::to_string(&messages).unwrap()).unwrap();
+
+        compact_inbox_at_base(base, team, recipient).unwrap();
+
+        let content = std::fs::read_to_string(&inbox_file).unwrap();
+        let compacted: Vec<TeamsMessage> = serde_json::from_str(&content).unwrap();
+        assert_eq!(compacted.len(), 500);
+        assert_eq!(compacted[0].text, "msg100");
+    }
+
+    #[test]
+    fn test_compact_inbox_deduplicates_idle() {
+        let tmp = tempdir().unwrap();
+        let base = tmp.path();
+        let team = "t";
+        let recipient = "r";
+        let inbox_dir = paths::inbox_dir_at(base, team);
+        std::fs::create_dir_all(&inbox_dir).unwrap();
+
+        // Create 20 read idle messages from same sender
+        let mut messages = Vec::new();
+        for i in 0..20 {
+            messages.push(TeamsMessage {
+                from: "agent".to_string(),
+                text: format!("idle{}", i),
+                summary: "idle".to_string(),
+                timestamp: format!("2026-03-24T12:00:0{:02}Z", i),
+                read: true,
+            });
+        }
+        let inbox_file = inbox_dir.join(format!("{}.json", recipient));
+        std::fs::write(&inbox_file, serde_json::to_string(&messages).unwrap()).unwrap();
+
+        compact_inbox_at_base(base, team, recipient).unwrap();
+
+        let content = std::fs::read_to_string(&inbox_file).unwrap();
+        let compacted: Vec<TeamsMessage> = serde_json::from_str(&content).unwrap();
+        assert_eq!(compacted.len(), 10);
+        assert_eq!(compacted[0].text, "idle10");
     }
 }

--- a/rust/claude-teams-bridge/src/lib.rs
+++ b/rust/claude-teams-bridge/src/lib.rs
@@ -13,7 +13,9 @@ mod verifier;
 
 pub use config::{read_team_config, write_team_config, TeamConfig, TeamMember};
 pub use discovery::{list_inboxes, list_teams};
-pub use inbox::{is_message_read, read_inbox, unread_messages, write_to_inbox, TeamsMessage};
+pub use inbox::{
+    compact_inbox, is_message_read, read_inbox, unread_messages, write_to_inbox, TeamsMessage,
+};
 pub use paths::{config_path, inbox_path, teams_base_dir};
 pub use registry::{TeamInfo, TeamRegistry};
 pub use verifier::wait_for_read;


### PR DESCRIPTION
## Summary
- Adds `compact_inbox` / `compact_inbox_at_base` that trims read messages to last 500 and idle notifications to last 10 per sender
- Triggers compaction automatically in `write_to_inbox_at_base` when array length exceeds 1000
- Preserves all unread messages unconditionally

## Test plan
- [x] `cargo test -p claude-teams-bridge` passes (including compaction tests)
- [x] `cargo clippy -p claude-teams-bridge` clean