### PR TITLE
type-safety: Optional birth_branch + from_dir_name returns Option

### DIFF
--- a/rust/exomonad-core/src/handlers/events.rs
+++ b/rust/exomonad-core/src/handlers/events.rs
@@ -257,6 +257,7 @@ fn resolve_recipient_tab_name(recipient: &str) -> String {
         "TL".to_string()
     } else {
         crate::services::agent_control::AgentType::from_dir_name(recipient)
+            .unwrap_or(crate::services::agent_control::AgentType::Gemini)
             .tab_display_name(recipient)
     }
 }

--- a/rust/exomonad-core/src/services/agent_control/cleanup.rs
+++ b/rust/exomonad-core/src/services/agent_control/cleanup.rs
@@ -32,7 +32,7 @@ impl AgentControlService {
                 (at, s.strip_suffix(&suffix).unwrap_or(s).to_string())
             }
             None => {
-                let at = AgentType::from_dir_name(identifier);
+                let at = AgentType::from_dir_name(identifier).unwrap_or(AgentType::Gemini);
                 let suffix = format!("-{}", at.suffix());
                 (
                     at,
@@ -45,7 +45,11 @@ impl AgentControlService {
         };
 
         // Remove synthetic team member registration (non-fatal if not registered)
-        let team_name = TeamName::from(format!("exo-{}", self.birth_branch).as_str());
+        let birth_branch = self
+            .birth_branch
+            .as_ref()
+            .expect("birth_branch was never initialized via with_birth_branch()");
+        let team_name = TeamName::from(format!("exo-{}", birth_branch).as_str());
         if let Err(e) =
             crate::services::synthetic_members::remove_synthetic_member(&team_name, &slug)
         {

--- a/rust/exomonad-core/src/services/agent_control/mod.rs
+++ b/rust/exomonad-core/src/services/agent_control/mod.rs
@@ -166,15 +166,17 @@ impl AgentType {
     }
 
     /// Infer agent type from a worktree directory name (e.g., "feature-a-claude" → Claude).
-    pub fn from_dir_name(dir_name: &str) -> Self {
+    pub fn from_dir_name(dir_name: &str) -> Option<Self> {
         if dir_name.ends_with("-claude") {
-            AgentType::Claude
+            Some(AgentType::Claude)
         } else if dir_name.ends_with("-shoal") {
-            AgentType::Shoal
+            Some(AgentType::Shoal)
         } else if dir_name.ends_with("-process") {
-            AgentType::Process
+            Some(AgentType::Process)
+        } else if dir_name.ends_with("-gemini") {
+            Some(AgentType::Gemini)
         } else {
-            AgentType::Gemini
+            None
         }
     }
 }
@@ -489,7 +491,7 @@ pub struct AgentControlService {
     /// Direct tmux IPC client.
     pub(crate) tmux_ipc: Option<super::tmux_ipc::TmuxIpc>,
     /// This agent's birth-branch (git identity). Root TL = "main".
-    pub(crate) birth_branch: BirthBranch,
+    pub(crate) birth_branch: Option<BirthBranch>,
     /// Git worktree service
     pub(crate) git_wt: Arc<GitWorktreeService>,
     /// ACP connection registry for Gemini agents.
@@ -514,7 +516,7 @@ impl AgentControlService {
             github,
             tmux_session: None,
             tmux_ipc: None,
-            birth_branch: BirthBranch::from("unset"),
+            birth_branch: None,
             git_wt,
             acp_registry: None,
             yolo: false,
@@ -549,7 +551,7 @@ impl AgentControlService {
 
     /// Set the birth-branch (git identity) for this agent.
     pub fn with_birth_branch(mut self, branch: BirthBranch) -> Self {
-        self.birth_branch = branch;
+        self.birth_branch = Some(branch);
         self
     }
 
@@ -564,13 +566,10 @@ impl AgentControlService {
     /// Callers pass the birth branch from EffectContext. Falls back to `self.birth_branch`
     /// if no override is provided.
     pub(crate) fn effective_birth_branch(&self, override_bb: Option<&BirthBranch>) -> BirthBranch {
-        override_bb.cloned().unwrap_or_else(|| {
-            debug_assert!(
-                self.birth_branch.as_str() != "unset",
-                "birth_branch was never initialized via with_birth_branch()"
-            );
-            self.birth_branch.clone()
-        })
+        override_bb
+            .cloned()
+            .or_else(|| self.birth_branch.clone())
+            .expect("birth_branch was never initialized via with_birth_branch()")
     }
 
     /// Common post-spawn bookkeeping.
@@ -627,7 +626,7 @@ impl AgentControlService {
             github,
             tmux_session: None,
             tmux_ipc: None,
-            birth_branch: BirthBranch::root()?,
+            birth_branch: Some(BirthBranch::root()?),
             git_wt,
             acp_registry: None,
             yolo: false,

--- a/rust/exomonad-core/src/services/agent_control/spawn.rs
+++ b/rust/exomonad-core/src/services/agent_control/spawn.rs
@@ -46,13 +46,17 @@ impl AgentControlService {
             let internal_name = format!("gh-{}-{}-{}", issue_id, slug, agent_suffix);
 
             // Determine base branch (use birth_branch for root detection)
-            let default_base = self.birth_branch.as_parent_branch().to_string();
+            let birth_branch = self
+                .birth_branch
+                .as_ref()
+                .expect("birth_branch was never initialized via with_birth_branch()");
+            let default_base = birth_branch.as_parent_branch().to_string();
             let base = options
                 .base_branch
                 .as_ref()
                 .map(|b| b.as_str().to_string())
                 .unwrap_or(default_base);
-            let branch_name = if self.birth_branch.depth() == 0 {
+            let branch_name = if birth_branch.depth() == 0 {
                 format!("gh-{}/{}-{}", issue_id, slug, agent_suffix)
             } else {
                 format!("{}/{}-{}", base, slug, agent_suffix)

--- a/rust/exomonad-core/src/services/github_poller.rs
+++ b/rust/exomonad-core/src/services/github_poller.rs
@@ -699,7 +699,7 @@ impl GitHubPoller {
             }
 
             let dir_name = entry.file_name().to_string_lossy().to_string();
-            let agent_type = AgentType::from_dir_name(&dir_name);
+            let agent_type = AgentType::from_dir_name(&dir_name).unwrap_or(AgentType::Gemini);
 
             // Execute git branch --show-current in the worktree
             let output = Command::new("git")


### PR DESCRIPTION
## Summary
- Make `AgentControlService.birth_branch` `Option<BirthBranch>` instead of using `"unset"` sentinel
- Make `AgentType::from_dir_name` return `Option<Self>` instead of defaulting to Gemini
- Update all callers to handle the new types

## Verification
- `cargo test --workspace --lib` ✅
- `cargo clippy --workspace -- -D warnings` ✅