### PR TITLE
fix: suppress stale notifications after parent notified

### DIFF
--- a/rust/exomonad-core/src/handlers/session.rs
+++ b/rust/exomonad-core/src/handlers/session.rs
@@ -206,6 +206,21 @@ impl<C: HasClaudeSessionRegistry + HasTeamRegistry + HasSupervisorRegistry + 'st
 
         info!(key = %key, "Deregistering Claude Teams info via effect");
 
+        // Remove all exomonad synthetic members from config.json BEFORE
+        // deregistering from TeamRegistry. This prevents ghost members
+        // from blocking CC's TeamDelete (which checks config.json).
+        if let Some(team_info) = self.ctx.team_registry().get(&key).await {
+            let team_name = crate::domain::TeamName::from(team_info.team_name.as_str());
+            match crate::services::synthetic_members::remove_all_synthetic_members(&team_name) {
+                Ok(removed) => {
+                    info!(team = %team_name, removed, "Cleaned synthetic members before team deregister");
+                }
+                Err(e) => {
+                    tracing::warn!(team = %team_name, error = %e, "Failed to clean synthetic members");
+                }
+            }
+        }
+
         self.ctx.team_registry().deregister(&key).await;
 
         // Also deregister under birth_branch

--- a/rust/exomonad-core/src/services/synthetic_members.rs
+++ b/rust/exomonad-core/src/services/synthetic_members.rs
@@ -144,6 +144,68 @@ fn remove_synthetic_member_at_path(
     Ok(())
 }
 
+/// Remove all synthetic (exomonad-managed) members from a Claude Teams config.json.
+///
+/// Retains CC-native members (those without `"backendType": "exomonad"`).
+/// Used during team teardown to prevent ghost members from blocking TeamDelete.
+pub fn remove_all_synthetic_members(team_name: &TeamName) -> Result<usize> {
+    let config_path = team_config_path(team_name)?;
+    remove_all_synthetic_members_at_path(&config_path, team_name)
+}
+
+fn remove_all_synthetic_members_at_path(
+    config_path: &PathBuf,
+    team_name: &TeamName,
+) -> Result<usize> {
+    if !config_path.exists() {
+        info!(team = %team_name, "Team config not found, nothing to clean");
+        return Ok(0);
+    }
+
+    let _lock = FileLock::acquire(config_path, Duration::from_secs(30)).with_context(|| {
+        format!(
+            "Failed to acquire lock on team config: {}",
+            config_path.display()
+        )
+    })?;
+    let content = std::fs::read_to_string(config_path)
+        .with_context(|| format!("Failed to read team config: {}", config_path.display()))?;
+    let mut config: Value =
+        serde_json::from_str(&content).context("Failed to parse team config")?;
+
+    let removed = if let Some(members) = config.get_mut("members").and_then(|m| m.as_array_mut()) {
+        let before = members.len();
+        members.retain(|m| m.get("backendType").and_then(|b| b.as_str()) != Some("exomonad"));
+        before - members.len()
+    } else {
+        0
+    };
+
+    if removed > 0 {
+        let content = serde_json::to_string_pretty(&config)?;
+        let tmp_dir = config_path.parent().ok_or_else(|| {
+            anyhow::anyhow!("No parent dir for config path: {}", config_path.display())
+        })?;
+        let tmp = tempfile::NamedTempFile::new_in(tmp_dir)?;
+        {
+            let mut writer = std::io::BufWriter::new(tmp.as_file());
+            writer.write_all(content.as_bytes())?;
+            writer.flush()?;
+            tmp.as_file().sync_all()?;
+        }
+        tmp.persist(config_path)?;
+
+        if let Some(parent) = config_path.parent() {
+            if let Err(e) = fsync_dir(parent) {
+                warn!(error = %e, "fsync on config dir failed");
+            }
+        }
+    }
+
+    info!(team = %team_name, removed, "Removed all synthetic members");
+    Ok(removed)
+}
+
 fn team_config_path(team_name: &TeamName) -> Result<PathBuf> {
     let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("HOME directory not found"))?;
     Ok(home
@@ -199,6 +261,66 @@ mod tests {
         assert_eq!(members.len(), 1);
         assert!(!members.iter().any(|m| m["name"] == "gemini-1"));
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_remove_all_synthetic_members() -> Result<()> {
+        let dir = tempdir()?;
+        let team_name = TeamName::from("test-team");
+        let config_path = dir.path().join("config.json");
+
+        let initial_config = serde_json::json!({
+            "members": [
+                {
+                    "agentId": "lead@test-team",
+                    "name": "lead",
+                    "agentType": "human"
+                },
+                {
+                    "agentId": "gemini-1@test-team",
+                    "name": "gemini-1",
+                    "agentType": "gemini-worker",
+                    "backendType": "exomonad"
+                },
+                {
+                    "agentId": "gemini-2@test-team",
+                    "name": "gemini-2",
+                    "agentType": "gemini-worker",
+                    "backendType": "exomonad"
+                },
+                {
+                    "agentId": "claude-sub@test-team",
+                    "name": "claude-sub",
+                    "agentType": "claude",
+                    "backendType": "exomonad"
+                }
+            ]
+        });
+        fs::write(&config_path, serde_json::to_string_pretty(&initial_config)?)?;
+
+        let removed = remove_all_synthetic_members_at_path(&config_path, &team_name)?;
+        assert_eq!(removed, 3);
+
+        let content = fs::read_to_string(&config_path)?;
+        let config: Value = serde_json::from_str(&content)?;
+        let members = config["members"].as_array().unwrap();
+        assert_eq!(members.len(), 1);
+        assert_eq!(members[0]["name"], "lead");
+
+        // Idempotent — no synthetic members left
+        let removed = remove_all_synthetic_members_at_path(&config_path, &team_name)?;
+        assert_eq!(removed, 0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_remove_all_synthetic_members_missing_config() -> Result<()> {
+        let team_name = TeamName::from("nonexistent-team");
+        let config_path = PathBuf::from("/tmp/nonexistent-config.json");
+        let removed = remove_all_synthetic_members_at_path(&config_path, &team_name)?;
+        assert_eq!(removed, 0);
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

Once the parent TL has been notified of approval (`[PR READY]`) or timeout (`[REVIEW TIMEOUT]`), `compute_pr_actions` now returns early with no actions. Late Copilot reviews, CI changes, and new commits on already-notified PRs are suppressed.

**Root cause:** The GitHub poller continued firing WASM event handlers after the parent had already been told to merge. These events caused agents to call `notify_parent` with stale information, confusing the TL.

**Fix:** Early return in `compute_pr_actions` when `notified_parent_approved || notified_parent_timeout`.

## Changes

- `github_poller.rs`: Added stale notification guard at top of `compute_pr_actions`
- `CLAUDE.md`: Documented the stale notification guard behavior
- 3 new tests: post-approval suppression, post-timeout suppression, new commits after approval suppression

## Test plan

- [x] `cargo test --workspace --lib` — all tests pass (including 3 new)
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --check` — clean