### PR TITLE
fix: suppress stale notifications after parent notified

### DIFF
--- a/rust/exomonad-core/CLAUDE.md
+++ b/rust/exomonad-core/CLAUDE.md
@@ -149,6 +149,10 @@ ReviewState::None ──(Copilot approves)──→ ReviewState::Approved
 4. Handler returns `EventAction` (InjectMessage, NotifyParentAction, NoAction)
 5. Poller acts on the action via `handle_event_action()`
 
+### Stale Notification Guard
+
+Once the parent has been notified (via `[PR READY]` approval or `[REVIEW TIMEOUT]`), `compute_pr_actions` suppresses all further events for that PR. Late Copilot reviews, CI status changes, and new commits are silently dropped — the TL has already been told to merge, so any further notifications are stale and confusing.
+
 ### Merge Detection
 
 When a tracked PR's branch disappears from the open PR list, it was merged/closed. The poller:

--- a/rust/exomonad-core/src/services/github_poller.rs
+++ b/rust/exomonad-core/src/services/github_poller.rs
@@ -125,6 +125,12 @@ fn compute_pr_actions(
     let mut pending_actions = Vec::new();
     let copilot_count = copilot_comments.len() + copilot_reviews.len();
 
+    // Once we've notified the parent (approved or timeout), suppress further events.
+    // The TL will merge; any later activity (late Copilot reviews, CI changes) is stale.
+    if old_state.notified_parent_approved || old_state.notified_parent_timeout {
+        return pending_actions;
+    }
+
     // Reset review tracking if new commits pushed
     if pr_sha != old_state.last_sha.as_str() {
         old_state.last_sha = CommitSha::from(pr_sha);
@@ -1316,5 +1322,80 @@ mod tests {
         );
 
         assert!(actions.iter().any(|a| matches!(a, PendingAction::WasmEvent { event_type: "pr_review", payload } if payload.get("kind").and_then(|v| v.as_str()) == Some("timeout"))));
+    }
+
+    #[test]
+    fn test_no_actions_after_parent_approved() {
+        let mut state = make_pr_state("main.feature", "abc123");
+        state.notified_parent_approved = true;
+        state.last_review_state = ReviewState::Approved;
+
+        // Late Copilot review arrives after approval — should be suppressed
+        let reviews = vec![CopilotReview {
+            body: "Some late feedback".to_string(),
+            state: ReviewState::Approved,
+        }];
+        let actions = compute_pr_actions(
+            &mut state,
+            PRNumber::new(123),
+            "abc123",
+            &[],
+            &reviews,
+            CIStatus::Success,
+            "main.feature",
+            &|_, _| String::new(),
+        );
+
+        assert!(
+            actions.is_empty(),
+            "Expected no actions after parent was notified of approval"
+        );
+    }
+
+    #[test]
+    fn test_no_actions_after_parent_timeout() {
+        let mut state = make_pr_state("main.feature", "abc123");
+        state.notified_parent_timeout = true;
+
+        // CI status change after timeout — should be suppressed
+        let actions = compute_pr_actions(
+            &mut state,
+            PRNumber::new(123),
+            "abc123",
+            &[],
+            &[],
+            CIStatus::Success,
+            "main.feature",
+            &|_, _| String::new(),
+        );
+
+        assert!(
+            actions.is_empty(),
+            "Expected no actions after parent was notified of timeout"
+        );
+    }
+
+    #[test]
+    fn test_new_commits_after_approval_suppressed() {
+        let mut state = make_pr_state("main.feature", "abc123");
+        state.notified_parent_approved = true;
+        state.last_review_state = ReviewState::Approved;
+
+        // New commits pushed after approval — should be suppressed
+        let actions = compute_pr_actions(
+            &mut state,
+            PRNumber::new(123),
+            "def456", // new SHA
+            &[],
+            &[],
+            CIStatus::Pending,
+            "main.feature",
+            &|_, _| String::new(),
+        );
+
+        assert!(
+            actions.is_empty(),
+            "Expected no actions for new commits after approval"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Once the parent TL has been notified of approval (`[PR READY]`) or timeout (`[REVIEW TIMEOUT]`), `compute_pr_actions` now returns early with no actions. Late Copilot reviews, CI changes, and new commits on already-notified PRs are suppressed.

**Root cause:** The GitHub poller continued firing WASM event handlers after the parent had already been told to merge. These events caused agents to call `notify_parent` with stale information, confusing the TL.

**Fix:** Early return in `compute_pr_actions` when `notified_parent_approved || notified_parent_timeout`.

## Changes

- `github_poller.rs`: Added stale notification guard at top of `compute_pr_actions`
- `CLAUDE.md`: Documented the stale notification guard behavior
- 3 new tests: post-approval suppression, post-timeout suppression, new commits after approval suppression

## Test plan

- [x] `cargo test --workspace --lib` — all tests pass (including 3 new)
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --check` — clean