### PR TITLE
fix: reset first_seen on any SHA change and addressed_changes on new review cycle (v2)

### DIFF
--- a/rust/exomonad-core/src/services/github_poller.rs
+++ b/rust/exomonad-core/src/services/github_poller.rs
@@ -177,51 +177,51 @@ fn compute_pr_actions(
                 reviews: Some(copilot_reviews.to_vec()),
             });
 
-            // Fire WASM event handler
-            pending_actions.push(PendingAction::WasmEvent {
-                event_type: "pr_review",
-                payload: serde_json::json!({
-                    "kind": "review_received",
-                    "pr_number": pr_number.as_u64(),
-                    "comments": message,
-                }),
+            // Check for state changes (approved or changes_requested)
+            let approved = copilot_reviews.iter().any(|r| {
+                r.state == ReviewState::Approved || r.body.to_lowercase().contains("approved")
             });
+            let changes_requested = copilot_reviews
+                .iter()
+                .any(|r| r.state == ReviewState::ChangesRequested);
+
+            if approved && old_state.last_review_state != ReviewState::Approved {
+                old_state.last_review_state = ReviewState::Approved;
+                old_state.notified_parent_approved = true;
+                pending_actions.push(PendingAction::WasmEvent {
+                    event_type: "pr_review",
+                    payload: serde_json::json!({
+                        "kind": "approved",
+                        "pr_number": pr_number.as_u64(),
+                    }),
+                });
+            } else if changes_requested
+                && old_state.last_review_state != ReviewState::ChangesRequested
+            {
+                old_state.last_review_state = ReviewState::ChangesRequested;
+                old_state.addressed_changes = false; // New review cycle starts
+                pending_actions.push(PendingAction::WasmEvent {
+                    event_type: "pr_review",
+                    payload: serde_json::json!({
+                        "kind": "review_received",
+                        "pr_number": pr_number.as_u64(),
+                        "comments": message,
+                    }),
+                });
+            } else {
+                // General review/comment activity
+                pending_actions.push(PendingAction::WasmEvent {
+                    event_type: "pr_review",
+                    payload: serde_json::json!({
+                        "kind": "review_received",
+                        "pr_number": pr_number.as_u64(),
+                        "comments": message,
+                    }),
+                });
+            }
         }
         // Update state even if count decreased (to sync with reality)
         old_state.last_copilot_comment_count = copilot_count;
-    }
-
-    // Check for Copilot approval
-    let approved = copilot_reviews
-        .iter()
-        .any(|r| r.state == ReviewState::Approved || r.body.to_lowercase().contains("approved"));
-    if approved && old_state.last_review_state != ReviewState::Approved {
-        old_state.last_review_state = ReviewState::Approved;
-        old_state.notified_parent_approved = true;
-        pending_actions.push(PendingAction::WasmEvent {
-            event_type: "pr_review",
-            payload: serde_json::json!({
-                "kind": "approved",
-                "pr_number": pr_number.as_u64(),
-            }),
-        });
-    }
-
-    // Check for changes_requested
-    let changes_requested = copilot_reviews
-        .iter()
-        .any(|r| r.state == ReviewState::ChangesRequested);
-    if changes_requested && old_state.last_review_state != ReviewState::ChangesRequested {
-        old_state.last_review_state = ReviewState::ChangesRequested;
-        old_state.addressed_changes = false; // New review cycle starts
-        pending_actions.push(PendingAction::WasmEvent {
-            event_type: "pr_review",
-            payload: serde_json::json!({
-                "kind": "review_received",
-                "pr_number": pr_number.as_u64(),
-                "comments": format_message(copilot_comments, copilot_reviews),
-            }),
-        });
     }
 
     // Check CI changes
@@ -1405,7 +1405,8 @@ mod tests {
     fn test_first_seen_resets_on_sha_change_in_none_state() {
         let mut state = make_pr_state("main.feature", "abc123");
         state.last_review_state = ReviewState::None;
-        state.first_seen = Instant::now() - Duration::from_secs(10 * 60);
+        let old_first_seen = Instant::now() - Duration::from_secs(10 * 60);
+        state.first_seen = old_first_seen;
 
         compute_pr_actions(
             &mut state,
@@ -1418,7 +1419,7 @@ mod tests {
             &|_, _| String::new(),
         );
 
-        assert!(state.first_seen.elapsed() < Duration::from_secs(1));
+        assert!(state.first_seen > old_first_seen);
     }
 
     #[test]
@@ -1484,10 +1485,16 @@ mod tests {
         assert_eq!(state.addressed_changes, true);
 
         // (c) New review arrives -> ChangesRequested, addressed_changes=false
-        let reviews2 = vec![CopilotReview {
-            body: "Second review".to_string(),
-            state: ReviewState::ChangesRequested,
-        }];
+        let reviews2 = vec![
+            CopilotReview {
+                body: "Initial review".to_string(),
+                state: ReviewState::ChangesRequested,
+            },
+            CopilotReview {
+                body: "Second review".to_string(),
+                state: ReviewState::ChangesRequested,
+            },
+        ];
         compute_pr_actions(
             &mut state,
             PRNumber::new(123),

--- a/rust/exomonad-core/src/services/github_poller.rs
+++ b/rust/exomonad-core/src/services/github_poller.rs
@@ -134,10 +134,11 @@ fn compute_pr_actions(
     // Reset review tracking if new commits pushed
     if pr_sha != old_state.last_sha.as_str() {
         old_state.last_sha = CommitSha::from(pr_sha);
+        old_state.first_seen = Instant::now();
+
         if old_state.last_review_state == ReviewState::ChangesRequested {
             old_state.last_review_state = ReviewState::None;
             old_state.notified_parent_timeout = false;
-            old_state.first_seen = Instant::now();
             old_state.addressed_changes = true;
 
             // Fire FixesPushed event — Copilot does NOT re-review,
@@ -212,6 +213,7 @@ fn compute_pr_actions(
         .any(|r| r.state == ReviewState::ChangesRequested);
     if changes_requested && old_state.last_review_state != ReviewState::ChangesRequested {
         old_state.last_review_state = ReviewState::ChangesRequested;
+        old_state.addressed_changes = false; // New review cycle starts
         pending_actions.push(PendingAction::WasmEvent {
             event_type: "pr_review",
             payload: serde_json::json!({
@@ -1397,5 +1399,106 @@ mod tests {
             actions.is_empty(),
             "Expected no actions for new commits after approval"
         );
+    }
+
+    #[test]
+    fn test_first_seen_resets_on_sha_change_in_none_state() {
+        let mut state = make_pr_state("main.feature", "abc123");
+        state.last_review_state = ReviewState::None;
+        state.first_seen = Instant::now() - Duration::from_secs(10 * 60);
+
+        compute_pr_actions(
+            &mut state,
+            PRNumber::new(123),
+            "def456", // new SHA
+            &[],
+            &[],
+            CIStatus::Success,
+            "main.feature",
+            &|_, _| String::new(),
+        );
+
+        assert!(state.first_seen.elapsed() < Duration::from_secs(1));
+    }
+
+    #[test]
+    fn test_addressed_changes_resets_on_new_review() {
+        let mut state = make_pr_state("main.feature", "abc123");
+        state.addressed_changes = true;
+        state.last_review_state = ReviewState::None;
+
+        let reviews = vec![CopilotReview {
+            body: "Need changes".to_string(),
+            state: ReviewState::ChangesRequested,
+        }];
+
+        compute_pr_actions(
+            &mut state,
+            PRNumber::new(123),
+            "abc123",
+            &[],
+            &reviews,
+            CIStatus::Success,
+            "main.feature",
+            &|_, _| String::new(),
+        );
+
+        assert_eq!(state.addressed_changes, false);
+        assert_eq!(state.last_review_state, ReviewState::ChangesRequested);
+    }
+
+    #[test]
+    fn test_full_cycle_addressed_changes_transitions() {
+        let mut state = make_pr_state("main.feature", "abc123");
+
+        // (a) Review arrives -> ChangesRequested, addressed_changes remains false
+        let reviews = vec![CopilotReview {
+            body: "Initial review".to_string(),
+            state: ReviewState::ChangesRequested,
+        }];
+        compute_pr_actions(
+            &mut state,
+            PRNumber::new(123),
+            "abc123",
+            &[],
+            &reviews,
+            CIStatus::Success,
+            "main.feature",
+            &|_, _| String::new(),
+        );
+        assert_eq!(state.last_review_state, ReviewState::ChangesRequested);
+        assert_eq!(state.addressed_changes, false);
+
+        // (b) Agent pushes fix -> SHA changes -> state None, addressed_changes=true
+        compute_pr_actions(
+            &mut state,
+            PRNumber::new(123),
+            "def456", // new SHA
+            &[],
+            &[],
+            CIStatus::Success,
+            "main.feature",
+            &|_, _| String::new(),
+        );
+        assert_eq!(state.last_review_state, ReviewState::None);
+        assert_eq!(state.addressed_changes, true);
+
+        // (c) New review arrives -> ChangesRequested, addressed_changes=false
+        let reviews2 = vec![CopilotReview {
+            body: "Second review".to_string(),
+            state: ReviewState::ChangesRequested,
+        }];
+        compute_pr_actions(
+            &mut state,
+            PRNumber::new(123),
+            "def456",
+            &[],
+            &reviews2,
+            CIStatus::Success,
+            "main.feature",
+            &|_, _| String::new(),
+        );
+        assert_eq!(state.last_review_state, ReviewState::ChangesRequested);
+        assert_eq!(state.addressed_changes, false);
     }
 }


### PR DESCRIPTION
Addresses Copilot review comments:
1. Gated `approved` and `changes_requested` state transitions on `copilot_count` increasing. This prevents old reviews from re-triggering state transitions (and resetting `addressed_changes`) after a SHA change reset the `last_review_state` to `None`.
2. Consolidated review event emitting logic to avoid duplicate `review_received` events.
3. Updated `test_first_seen_resets_on_sha_change_in_none_state` to use a deterministic `Instant` comparison instead of a time-elapsed check, eliminating potential flakiness in slow environments.
4. Updated `test_full_cycle_addressed_changes_transitions` to correctly simulate growing review history.