### PR TITLE
fix: handle detached HEAD and empty agent id without panicking (v2)

### DIFF
--- a/rust/exomonad-core/src/handlers/events.rs
+++ b/rust/exomonad-core/src/handlers/events.rs
@@ -184,6 +184,12 @@ impl<
                 Address::Team { team, member: None } => {
                     let lead = self.ctx.team_registry().resolve_lead(team.as_str()).await;
                     let id = lead.unwrap_or_else(|| "root".to_string());
+                    if id.is_empty() {
+                        return Err(crate::effects::EffectError::custom(
+                            "events_empty_id",
+                            "empty agent id from registry",
+                        ));
+                    }
                     let lead_name = crate::domain::AgentName::from(id.as_str());
                     let tab = crate::services::delivery::resolve_tab_name_for_agent(
                         &lead_name,
@@ -339,11 +345,58 @@ impl<
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::{AgentName, BirthBranch};
+    use crate::effects::EffectContext;
 
     #[test]
     fn test_event_handler_namespace() {
         let services = Arc::new(crate::services::Services::test());
         let handler = EventHandler::new(services, None);
         assert_eq!(handler.namespace(), "events");
+    }
+
+    #[tokio::test]
+    async fn test_notify_parent_empty_lead() {
+        let services = Arc::new(crate::services::Services::test());
+        // Register an empty lead for "test-team"
+        services
+            .team_registry()
+            .register(
+                "",
+                claude_teams_bridge::TeamInfo {
+                    team_name: "test-team".to_string(),
+                    inbox_name: "lead".to_string(),
+                },
+            )
+            .await;
+
+        let handler = EventHandler::new(services, None);
+        let ctx = EffectContext {
+            agent_name: AgentName::from("agent"),
+            birth_branch: BirthBranch::from("main"),
+            working_dir: std::path::PathBuf::from("."),
+        };
+
+        let req = NotifyParentRequest {
+            message: "hello".to_string(),
+            status: "success".to_string(),
+            agent_id: "".to_string(),
+            override_recipient: Some(exomonad_proto::effects::events::Address {
+                kind: Some(exomonad_proto::effects::events::address::Kind::Team(
+                    exomonad_proto::effects::events::TeamAddress {
+                        team: "test-team".to_string(),
+                        member: "".to_string(),
+                    },
+                )),
+            }),
+        };
+
+        let result = handler.notify_parent(req, &ctx).await;
+        assert!(result.is_err());
+        if let Err(crate::effects::EffectError::Custom { code, .. }) = result {
+            assert_eq!(code, "events_empty_id");
+        } else {
+            panic!("Expected events_empty_id error, got {:?}", result);
+        }
     }
 }

--- a/rust/exomonad-core/src/handlers/events.rs
+++ b/rust/exomonad-core/src/handlers/events.rs
@@ -186,7 +186,7 @@ impl<
                     let id = lead.unwrap_or_else(|| "root".to_string());
                     if id.is_empty() {
                         return Err(crate::effects::EffectError::custom(
-                            "events_empty_id",
+                            "events.empty_id",
                             "empty agent id from registry",
                         ));
                     }
@@ -394,9 +394,9 @@ mod tests {
         let result = handler.notify_parent(req, &ctx).await;
         assert!(result.is_err());
         if let Err(crate::effects::EffectError::Custom { code, .. }) = result {
-            assert_eq!(code, "events_empty_id");
+            assert_eq!(code, "events.empty_id");
         } else {
-            panic!("Expected events_empty_id error, got {:?}", result);
+            panic!("Expected events.empty_id error, got {:?}", result);
         }
     }
 }

--- a/rust/exomonad-core/src/handlers/git.rs
+++ b/rust/exomonad-core/src/handlers/git.rs
@@ -52,10 +52,13 @@ impl GitEffects for GitHandler {
             .await
             .effect_err("git")?;
 
-        info!(branch = %branch, "[Git] get_branch complete");
+        let detached = branch.is_none();
+        let branch_str = branch.map(|b| b.to_string()).unwrap_or_default();
+
+        info!(branch = %branch_str, detached, "[Git] get_branch complete");
         Ok(GetBranchResponse {
-            branch: branch.to_string(),
-            detached: false,
+            branch: branch_str,
+            detached,
         })
     }
 
@@ -196,9 +199,10 @@ impl GitEffects for GitHandler {
             .await
             .effect_err("git")?;
 
-        info!(branch = %info.branch, "[Git] get_repo_info complete");
+        let branch_str = info.branch.map(|b| b.to_string()).unwrap_or_default();
+        info!(branch = %branch_str, "[Git] get_repo_info complete");
         Ok(GetRepoInfoResponse {
-            branch: info.branch.to_string(),
+            branch: branch_str,
             owner: info.owner.map(Into::into).unwrap_or_else(|| {
                 tracing::debug!("Could not determine repo owner from remote URL");
                 String::new()
@@ -224,10 +228,11 @@ impl GitEffects for GitHandler {
             .await
             .effect_err("git")?;
 
-        info!(path = %info.path, branch = %info.branch, "[Git] get_worktree complete");
+        let branch_str = info.branch.map(|b| b.to_string()).unwrap_or_default();
+        info!(path = %info.path, branch = %branch_str, "[Git] get_worktree complete");
         Ok(GetWorktreeResponse {
             path: info.path,
-            branch: info.branch.to_string(),
+            branch: branch_str,
             head_commit: String::new(),
             is_linked: false,
         })

--- a/rust/exomonad-core/src/handlers/git.rs
+++ b/rust/exomonad-core/src/handlers/git.rs
@@ -50,15 +50,18 @@ impl GitEffects for GitHandler {
             .service
             .get_branch(&working_dir)
             .await
-            .effect_err("git")?;
+            .effect_err("git")?
+            .ok_or_else(|| {
+                crate::effects::EffectError::custom(
+                    "git.detached_head",
+                    "Not on a branch (detached HEAD)",
+                )
+            })?;
 
-        let detached = branch.is_none();
-        let branch_str = branch.map(|b| b.to_string()).unwrap_or_default();
-
-        info!(branch = %branch_str, detached, "[Git] get_branch complete");
+        info!(branch = %branch, "[Git] get_branch complete");
         Ok(GetBranchResponse {
-            branch: branch_str,
-            detached,
+            branch: branch.to_string(),
+            detached: false,
         })
     }
 
@@ -199,10 +202,16 @@ impl GitEffects for GitHandler {
             .await
             .effect_err("git")?;
 
-        let branch_str = info.branch.map(|b| b.to_string()).unwrap_or_default();
-        info!(branch = %branch_str, "[Git] get_repo_info complete");
+        let branch = info.branch.ok_or_else(|| {
+            crate::effects::EffectError::custom(
+                "git.detached_head",
+                "Not on a branch (detached HEAD)",
+            )
+        })?;
+
+        info!(branch = %branch, "[Git] get_repo_info complete");
         Ok(GetRepoInfoResponse {
-            branch: branch_str,
+            branch: branch.to_string(),
             owner: info.owner.map(Into::into).unwrap_or_else(|| {
                 tracing::debug!("Could not determine repo owner from remote URL");
                 String::new()
@@ -228,11 +237,17 @@ impl GitEffects for GitHandler {
             .await
             .effect_err("git")?;
 
-        let branch_str = info.branch.map(|b| b.to_string()).unwrap_or_default();
-        info!(path = %info.path, branch = %branch_str, "[Git] get_worktree complete");
+        let branch = info.branch.ok_or_else(|| {
+            crate::effects::EffectError::custom(
+                "git.detached_head",
+                "Not on a branch (detached HEAD)",
+            )
+        })?;
+
+        info!(path = %info.path, branch = %branch, "[Git] get_worktree complete");
         Ok(GetWorktreeResponse {
             path: info.path,
-            branch: branch_str,
+            branch: branch.to_string(),
             head_commit: String::new(),
             is_linked: false,
         })

--- a/rust/exomonad-core/src/services/git.rs
+++ b/rust/exomonad-core/src/services/git.rs
@@ -71,8 +71,8 @@ pub struct WorktreeInfo {
     /// Absolute path to the worktree directory.
     pub path: String,
 
-    /// Current branch name (or "HEAD" if detached).
-    pub branch: BranchName,
+    /// Current branch name (None if detached).
+    pub branch: Option<BranchName>,
 }
 
 /// Git repository information.
@@ -80,8 +80,8 @@ pub struct WorktreeInfo {
 /// Returned by [`GitService::get_repo_info()`].
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct RepoInfo {
-    /// Current branch name.
-    pub branch: BranchName,
+    /// Current branch name (None if detached).
+    pub branch: Option<BranchName>,
 
     /// Repository owner (parsed from remote URL, if available).
     ///
@@ -110,7 +110,7 @@ pub struct RepoInfo {
 /// let git = GitService::new(executor);
 ///
 /// let branch = git.get_branch(".").await?;
-/// println!("On branch: {}", branch);
+/// println!("On branch: {:?}", branch);
 /// # Ok(())
 /// # }
 /// ```
@@ -132,11 +132,15 @@ impl GitService {
     }
 
     #[tracing::instrument(skip(self))]
-    pub async fn get_branch(&self, dir: &str) -> Result<BranchName> {
+    pub async fn get_branch(&self, dir: &str) -> Result<Option<BranchName>> {
         let output = self.exec_git(dir, &["branch", "--show-current"]).await?;
-        Ok(BranchName::from(output.trim()))
+        let trimmed = output.trim();
+        if trimmed.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(BranchName::from(trimmed)))
+        }
     }
-
     #[tracing::instrument(skip(self))]
     pub async fn get_worktree(&self, dir: &str) -> Result<WorktreeInfo> {
         let path = self
@@ -266,19 +270,27 @@ mod tests {
         let mock = Arc::new(MockExecutor::new(vec![Ok("main\n".to_string())]));
         let git = GitService::new(mock);
         let branch = git.get_branch("/app").await.unwrap();
-        assert_eq!(branch.as_str(), "main");
+        assert_eq!(branch.unwrap().as_str(), "main");
+    }
+
+    #[tokio::test]
+    async fn test_get_branch_detached_head() {
+        let mock = Arc::new(MockExecutor::new(vec![Ok("\n".to_string())]));
+        let git = GitService::new(mock);
+        let branch = git.get_branch("/app").await.unwrap();
+        assert!(branch.is_none());
     }
 
     #[tokio::test]
     async fn test_get_worktree() {
         let mock = Arc::new(MockExecutor::new(vec![
             Ok("/app\n".to_string()),        // rev-parse --show-toplevel
-            Ok("feature/123\n".to_string()), // rev-parse --abbrev-ref HEAD
+            Ok("feature/123\n".to_string()), // branch --show-current
         ]));
         let git = GitService::new(mock);
         let wt = git.get_worktree("/app/src").await.unwrap();
         assert_eq!(wt.path, "/app");
-        assert_eq!(wt.branch.as_str(), "feature/123");
+        assert_eq!(wt.branch.unwrap().as_str(), "feature/123");
     }
 
     #[tokio::test]


### PR DESCRIPTION
Updated to address Copilot review comments:

1. **Fail safe on detached HEAD**: Modified `GitHandler` to return a structured `EffectError` (`git.detached_head`) when `get_branch`, `get_repo_info`, or `get_worktree` are called in a detached HEAD state. This prevents WASM guests from accidentally using an empty branch string.
2. **Consistent error codes**: Renamed `events_empty_id` to `events.empty_id` in `handlers/events.rs` to match the project's dot-separated error code convention. Updated tests accordingly.

All tests passed.
