### PR TITLE
fix(tmux): isolate delivery tests via per-test tmux sockets

### DIFF
--- a/rust/exomonad-core/src/handlers/agent.rs
+++ b/rust/exomonad-core/src/handlers/agent.rs
@@ -24,7 +24,7 @@ use tracing::{info, warn};
 
 use crate::services::{
     HasAcpRegistry, HasAgentResolver, HasClaudeSessionRegistry, HasEventLog, HasGitHubClient,
-    HasGitWorktreeService, HasProjectDir, HasSupervisorRegistry, HasTeamRegistry,
+    HasGitWorktreeService, HasProjectDir, HasSupervisorRegistry, HasTeamRegistry, HasTmuxIpc,
 };
 
 /// Agent effect handler.
@@ -46,6 +46,7 @@ impl<
             + HasSupervisorRegistry
             + HasClaudeSessionRegistry
             + HasEventLog
+            + HasTmuxIpc
             + 'static,
     > AgentHandler<C>
 {
@@ -200,6 +201,7 @@ impl<
             + HasSupervisorRegistry
             + HasClaudeSessionRegistry
             + HasEventLog
+            + HasTmuxIpc
             + 'static,
     > EffectHandler for AgentHandler<C>
 {
@@ -275,6 +277,7 @@ impl<
             + HasSupervisorRegistry
             + HasClaudeSessionRegistry
             + HasEventLog
+            + HasTmuxIpc
             + 'static,
     > AgentEffects for AgentHandler<C>
 {
@@ -794,7 +797,10 @@ impl<
             // Try pane_id first (ephemeral workers)
             if let Some(pane_id) = r["pane_id"].as_str() {
                 info!(agent = %ctx.agent_name, pane_id = %pane_id, "Closing worker pane");
-                if let Err(e) = crate::services::tmux_events::close_worker_pane(pane_id).await {
+                if let Err(e) =
+                    crate::services::tmux_events::close_worker_pane(self.ctx.tmux_ipc(), pane_id)
+                        .await
+                {
                     warn!(agent = %ctx.agent_name, pane_id = %pane_id, error = %e, "Failed to close worker pane");
                 } else {
                     closed = true;
@@ -803,9 +809,7 @@ impl<
             // Try window_id (worktree-based agents)
             else if let Some(window_id) = r["window_id"].as_str() {
                 info!(agent = %ctx.agent_name, window_id = %window_id, "Closing agent window");
-                let session = std::env::var("EXOMONAD_TMUX_SESSION")
-                    .unwrap_or_else(|_| "exomonad".to_string());
-                let ipc = crate::services::tmux_ipc::TmuxIpc::new(&session);
+                let ipc = self.ctx.tmux_ipc();
                 match crate::services::tmux_ipc::WindowId::parse(window_id) {
                     Ok(wid) => {
                         if let Err(e) = ipc.kill_window(&wid).await {

--- a/rust/exomonad-core/src/handlers/events.rs
+++ b/rust/exomonad-core/src/handlers/events.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 use crate::services::{
     HasAcpRegistry, HasAgentResolver, HasEventLog, HasEventQueue, HasProjectDir,
-    HasSupervisorRegistry, HasTeamRegistry,
+    HasSupervisorRegistry, HasTeamRegistry, HasTmuxIpc,
 };
 
 /// Events effect handler.
@@ -42,6 +42,7 @@ impl<
             + HasEventQueue
             + HasProjectDir
             + HasSupervisorRegistry
+            + HasTmuxIpc
             + 'static,
     > EffectHandler for EventHandler<C>
 {
@@ -68,6 +69,7 @@ impl<
             + HasEventQueue
             + HasProjectDir
             + HasSupervisorRegistry
+            + HasTmuxIpc
             + 'static,
     > EventEffects for EventHandler<C>
 {

--- a/rust/exomonad-core/src/services/agent_control/cleanup.rs
+++ b/rust/exomonad-core/src/services/agent_control/cleanup.rs
@@ -7,6 +7,7 @@ impl<
             + super::super::HasAgentResolver
             + super::super::HasProjectDir
             + super::super::HasGitWorktreeService
+            + super::super::HasTmuxIpc
             + 'static,
     > AgentControlService<C>
 {

--- a/rust/exomonad-core/src/services/agent_control/internal.rs
+++ b/rust/exomonad-core/src/services/agent_control/internal.rs
@@ -125,7 +125,19 @@ impl<
 
     /// Get the direct tmux IPC client from context.
     pub(crate) fn tmux(&self) -> Result<super::tmux_ipc::TmuxIpc> {
-        Ok(self.ctx.tmux_ipc().clone())
+        let tmux = self.ctx.tmux_ipc().clone();
+        let configured_session = self.resolve_tmux_session()?;
+        let ctx_session = tmux.session_name();
+
+        if configured_session != ctx_session {
+            anyhow::bail!(
+                "Configured tmux session '{}' does not match context tmux session '{}'",
+                configured_session,
+                ctx_session
+            );
+        }
+
+        Ok(tmux)
     }
 
     /// Clean up an existing worktree (if present) and create a fresh one.
@@ -1190,6 +1202,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_spawn_rollback_disarmed_preserves_state() {
+        if !super::tmux_ipc::IsolatedTmux::is_available().await {
+            eprintln!("skipping test_spawn_rollback_disarmed_preserves_state: tmux not available");
+            return;
+        }
         let temp_dir = tempfile::tempdir().unwrap();
         let project_dir = temp_dir.path().to_path_buf();
         let services = test_services(project_dir.clone());

--- a/rust/exomonad-core/src/services/agent_control/internal.rs
+++ b/rust/exomonad-core/src/services/agent_control/internal.rs
@@ -113,6 +113,7 @@ impl<
             + super::super::HasAgentResolver
             + super::super::HasProjectDir
             + super::super::HasGitWorktreeService
+            + super::super::HasTmuxIpc
             + 'static,
     > AgentControlService<C>
 {
@@ -122,13 +123,9 @@ impl<
             .ok_or_else(|| anyhow!("No tmux session configured (call with_tmux_session)"))
     }
 
-    /// Get the direct tmux IPC client, falling back to creating one from config or env.
+    /// Get the direct tmux IPC client from context.
     pub(crate) fn tmux(&self) -> Result<super::tmux_ipc::TmuxIpc> {
-        if let Some(ref ipc) = self.tmux_ipc {
-            return Ok(ipc.clone());
-        }
-        let session = self.resolve_tmux_session()?;
-        Ok(super::tmux_ipc::TmuxIpc::new(&session))
+        Ok(self.ctx.tmux_ipc().clone())
     }
 
     /// Clean up an existing worktree (if present) and create a fresh one.
@@ -1166,7 +1163,7 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
         let project_dir = temp_dir.path().to_path_buf();
         let services = test_services(project_dir.clone());
-        let tmux = super::tmux_ipc::TmuxIpc::new("test");
+        let isolated = super::tmux_ipc::IsolatedTmux::new().await.unwrap();
         let git_wt = services.git_worktree_service().clone();
 
         let wt_path = project_dir.join("test-wt");
@@ -1174,7 +1171,7 @@ mod tests {
         assert!(wt_path.exists());
 
         {
-            let mut rollback = SpawnRollback::new(tmux, git_wt);
+            let mut rollback = SpawnRollback::new(isolated.ipc.clone(), git_wt);
             rollback.set_worktree(wt_path.clone());
             // Drop without disarming
         }
@@ -1196,7 +1193,7 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
         let project_dir = temp_dir.path().to_path_buf();
         let services = test_services(project_dir.clone());
-        let tmux = super::tmux_ipc::TmuxIpc::new("test");
+        let isolated = super::tmux_ipc::IsolatedTmux::new().await.unwrap();
         let git_wt = services.git_worktree_service().clone();
 
         let wt_path = project_dir.join("test-wt-preserved");
@@ -1204,7 +1201,7 @@ mod tests {
         assert!(wt_path.exists());
 
         {
-            let mut rollback = SpawnRollback::new(tmux, git_wt);
+            let mut rollback = SpawnRollback::new(isolated.ipc.clone(), git_wt);
             rollback.set_worktree(wt_path.clone());
             rollback.disarm();
             // Drop while disarmed

--- a/rust/exomonad-core/src/services/agent_control/mod.rs
+++ b/rust/exomonad-core/src/services/agent_control/mod.rs
@@ -517,8 +517,6 @@ pub struct AgentControlService<C> {
     pub(crate) worktree_base: PathBuf,
     /// tmux session name for event emission
     pub(crate) tmux_session: Option<String>,
-    /// Direct tmux IPC client.
-    pub(crate) tmux_ipc: Option<super::tmux_ipc::TmuxIpc>,
     /// This agent's birth-branch (git identity). Root TL = "main".
     pub(crate) birth_branch: BirthBranch,
     /// When true, spawned Gemini agents receive `--yolo` flag.
@@ -536,6 +534,7 @@ impl<
             + super::HasAgentResolver
             + super::HasProjectDir
             + super::HasGitWorktreeService
+            + super::HasTmuxIpc
             + 'static,
     > AgentControlService<C>
 {
@@ -546,7 +545,6 @@ impl<
             ctx,
             worktree_base,
             tmux_session: None,
-            tmux_ipc: None,
             birth_branch: BirthBranch::from("unset"),
             yolo: false,
             wasm_name: "devswarm".to_string(),
@@ -566,9 +564,8 @@ impl<
         self
     }
 
-    /// Set the tmux session name for event emission + direct IPC.
+    /// Set the tmux session name for event emission.
     pub fn with_tmux_session(mut self, session: String) -> Self {
-        self.tmux_ipc = Some(super::tmux_ipc::TmuxIpc::new(&session));
         self.tmux_session = Some(session);
         self
     }

--- a/rust/exomonad-core/src/services/agent_control/spawn.rs
+++ b/rust/exomonad-core/src/services/agent_control/spawn.rs
@@ -7,6 +7,7 @@ impl<
             + super::super::HasAgentResolver
             + super::super::HasProjectDir
             + super::super::HasGitWorktreeService
+            + super::super::HasTmuxIpc
             + 'static,
     > AgentControlService<C>
 {

--- a/rust/exomonad-core/src/services/delivery.rs
+++ b/rust/exomonad-core/src/services/delivery.rs
@@ -834,6 +834,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_deliver_no_registry_returns_tmux() {
+        if !crate::services::tmux_ipc::IsolatedTmux::is_available().await {
+            eprintln!("skipping test_deliver_no_registry_returns_tmux: tmux not available");
+            return;
+        }
         let isolated = crate::services::tmux_ipc::IsolatedTmux::new()
             .await
             .expect("tmux unavailable");
@@ -854,6 +858,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_route_message_to_agent_address_unknown() {
+        if !crate::services::tmux_ipc::IsolatedTmux::is_available().await {
+            eprintln!("skipping test_route_message_to_agent_address_unknown: tmux not available");
+            return;
+        }
         let isolated = crate::services::tmux_ipc::IsolatedTmux::new()
             .await
             .expect("tmux unavailable");
@@ -869,6 +877,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_route_message_to_team_with_explicit_member() {
+        if !crate::services::tmux_ipc::IsolatedTmux::is_available().await {
+            eprintln!(
+                "skipping test_route_message_to_team_with_explicit_member: tmux not available"
+            );
+            return;
+        }
         let isolated = crate::services::tmux_ipc::IsolatedTmux::new()
             .await
             .expect("tmux unavailable");
@@ -884,6 +898,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_route_message_to_team_lead_fallback_no_config() {
+        if !crate::services::tmux_ipc::IsolatedTmux::is_available().await {
+            eprintln!(
+                "skipping test_route_message_to_team_lead_fallback_no_config: tmux not available"
+            );
+            return;
+        }
         let isolated = crate::services::tmux_ipc::IsolatedTmux::new()
             .await
             .expect("tmux unavailable");
@@ -909,6 +929,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_deliver_to_agent_no_routing() {
+        if !crate::services::tmux_ipc::IsolatedTmux::is_available().await {
+            eprintln!("skipping test_deliver_to_agent_no_routing: tmux not available");
+            return;
+        }
         let isolated = crate::services::tmux_ipc::IsolatedTmux::new()
             .await
             .expect("tmux unavailable");
@@ -961,6 +985,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_resolve_lead_root_fallback() {
+        if !crate::services::tmux_ipc::IsolatedTmux::is_available().await {
+            eprintln!("skipping test_resolve_lead_root_fallback: tmux not available");
+            return;
+        }
         let isolated = crate::services::tmux_ipc::IsolatedTmux::new()
             .await
             .expect("tmux unavailable");

--- a/rust/exomonad-core/src/services/delivery.rs
+++ b/rust/exomonad-core/src/services/delivery.rs
@@ -154,7 +154,8 @@ pub async fn route_message(
     ctx: &(impl super::HasTeamRegistry
           + super::HasAcpRegistry
           + super::HasAgentResolver
-          + super::HasProjectDir),
+          + super::HasProjectDir
+          + super::HasTmuxIpc),
     address: &Address,
     from: &crate::domain::AgentName,
     content: &str,
@@ -194,7 +195,8 @@ async fn resolve_and_deliver_to_lead(
     ctx: &(impl super::HasTeamRegistry
           + super::HasAcpRegistry
           + super::HasAgentResolver
-          + super::HasProjectDir),
+          + super::HasProjectDir
+          + super::HasTmuxIpc),
     team_name: &str,
     from: &crate::domain::AgentName,
     content: &str,
@@ -286,7 +288,8 @@ pub async fn notify_parent_delivery(
           + super::HasAcpRegistry
           + super::HasEventLog
           + super::HasEventQueue
-          + super::HasProjectDir),
+          + super::HasProjectDir
+          + super::HasTmuxIpc),
     agent_id: &crate::domain::AgentName,
     parent_session_id: &str,
     parent_tab_name: &str,
@@ -427,7 +430,10 @@ async fn deliver_via_uds(
 /// Falls back to tmux input injection if other delivery methods fail or are not available.
 #[instrument(skip_all, fields(agent_key = %agent_key, from = %from, delivery_method = tracing::field::Empty))]
 pub async fn deliver_to_agent(
-    ctx: &(impl super::HasTeamRegistry + super::HasAcpRegistry + super::HasProjectDir),
+    ctx: &(impl super::HasTeamRegistry
+          + super::HasAcpRegistry
+          + super::HasProjectDir
+          + super::HasTmuxIpc),
     agent_key: &str,
     tmux_target: &str,
     from: &crate::domain::AgentName,
@@ -437,6 +443,7 @@ pub async fn deliver_to_agent(
     let team_registry = ctx.team_registry();
     let acp_registry = ctx.acp_registry();
     let project_dir = ctx.project_dir();
+    let tmux_ipc = ctx.tmux_ipc();
 
     // Batch lookup: sender's team (for Tier 2 scoping) + recipient in-memory check.
     // Single lock acquisition instead of two separate get() calls.
@@ -530,6 +537,7 @@ pub async fn deliver_to_agent(
                 crate::services::resolve_worktree_from_tab(tmux_target)
             };
             let pd = project_dir.join(worktree);
+            let tmux_ipc = tmux_ipc.clone();
             tokio::spawn(async move {
                 let verify_policy = crate::services::resilience::RetryPolicy::new(
                     3,
@@ -572,7 +580,7 @@ pub async fn deliver_to_agent(
                     target = %target,
                     "Teams inbox message not read after 30s, falling back to tmux injection"
                 );
-                if let Err(e) = tmux_events::inject_input(&target, &msg, &pd).await {
+                if let Err(e) = tmux_events::inject_input(&tmux_ipc, &target, &msg, &pd).await {
                     warn!(target = %target, error = %e, "tmux inject_input failed (Teams fallback)");
                 }
             });
@@ -721,13 +729,14 @@ pub async fn deliver_to_agent(
             crate::services::resolve_working_dir(agent_key)
         };
         let effective_pd = project_dir.join(worktree);
-        let outcome = match tmux_events::inject_input(&target, message, &effective_pd).await {
-            Ok(()) => "success",
-            Err(e) => {
-                warn!(target = %target, error = %e, "tmux inject_input failed (routing.json)");
-                "failed"
-            }
-        };
+        let outcome =
+            match tmux_events::inject_input(tmux_ipc, &target, message, &effective_pd).await {
+                Ok(()) => "success",
+                Err(e) => {
+                    warn!(target = %target, error = %e, "tmux inject_input failed (routing.json)");
+                    "failed"
+                }
+            };
         tracing::info!(
             otel.name = "message.delivery",
             agent_id = %from,
@@ -753,13 +762,14 @@ pub async fn deliver_to_agent(
         crate::services::resolve_worktree_from_tab(tmux_target)
     };
     let effective_pd = project_dir.join(worktree);
-    let outcome = match tmux_events::inject_input(tmux_target, message, &effective_pd).await {
-        Ok(()) => "success",
-        Err(e) => {
-            warn!(target = %tmux_target, error = %e, "tmux inject_input failed (fallback)");
-            "failed"
-        }
-    };
+    let outcome =
+        match tmux_events::inject_input(tmux_ipc, tmux_target, message, &effective_pd).await {
+            Ok(()) => "success",
+            Err(e) => {
+                warn!(target = %tmux_target, error = %e, "tmux inject_input failed (fallback)");
+                "failed"
+            }
+        };
     tracing::info!(
         otel.name = "message.delivery",
         agent_id = %from,
@@ -778,6 +788,7 @@ mod tests {
     use crate::domain::AgentName;
     use crate::services::HasEventQueue;
     use serial_test::serial;
+    use std::sync::Arc;
 
     #[test]
     fn test_format_parent_notification_success() {
@@ -823,7 +834,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_deliver_no_registry_returns_tmux() {
-        let services = crate::services::Services::test();
+        let isolated = crate::services::tmux_ipc::IsolatedTmux::new()
+            .await
+            .expect("tmux unavailable");
+        let services = crate::services::Services::test_with_tmux(Arc::new(isolated.ipc.clone()));
         let result = deliver_to_agent(
             &services,
             "agent-1",
@@ -833,12 +847,17 @@ mod tests {
             "summary",
         )
         .await;
+        // In isolated tmux, tab-1 doesn't exist, so it should still return Tmux
+        // (the delivery code returns Tmux regardless of inject_input success, it just warns on Err)
         assert_eq!(result, DeliveryResult::Tmux);
     }
 
     #[tokio::test]
     async fn test_route_message_to_agent_address_unknown() {
-        let services = crate::services::Services::test();
+        let isolated = crate::services::tmux_ipc::IsolatedTmux::new()
+            .await
+            .expect("tmux unavailable");
+        let services = crate::services::Services::test_with_tmux(Arc::new(isolated.ipc.clone()));
         let from = AgentName::from("sender");
         let address = Address::Agent(AgentName::from("unknown"));
         let outcome = route_message(&services, &address, &from, "content", "summary").await;
@@ -850,7 +869,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_route_message_to_team_with_explicit_member() {
-        let services = crate::services::Services::test();
+        let isolated = crate::services::tmux_ipc::IsolatedTmux::new()
+            .await
+            .expect("tmux unavailable");
+        let services = crate::services::Services::test_with_tmux(Arc::new(isolated.ipc.clone()));
         let from = AgentName::from("sender");
         let address = Address::Team {
             team: "team-a".into(),
@@ -862,7 +884,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_route_message_to_team_lead_fallback_no_config() {
-        let services = crate::services::Services::test();
+        let isolated = crate::services::tmux_ipc::IsolatedTmux::new()
+            .await
+            .expect("tmux unavailable");
+        let services = crate::services::Services::test_with_tmux(Arc::new(isolated.ipc.clone()));
         let from = AgentName::from("sender");
         let address = Address::Team {
             team: "team-a".into(),
@@ -884,7 +909,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_deliver_to_agent_no_routing() {
-        let services = crate::services::Services::test();
+        let isolated = crate::services::tmux_ipc::IsolatedTmux::new()
+            .await
+            .expect("tmux unavailable");
+        let services = crate::services::Services::test_with_tmux(Arc::new(isolated.ipc.clone()));
         let result = deliver_to_agent(
             &services,
             "agent-no-routing",
@@ -908,7 +936,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_notify_parent_delivery_publishes_event() {
-        let services = crate::services::Services::test();
+        let isolated = crate::services::tmux_ipc::IsolatedTmux::new()
+            .await
+            .expect("tmux unavailable");
+        let services = crate::services::Services::test_with_tmux(Arc::new(isolated.ipc.clone()));
         let agent_id = AgentName::from("agent-1");
 
         notify_parent_delivery(
@@ -930,7 +961,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_resolve_lead_root_fallback() {
-        let services = crate::services::Services::test();
+        let isolated = crate::services::tmux_ipc::IsolatedTmux::new()
+            .await
+            .expect("tmux unavailable");
+        let services = crate::services::Services::test_with_tmux(Arc::new(isolated.ipc.clone()));
         let from = AgentName::from("sender");
         // No config.json and empty TeamRegistry should fallback to root
         let outcome =
@@ -1003,7 +1037,10 @@ mod tests {
         });
         std::fs::write(&config_file, serde_json::to_string(&config).unwrap()).unwrap();
 
-        let services = crate::services::Services::test();
+        let isolated = crate::services::tmux_ipc::IsolatedTmux::new()
+            .await
+            .expect("tmux unavailable");
+        let services = crate::services::Services::test_with_tmux(Arc::new(isolated.ipc.clone()));
         let from = AgentName::from("sender");
         let outcome =
             resolve_and_deliver_to_lead(&services, team_name, &from, "content", "summary").await;

--- a/rust/exomonad-core/src/services/github_poller.rs
+++ b/rust/exomonad-core/src/services/github_poller.rs
@@ -16,7 +16,7 @@ use tracing::{debug, info, instrument, warn};
 
 use crate::services::{
     HasAcpRegistry, HasAgentResolver, HasEventLog, HasEventQueue, HasGitHubClient, HasProjectDir,
-    HasTeamRegistry,
+    HasTeamRegistry, HasTmuxIpc,
 };
 
 type PluginMap = Arc<RwLock<HashMap<crate::AgentName, Arc<PluginManager>>>>;
@@ -283,6 +283,7 @@ impl<
             + HasEventQueue
             + HasProjectDir
             + HasGitHubClient
+            + HasTmuxIpc
             + 'static,
     > GitHubPoller<C>
 {

--- a/rust/exomonad-core/src/services/inbox_watcher.rs
+++ b/rust/exomonad-core/src/services/inbox_watcher.rs
@@ -19,6 +19,7 @@ use claude_teams_bridge::{inbox_path, TeamsMessage};
 struct WatchState {
     last_count: usize,
     tmux_target: String,
+    tmux: Arc<crate::services::tmux_ipc::TmuxIpc>,
     project_dir: PathBuf,
     is_running: Arc<AtomicBool>,
 }
@@ -47,6 +48,7 @@ impl InboxWatcher {
         team_name: String,
         member_name: String,
         tmux_target: String,
+        tmux: Arc<crate::services::tmux_ipc::TmuxIpc>,
         project_dir: PathBuf,
     ) {
         let mut watches = self.watches.lock().await;
@@ -69,6 +71,7 @@ impl InboxWatcher {
             WatchState {
                 last_count,
                 tmux_target: tmux_target.clone(),
+                tmux,
                 project_dir: project_dir.clone(),
                 is_running: is_running.clone(),
             },
@@ -120,9 +123,13 @@ impl InboxWatcher {
                         let new_count = msgs.len() - state.last_count;
                         info!(member = %member, new_messages = new_count, "InboxWatcher: routing to tmux");
                         for msg in &msgs[state.last_count..] {
-                            if let Err(e) =
-                                inject_input(&state.tmux_target, &msg.text, &state.project_dir)
-                                    .await
+                            if let Err(e) = inject_input(
+                                &state.tmux,
+                                &state.tmux_target,
+                                &msg.text,
+                                &state.project_dir,
+                            )
+                            .await
                             {
                                 warn!(member = %member, error = %e, "Failed to inject inbox message via tmux");
                             }

--- a/rust/exomonad-core/src/services/mod.rs
+++ b/rust/exomonad-core/src/services/mod.rs
@@ -297,12 +297,16 @@ impl Services {
     pub fn test() -> Self {
         Self::test_with_project_dir(PathBuf::from("."))
     }
-
     /// Construct a test Services rooted at `project_dir`. The `git_wt` service
     /// is constructed from the same directory.
     pub fn test_with_project_dir(project_dir: PathBuf) -> Self {
         let git_wt = Arc::new(GitWorktreeService::new(project_dir.clone()));
-        let tmux_ipc = Arc::new(self::tmux_ipc::TmuxIpc::new("test-session"));
+        // Use a dummy socket for tests to avoid hitting the real tmux server
+        // unless explicitly requested via test_with_tmux().
+        let tmux_ipc = Arc::new(self::tmux_ipc::TmuxIpc::new_with_socket(
+            "test-session",
+            Some("exomonad-test-dummy".to_string()),
+        ));
         ServicesBuilder::new(
             project_dir,
             PathBuf::from(".claude/tasks"),

--- a/rust/exomonad-core/src/services/mod.rs
+++ b/rust/exomonad-core/src/services/mod.rs
@@ -88,6 +88,9 @@ pub trait HasGitWorktreeService: Send + Sync {
 pub trait HasTasksDir: Send + Sync {
     fn tasks_dir(&self) -> &std::path::Path;
 }
+pub trait HasTmuxIpc: Send + Sync {
+    fn tmux_ipc(&self) -> &self::tmux_ipc::TmuxIpc;
+}
 
 // ============================================================================
 // Services — the concrete type that implements all traits
@@ -112,6 +115,7 @@ pub struct Services {
     event_queue: Arc<EventQueue>,
     mutex_registry: Arc<MutexRegistry>,
     git_wt: Arc<GitWorktreeService>,
+    tmux_ipc: Arc<self::tmux_ipc::TmuxIpc>,
 }
 
 /// Builder for [`Services`]. All required fields are passed to `new()`; optional
@@ -121,6 +125,7 @@ pub struct ServicesBuilder {
     project_dir: PathBuf,
     tasks_dir: PathBuf,
     git_wt: Arc<GitWorktreeService>,
+    tmux_ipc: Arc<self::tmux_ipc::TmuxIpc>,
     github_client: Option<Arc<GitHubClient>>,
     event_log: Option<Arc<EventLog>>,
     team_registry: Arc<TeamRegistry>,
@@ -133,11 +138,17 @@ pub struct ServicesBuilder {
 }
 
 impl ServicesBuilder {
-    pub fn new(project_dir: PathBuf, tasks_dir: PathBuf, git_wt: Arc<GitWorktreeService>) -> Self {
+    pub fn new(
+        project_dir: PathBuf,
+        tasks_dir: PathBuf,
+        git_wt: Arc<GitWorktreeService>,
+        tmux_ipc: Arc<self::tmux_ipc::TmuxIpc>,
+    ) -> Self {
         Self {
             project_dir,
             tasks_dir,
             git_wt,
+            tmux_ipc,
             github_client: None,
             event_log: None,
             team_registry: Arc::new(TeamRegistry::new()),
@@ -209,6 +220,7 @@ impl ServicesBuilder {
             event_queue: self.event_queue,
             mutex_registry: self.mutex_registry,
             git_wt: self.git_wt,
+            tmux_ipc: self.tmux_ipc,
         }
     }
 }
@@ -273,6 +285,11 @@ impl HasTasksDir for Services {
         &self.tasks_dir
     }
 }
+impl HasTmuxIpc for Services {
+    fn tmux_ipc(&self) -> &self::tmux_ipc::TmuxIpc {
+        &self.tmux_ipc
+    }
+}
 
 #[cfg(test)]
 impl Services {
@@ -285,7 +302,27 @@ impl Services {
     /// is constructed from the same directory.
     pub fn test_with_project_dir(project_dir: PathBuf) -> Self {
         let git_wt = Arc::new(GitWorktreeService::new(project_dir.clone()));
-        ServicesBuilder::new(project_dir, PathBuf::from(".claude/tasks"), git_wt).build()
+        let tmux_ipc = Arc::new(self::tmux_ipc::TmuxIpc::new("test-session"));
+        ServicesBuilder::new(
+            project_dir,
+            PathBuf::from(".claude/tasks"),
+            git_wt,
+            tmux_ipc,
+        )
+        .build()
+    }
+
+    /// Construct a test Services with a specific TmuxIpc.
+    pub fn test_with_tmux(tmux_ipc: Arc<self::tmux_ipc::TmuxIpc>) -> Self {
+        let project_dir = PathBuf::from(".");
+        let git_wt = Arc::new(GitWorktreeService::new(project_dir.clone()));
+        ServicesBuilder::new(
+            project_dir,
+            PathBuf::from(".claude/tasks"),
+            git_wt,
+            tmux_ipc,
+        )
+        .build()
     }
 
     /// Test-only setter for injecting a GitHubClient into an already-built

--- a/rust/exomonad-core/src/services/tmux_events.rs
+++ b/rust/exomonad-core/src/services/tmux_events.rs
@@ -73,12 +73,12 @@ async fn gc_tmp_dir(tmp_dir: &Path) {
 /// Both Claude and Gemini auto-read `@filepath` references.
 ///
 /// Tmp files older than 1 hour are garbage-collected on each write.
-pub async fn inject_input(target: &str, text: &str, project_dir: &Path) -> Result<()> {
-    let session =
-        std::env::var("EXOMONAD_TMUX_SESSION").context("EXOMONAD_TMUX_SESSION not set")?;
-
-    let ipc = TmuxIpc::new(&session);
-
+pub async fn inject_input(
+    ipc: &TmuxIpc,
+    target: &str,
+    text: &str,
+    project_dir: &Path,
+) -> Result<()> {
     if text.contains('\n') {
         let tmp_dir = project_dir.join(".exo/tmp");
         tokio::fs::create_dir_all(&tmp_dir)
@@ -105,8 +105,7 @@ pub async fn inject_input(target: &str, text: &str, project_dir: &Path) -> Resul
             relative_path
         );
 
-        let target = target.to_string();
-        ipc.inject_input(&target, &pointer).await
+        ipc.inject_input(target, &pointer).await
     } else {
         info!(
             "[TmuxEvents] Injecting input to target '{}': {} chars",
@@ -114,22 +113,15 @@ pub async fn inject_input(target: &str, text: &str, project_dir: &Path) -> Resul
             text.len()
         );
 
-        let target = target.to_string();
-        let text = text.to_string();
-        ipc.inject_input(&target, &text).await
+        ipc.inject_input(target, text).await
     }
 }
 
 /// Close a worker pane by pane_id.
-pub async fn close_worker_pane(pane_id: &str) -> Result<()> {
-    let session =
-        std::env::var("EXOMONAD_TMUX_SESSION").context("EXOMONAD_TMUX_SESSION not set")?;
-
+pub async fn close_worker_pane(ipc: &TmuxIpc, pane_id: &str) -> Result<()> {
     info!("[TmuxEvents] Closing worker pane '{}'", pane_id);
 
     let pid = PaneId::parse(pane_id).context("Invalid pane_id")?;
-    let ipc = TmuxIpc::new(&session);
-
     ipc.kill_pane(&pid).await
 }
 

--- a/rust/exomonad-core/src/services/tmux_ipc.rs
+++ b/rust/exomonad-core/src/services/tmux_ipc.rs
@@ -110,12 +110,21 @@ pub struct WindowInfo {
 #[derive(Debug, Clone)]
 pub struct TmuxIpc {
     session_name: String,
+    socket_name: Option<String>,
 }
 
 impl TmuxIpc {
     pub fn new(session_name: &str) -> Self {
         Self {
             session_name: session_name.to_string(),
+            socket_name: None,
+        }
+    }
+
+    pub fn new_with_socket(session_name: &str, socket_name: Option<String>) -> Self {
+        Self {
+            session_name: session_name.to_string(),
+            socket_name,
         }
     }
 
@@ -123,11 +132,32 @@ impl TmuxIpc {
         &self.session_name
     }
 
+    fn tmux_cmd(&self) -> Command {
+        let mut cmd = Command::new("tmux");
+        if let Some(socket) = &self.socket_name {
+            cmd.arg("-L").arg(socket);
+        }
+        cmd
+    }
+
+    #[cfg(test)]
+    fn tmux_cmd_sync(&self) -> std::process::Command {
+        let mut cmd = std::process::Command::new("tmux");
+        if let Some(socket) = &self.socket_name {
+            cmd.arg("-L").arg(socket);
+        }
+        cmd
+    }
+
     // -- Session management (static, no &self) --
 
     /// Create a new tmux session. Returns the stable window ID (@N) of the initial window.
-    pub async fn new_session(name: &str, cwd: &Path) -> Result<WindowId> {
-        let output = Command::new("tmux")
+    pub async fn new_session(name: &str, cwd: &Path, socket: Option<&str>) -> Result<WindowId> {
+        let mut cmd = Command::new("tmux");
+        if let Some(s) = socket {
+            cmd.arg("-L").arg(s);
+        }
+        let output = cmd
             .args([
                 "new-session",
                 "-d",
@@ -155,8 +185,12 @@ impl TmuxIpc {
         Ok(window_id)
     }
 
-    pub async fn has_session(name: &str) -> Result<bool> {
-        let status = Command::new("tmux")
+    pub async fn has_session(name: &str, socket: Option<&str>) -> Result<bool> {
+        let mut cmd = Command::new("tmux");
+        if let Some(s) = socket {
+            cmd.arg("-L").arg(s);
+        }
+        let status = cmd
             .args(["has-session", "-t", name])
             .status()
             .await
@@ -164,8 +198,12 @@ impl TmuxIpc {
         Ok(status.success())
     }
 
-    pub async fn kill_session(name: &str) -> Result<()> {
-        let output = Command::new("tmux")
+    pub async fn kill_session(name: &str, socket: Option<&str>) -> Result<()> {
+        let mut cmd = Command::new("tmux");
+        if let Some(s) = socket {
+            cmd.arg("-L").arg(s);
+        }
+        let output = cmd
             .args(["kill-session", "-t", name])
             .output()
             .await
@@ -181,11 +219,13 @@ impl TmuxIpc {
     }
 
     /// Exec into tmux attach (replaces current process).
-    pub async fn attach_session(name: &str) -> Result<()> {
+    pub async fn attach_session(name: &str, socket: Option<&str>) -> Result<()> {
         use std::os::unix::process::CommandExt;
-        let err = std::process::Command::new("tmux")
-            .args(["attach-session", "-t", name])
-            .exec();
+        let mut cmd = std::process::Command::new("tmux");
+        if let Some(s) = socket {
+            cmd.arg("-L").arg(s);
+        }
+        let err = cmd.args(["attach-session", "-t", name]).exec();
         Err(anyhow::anyhow!("exec tmux attach failed: {}", err))
     }
 
@@ -199,7 +239,8 @@ impl TmuxIpc {
         shell: &str,
         command: &str,
     ) -> Result<WindowId> {
-        let output = Command::new("tmux")
+        let output = self
+            .tmux_cmd()
             .args([
                 "new-window",
                 "-P",
@@ -233,7 +274,8 @@ impl TmuxIpc {
     }
 
     pub async fn list_windows(&self) -> Result<Vec<WindowInfo>> {
-        let output = Command::new("tmux")
+        let output = self
+            .tmux_cmd()
             .args([
                 "list-windows",
                 "-t",
@@ -286,7 +328,8 @@ impl TmuxIpc {
     }
 
     pub async fn kill_window(&self, window_id: &WindowId) -> Result<()> {
-        let output = Command::new("tmux")
+        let output = self
+            .tmux_cmd()
             .args(["kill-window", "-t", window_id.as_str()])
             .output()
             .await
@@ -302,7 +345,8 @@ impl TmuxIpc {
     }
 
     pub async fn select_window(&self, window_id: &WindowId) -> Result<()> {
-        let output = Command::new("tmux")
+        let output = self
+            .tmux_cmd()
             .args(["select-window", "-t", window_id.as_str()])
             .output()
             .await
@@ -326,7 +370,8 @@ impl TmuxIpc {
         shell: &str,
         command: &str,
     ) -> Result<PaneId> {
-        let output = Command::new("tmux")
+        let output = self
+            .tmux_cmd()
             .args([
                 "split-window",
                 "-P",
@@ -365,7 +410,8 @@ impl TmuxIpc {
     ) -> Result<()> {
         let qualified = format!("{}:{}", self.session_name, window_id.as_str());
         let layout_str = layout.as_str();
-        let output = Command::new("tmux")
+        let output = self
+            .tmux_cmd()
             .args(["select-layout", "-t", &qualified, layout_str])
             .output()
             .await
@@ -381,7 +427,8 @@ impl TmuxIpc {
     }
 
     pub async fn kill_pane(&self, pane_id: &PaneId) -> Result<()> {
-        let output = Command::new("tmux")
+        let output = self
+            .tmux_cmd()
             .args(["kill-pane", "-t", pane_id.as_str()])
             .output()
             .await
@@ -434,7 +481,8 @@ impl TmuxIpc {
 
         // Exit copy/scroll mode if active — copy mode intercepts input,
         // preventing paste-buffer from reaching the underlying process.
-        let mode_output = Command::new("tmux")
+        let mode_output = self
+            .tmux_cmd()
             .args([
                 "display-message",
                 "-p",
@@ -446,7 +494,8 @@ impl TmuxIpc {
             .await;
         if let Ok(output) = mode_output {
             if output.status.success() && String::from_utf8_lossy(&output.stdout).trim() == "1" {
-                let _ = Command::new("tmux")
+                let _ = self
+                    .tmux_cmd()
                     .args(["send-keys", "-t", &qualified_target, "-X", "cancel"])
                     .output()
                     .await;
@@ -464,7 +513,8 @@ impl TmuxIpc {
             .await
             .context("Failed to write temp buffer file")?;
 
-        let load_result = Command::new("tmux")
+        let load_result = self
+            .tmux_cmd()
             .args(["load-buffer", "-b", &buf_name, &tmp_path])
             .output()
             .await;
@@ -483,14 +533,16 @@ impl TmuxIpc {
         // No -p flag: bracketed paste (\e[200~...\e[201~) crashes Claude Code's
         // Ink TUI and breaks Gemini CLI's readline. Plain paste streams bytes
         // as standard keyboard input.
-        let paste_output = Command::new("tmux")
+        let paste_output = self
+            .tmux_cmd()
             .args(["paste-buffer", "-b", &buf_name, "-t", &qualified_target])
             .output()
             .await
             .context("Failed to run tmux paste-buffer")?;
 
         // Delete the named buffer
-        match Command::new("tmux")
+        match self
+            .tmux_cmd()
             .args(["delete-buffer", "-b", &buf_name])
             .output()
             .await
@@ -526,10 +578,11 @@ impl TmuxIpc {
                 initial: std::time::Duration::from_millis(200),
             },
         );
-        let qt = &qualified_target;
+        let qt = qualified_target.clone();
         crate::services::resilience::retry(&enter_policy, || async {
-            let output = Command::new("tmux")
-                .args(["send-keys", "-t", qt, "Enter"])
+            let output = self
+                .tmux_cmd()
+                .args(["send-keys", "-t", &qt, "Enter"])
                 .output()
                 .await
                 .context("Failed to run tmux send-keys")?;
@@ -563,7 +616,8 @@ impl TmuxIpc {
         let qualified = format!("{}:{}", self.session_name, target);
 
         // Read current window dimensions
-        let output = Command::new("tmux")
+        let output = self
+            .tmux_cmd()
             .args([
                 "display-message",
                 "-t",
@@ -592,7 +646,8 @@ impl TmuxIpc {
         let height: u32 = parts[1].parse().context("Failed to parse window height")?;
 
         // Resize +1 column
-        let _ = Command::new("tmux")
+        let _ = self
+            .tmux_cmd()
             .args([
                 "resize-window",
                 "-t",
@@ -608,7 +663,8 @@ impl TmuxIpc {
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
         // Restore original size
-        let _ = Command::new("tmux")
+        let _ = self
+            .tmux_cmd()
             .args([
                 "resize-window",
                 "-t",
@@ -628,12 +684,62 @@ impl TmuxIpc {
     // -- Query --
 
     pub async fn pane_exists(&self, pane_id: &PaneId) -> Result<bool> {
-        let status = Command::new("tmux")
+        let status = self
+            .tmux_cmd()
             .args(["display-message", "-t", pane_id.as_str(), "-p", ""])
             .status()
             .await
             .context("Failed to run tmux display-message")?;
         Ok(status.success())
+    }
+}
+
+#[cfg(test)]
+pub struct IsolatedTmux {
+    socket: String,
+    pub session: String,
+    pub ipc: TmuxIpc,
+}
+
+#[cfg(test)]
+impl IsolatedTmux {
+    /// Spins up a fresh tmux server on a unique socket, creates a test session,
+    /// and returns a TmuxIpc bound to it. Drop kills the server.
+    pub async fn new() -> Result<Self> {
+        let socket = format!("exomonad-test-{}", uuid::Uuid::new_v4());
+        let session = "test".to_string();
+        let tmp = std::env::temp_dir();
+
+        // Create the session on the isolated socket.
+        let mut cmd = tokio::process::Command::new("tmux");
+        cmd.arg("-L")
+            .arg(&socket)
+            .args(["new-session", "-d", "-s", &session, "-c"])
+            .arg(&tmp);
+
+        let output = cmd
+            .output()
+            .await
+            .context("failed to spawn isolated tmux")?;
+        anyhow::ensure!(
+            output.status.success(),
+            "isolated tmux new-session failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let ipc = TmuxIpc::new_with_socket(&session, Some(socket.clone()));
+        Ok(Self {
+            socket,
+            session,
+            ipc,
+        })
+    }
+}
+
+#[cfg(test)]
+impl Drop for IsolatedTmux {
+    fn drop(&mut self) {
+        // Kill the isolated server. Best-effort — use std::process so Drop is sync.
+        let _ = self.ipc.tmux_cmd_sync().arg("kill-server").output();
     }
 }
 
@@ -812,6 +918,16 @@ mod tests {
         assert!(
             result.is_err(),
             "wake_pane should fail without a real tmux session"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_isolated_tmux() {
+        let isolated = IsolatedTmux::new().await.unwrap();
+        assert!(
+            TmuxIpc::has_session(&isolated.session, Some(&isolated.socket))
+                .await
+                .unwrap()
         );
     }
 }

--- a/rust/exomonad-core/src/services/tmux_ipc.rs
+++ b/rust/exomonad-core/src/services/tmux_ipc.rs
@@ -703,6 +703,16 @@ pub struct IsolatedTmux {
 
 #[cfg(test)]
 impl IsolatedTmux {
+    /// Check if tmux is available in the current environment.
+    pub async fn is_available() -> bool {
+        tokio::process::Command::new("tmux")
+            .arg("-V")
+            .status()
+            .await
+            .map(|s| s.success())
+            .unwrap_or(false)
+    }
+
     /// Spins up a fresh tmux server on a unique socket, creates a test session,
     /// and returns a TmuxIpc bound to it. Drop kills the server.
     pub async fn new() -> Result<Self> {
@@ -710,10 +720,13 @@ impl IsolatedTmux {
         let session = "test".to_string();
         let tmp = std::env::temp_dir();
 
-        // Create the session on the isolated socket.
+        // Create the session on the isolated socket using a minimal tmux config
+        // so tests do not depend on the user's ~/.tmux.conf.
         let mut cmd = tokio::process::Command::new("tmux");
         cmd.arg("-L")
             .arg(&socket)
+            .arg("-f")
+            .arg("/dev/null")
             .args(["new-session", "-d", "-s", &session, "-c"])
             .arg(&tmp);
 
@@ -923,6 +936,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_isolated_tmux() {
+        if !IsolatedTmux::is_available().await {
+            eprintln!("skipping test_isolated_tmux: tmux not available");
+            return;
+        }
         let isolated = IsolatedTmux::new().await.unwrap();
         assert!(
             TmuxIpc::has_session(&isolated.session, Some(&isolated.socket))

--- a/rust/exomonad/src/init.rs
+++ b/rust/exomonad/src/init.rs
@@ -274,7 +274,7 @@ pub async fn run(session_override: Option<String>, recreate: bool) -> Result<()>
         }
     }
 
-    let session_alive = TmuxIpc::has_session(&session).await?;
+    let session_alive = TmuxIpc::has_session(&session, None).await?;
 
     if recreate {
         // Kill the running server process before tearing down the session
@@ -307,12 +307,12 @@ pub async fn run(session_override: Option<String>, recreate: bool) -> Result<()>
 
         if session_alive {
             info!(session = %session, "Deleting session (--recreate)");
-            TmuxIpc::kill_session(&session).await?;
+            TmuxIpc::kill_session(&session, None).await?;
         }
     } else if session_alive {
         // Attach to running session
         info!(session = %session, "Attaching to session");
-        return TmuxIpc::attach_session(&session).await;
+        return TmuxIpc::attach_session(&session, None).await;
     }
 
     // Create fresh session
@@ -354,10 +354,10 @@ pub async fn run(session_override: Option<String>, recreate: bool) -> Result<()>
     info!("Wrote .mcp.json with {} MCP server(s)", mcp_servers.len());
 
     // 2. Create session in background
-    let server_window_id = TmuxIpc::new_session(&session, &cwd).await?;
+    let server_window_id = TmuxIpc::new_session(&session, &cwd, None).await?;
 
     // Verify session
-    if !TmuxIpc::has_session(&session).await? {
+    if !TmuxIpc::has_session(&session, None).await? {
         anyhow::bail!(
             "tmux session '{}' was created but is not responding.",
             session
@@ -787,7 +787,7 @@ pub async fn run(session_override: Option<String>, recreate: bool) -> Result<()>
 
     // 6. Attach
     info!(session = %session, "Attaching to session");
-    TmuxIpc::attach_session(&session).await
+    TmuxIpc::attach_session(&session, None).await
 }
 
 pub fn ensure_gitignore(project_dir: &Path) -> Result<()> {

--- a/rust/exomonad/src/serve.rs
+++ b/rust/exomonad/src/serve.rs
@@ -913,20 +913,30 @@ Run `exomonad recompile` first to build it.",
     let claude_session_registry =
         Arc::new(exomonad_core::services::claude_session_registry::ClaudeSessionRegistry::new());
 
+    let tmux_session = config.tmux_session.clone();
+    let tmux_ipc = Arc::new(exomonad_core::services::tmux_ipc::TmuxIpc::new(
+        &tmux_session,
+    ));
+
     // Build Services once — all shared registries in one struct
     let tasks_dir = dirs::home_dir().unwrap_or_default().join(".claude/tasks");
     let services = Arc::new(
-        exomonad_core::services::ServicesBuilder::new(project_dir.clone(), tasks_dir, git_wt)
-            .github_client_opt(github_client.clone())
-            .event_log_opt(event_log.clone())
-            .team_registry(team_registry.clone())
-            .acp_registry(acp_registry.clone())
-            .supervisor_registry(supervisor_registry)
-            .claude_session_registry(claude_session_registry)
-            .agent_resolver(agent_resolver.clone())
-            .event_queue(event_queue.clone())
-            .mutex_registry(mutex_registry)
-            .build(),
+        exomonad_core::services::ServicesBuilder::new(
+            project_dir.clone(),
+            tasks_dir,
+            git_wt,
+            tmux_ipc,
+        )
+        .github_client_opt(github_client.clone())
+        .event_log_opt(event_log.clone())
+        .team_registry(team_registry.clone())
+        .acp_registry(acp_registry.clone())
+        .supervisor_registry(supervisor_registry)
+        .claude_session_registry(claude_session_registry)
+        .agent_resolver(agent_resolver.clone())
+        .event_queue(event_queue.clone())
+        .mutex_registry(mutex_registry)
+        .build(),
     );
 
     let mut agent_control =


### PR DESCRIPTION
This PR fixes test pollution by isolating delivery tests using per-test tmux sockets (`tmux -L <socket>`).

### Changes
- **`TmuxIpc`**: Added support for optional `socket_name`. Refactored all tmux command building to use the socket if present.
- **`IsolatedTmux`**: Added a test helper that spins up a fresh tmux server on a unique socket and kills it on `Drop`. Now uses `-f /dev/null` for predictable configuration.
- **`Services`**: Introduced `HasTmuxIpc` capability trait and wired `TmuxIpc` into `Services`. `test_with_project_dir()` now uses a dummy socket by default.
- **`tmux_events`**: Refactored `inject_input` and `close_worker_pane` to take `&TmuxIpc` instead of reading `EXOMONAD_TMUX_SESSION` from environment.
- **`delivery` tests**: Updated all delivery tests to use `IsolatedTmux`, ensuring they don't inject text into the developer's live tmux session. Tests now skip gracefully if `tmux` is not available.
- **`AgentControlService`**: Updated to use `TmuxIpc` from context instead of its own field. `tmux()` now validates that the context session matches the configured session.

### Fixes from Review
- Added `-f /dev/null` to isolated tmux server spawn.
- Added session name validation in `AgentControlService::tmux()`.
- Defaulted `Services::test_with_project_dir()` to a dummy isolated socket.
- Added `IsolatedTmux::is_available()` check to skip tests in environments without tmux.

Verified with `cargo test --workspace --lib -- delivery` and full workspace check.