### PR TITLE
fix(poller): drop PR tracking on external merge to prevent stale notifications

### DIFF
--- a/rust/exomonad-core/src/handlers/fs.rs
+++ b/rust/exomonad-core/src/handlers/fs.rs
@@ -435,7 +435,6 @@ mod tests {
         assert!(resp.is_directory);
     }
 
-
     #[tokio::test]
     async fn test_list_directory() {
         let dir = tempdir().unwrap();

--- a/rust/exomonad-core/src/handlers/merge_pr.rs
+++ b/rust/exomonad-core/src/handlers/merge_pr.rs
@@ -100,7 +100,10 @@ impl<C: HasGitHubClient + HasEventLog + HasGitWorktreeService + HasEventQueue + 
                     changes: vec![],
                 })),
             };
-            self.ctx.event_queue().notify_event("system", event).await;
+            self.ctx
+                .event_queue()
+                .notify_event("system.pr_merged", event)
+                .await;
         } else {
             tracing::info!(
                 otel.name = "pr.merge_failed",

--- a/rust/exomonad-core/src/handlers/merge_pr.rs
+++ b/rust/exomonad-core/src/handlers/merge_pr.rs
@@ -1,24 +1,27 @@
 use crate::effects::{dispatch_merge_pr_effect, EffectResult, MergePrEffects, ResultExt};
 use crate::services::merge_pr;
 use async_trait::async_trait;
+use exomonad_proto::effects::events::{event::EventType, AgentMessage, Event};
 use exomonad_proto::effects::merge_pr::*;
 use std::sync::Arc;
 use tracing::instrument;
 
-use crate::services::{HasEventLog, HasGitHubClient, HasGitWorktreeService};
+use crate::services::{HasEventLog, HasEventQueue, HasGitHubClient, HasGitWorktreeService};
 
 pub struct MergePRHandler<C> {
     ctx: Arc<C>,
 }
 
-impl<C: HasGitHubClient + HasEventLog + HasGitWorktreeService + 'static> MergePRHandler<C> {
+impl<C: HasGitHubClient + HasEventLog + HasGitWorktreeService + HasEventQueue + 'static>
+    MergePRHandler<C>
+{
     pub fn new(ctx: Arc<C>) -> Self {
         Self { ctx }
     }
 }
 
 #[async_trait]
-impl<C: HasGitHubClient + HasEventLog + HasGitWorktreeService + 'static>
+impl<C: HasGitHubClient + HasEventLog + HasGitWorktreeService + HasEventQueue + 'static>
     crate::effects::EffectHandler for MergePRHandler<C>
 {
     fn namespace(&self) -> &str {
@@ -36,8 +39,8 @@ impl<C: HasGitHubClient + HasEventLog + HasGitWorktreeService + 'static>
 }
 
 #[async_trait]
-impl<C: HasGitHubClient + HasEventLog + HasGitWorktreeService + 'static> MergePrEffects
-    for MergePRHandler<C>
+impl<C: HasGitHubClient + HasEventLog + HasGitWorktreeService + HasEventQueue + 'static>
+    MergePrEffects for MergePRHandler<C>
 {
     #[instrument(skip_all, fields(agent_name = %ctx.agent_name, pr_number = req.pr_number))]
     async fn merge_pr(
@@ -86,6 +89,18 @@ impl<C: HasGitHubClient + HasEventLog + HasGitWorktreeService + 'static> MergePr
                     }),
                 );
             }
+
+            // Notify EventQueue so GitHubPoller can drop tracking immediately
+            let event = Event {
+                event_id: 0,
+                event_type: Some(EventType::AgentMessage(AgentMessage {
+                    agent_id: "system".to_string(),
+                    status: "pr.merged".to_string(),
+                    message: pr_number.to_string(),
+                    changes: vec![],
+                })),
+            };
+            self.ctx.event_queue().notify_event("system", event).await;
         } else {
             tracing::info!(
                 otel.name = "pr.merge_failed",

--- a/rust/exomonad-core/src/services/github_poller.rs
+++ b/rust/exomonad-core/src/services/github_poller.rs
@@ -297,6 +297,19 @@ impl<
         }
     }
 
+    /// Mark a PR as externally merged. Drops the PRState from the tracking map
+    /// so no further events (including queued timeouts) fire for it. Call this
+    /// from merge_pr when the merge completes.
+    pub async fn mark_merged(&self, pr_number: PRNumber) {
+        let mut states = self.state.lock().await;
+        if states.remove(&pr_number).is_some() {
+            info!(
+                pr = %pr_number.as_u64(),
+                "GitHubPoller: PR marked merged externally, tracking removed"
+            );
+        }
+    }
+
     pub fn with_poll_interval(mut self, interval: Duration) -> Self {
         self.poll_interval = interval;
         self
@@ -312,6 +325,47 @@ impl<
             poll_interval_secs = self.poll_interval.as_secs(),
             "GitHub poller started"
         );
+
+        // Spawn a background task to listen for external merge events
+        let poller = Arc::new(Self {
+            ctx: self.ctx.clone(),
+            poll_interval: self.poll_interval,
+            state: self.state.clone(),
+            repo_info: self.repo_info.clone(),
+            plugins: self.plugins.clone(),
+        });
+
+        let poller_for_events = poller.clone();
+        tokio::spawn(async move {
+            let mut last_event_id = 0;
+            loop {
+                match poller_for_events
+                    .ctx
+                    .event_queue()
+                    .wait_for_event(
+                        "system",
+                        &["agent_message".to_string()],
+                        Duration::from_secs(30),
+                        last_event_id,
+                    )
+                    .await
+                {
+                    Ok(event) => {
+                        last_event_id = event.event_id;
+                        if let Some(EventType::AgentMessage(msg)) = event.event_type {
+                            if msg.status == "pr.merged" {
+                                if let Ok(pr_num) = msg.message.parse::<u64>() {
+                                    poller_for_events.mark_merged(PRNumber::new(pr_num)).await;
+                                }
+                            }
+                        }
+                    }
+                    Err(_) => {
+                        // Timeout is expected, just loop
+                    }
+                }
+            }
+        });
 
         let base_interval = self.poll_interval;
         let max_backoff = Duration::from_secs(600); // 10 minutes max
@@ -1508,5 +1562,137 @@ mod tests {
         );
         assert_eq!(state.last_review_state, ReviewState::ChangesRequested);
         assert_eq!(state.addressed_changes, false);
+    }
+
+    #[tokio::test]
+    async fn test_mark_merged_removes_pr_state() {
+        let services = Arc::new(crate::services::Services::test());
+        let poller = GitHubPoller::new(services);
+        let pr_num = PRNumber::new(123);
+
+        {
+            let mut state = poller.state.lock().await;
+            state.insert(pr_num, make_pr_state("main.feat", "abc"));
+        }
+
+        poller.mark_merged(pr_num).await;
+
+        let state = poller.state.lock().await;
+        assert!(!state.contains_key(&pr_num));
+    }
+
+    #[tokio::test]
+    async fn test_mark_merged_on_unknown_pr_is_noop() {
+        let services = Arc::new(crate::services::Services::test());
+        let poller = GitHubPoller::new(services);
+        poller.mark_merged(PRNumber::new(999)).await;
+        let state = poller.state.lock().await;
+        assert!(state.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_compute_pr_actions_after_mark_merged_returns_empty() {
+        let mut state = make_pr_state("main.feat", "abc");
+        state.first_seen = Instant::now() - Duration::from_secs(20 * 60); // Would timeout
+
+        // In the poller loop, if mark_merged removed the state, compute_pr_actions is never called.
+        // But if it IS called (e.g. race), the PRState itself has internal guards.
+        // The real suppression is that mark_merged removes it from the HashMap.
+        // Here we test that if we didn't have the state in the map, we wouldn't even call it.
+        let services = Arc::new(crate::services::Services::test());
+        let poller = GitHubPoller::new(services);
+        poller.mark_merged(PRNumber::new(123)).await;
+
+        let state_guard = poller.state.lock().await;
+        assert!(state_guard.get(&PRNumber::new(123)).is_none());
+    }
+
+    #[tokio::test]
+    async fn test_merged_pr_suppresses_pending_timeout() {
+        let mut state = make_pr_state("main.feat", "abc");
+        state.first_seen = Instant::now() - Duration::from_secs(20 * 60); // 20 mins ago
+        state.last_review_state = ReviewState::None;
+
+        // Before mark_merged: compute_pr_actions would return a timeout
+        let actions = compute_pr_actions(
+            &mut state,
+            PRNumber::new(123),
+            "abc",
+            &[],
+            &[],
+            CIStatus::Success,
+            "main.feat",
+            &|_, _| String::new(),
+        );
+        assert!(actions.iter().any(|a| matches!(
+            a,
+            PendingAction::WasmEvent {
+                event_type: "pr_review",
+                ..
+            }
+        )));
+
+        // Now simulate the poller cycle after mark_merged
+        let services = Arc::new(crate::services::Services::test());
+        let poller = GitHubPoller::new(services);
+        poller.mark_merged(PRNumber::new(123)).await;
+
+        // The poller's process_pr would do:
+        let state_guard = poller.state.lock().await;
+        let old_state = state_guard.get(&PRNumber::new(123));
+        assert!(
+            old_state.is_none(),
+            "State should be gone after mark_merged"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_event_queue_trigger_mark_merged() {
+        let services = Arc::new(crate::services::Services::test());
+        let poller = GitHubPoller::new(services.clone());
+        let pr_num = PRNumber::new(456);
+
+        {
+            let mut state = poller.state.lock().await;
+            state.insert(pr_num, make_pr_state("main.feat", "abc"));
+        }
+
+        // Start the poller's background listener
+        let poller_arc = Arc::new(poller);
+        let poller_clone = poller_arc.clone();
+        tokio::spawn(async move {
+            poller_clone.run().await;
+        });
+
+        // Give it a moment to start
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // Notify merge event
+        let event = Event {
+            event_id: 0,
+            event_type: Some(EventType::AgentMessage(AgentMessage {
+                agent_id: "system".to_string(),
+                status: "pr.merged".to_string(),
+                message: pr_num.to_string(),
+                changes: vec![],
+            })),
+        };
+        services.event_queue().notify_event("system", event).await;
+
+        // Wait for listener to react
+        let mut success = false;
+        for _ in 0..10 {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            let state = poller_arc.state.lock().await;
+            if !state.contains_key(&pr_num) {
+                success = true;
+                break;
+            }
+        }
+
+        assert!(
+            success,
+            "PR state should have been removed by EventQueue listener"
+        );
     }
 }

--- a/rust/exomonad-core/src/services/github_poller.rs
+++ b/rust/exomonad-core/src/services/github_poller.rs
@@ -298,8 +298,9 @@ impl<
     }
 
     /// Mark a PR as externally merged. Drops the PRState from the tracking map
-    /// so no further events (including queued timeouts) fire for it. Call this
-    /// from merge_pr when the merge completes.
+    /// so no further events (including queued timeouts) fire for it. This is
+    /// used by the EventQueue-driven merge flow: `merge_pr` publishes the
+    /// merge-complete event, and the poller consumes it to remove tracking.
     pub async fn mark_merged(&self, pr_number: PRNumber) {
         let mut states = self.state.lock().await;
         if states.remove(&pr_number).is_some() {
@@ -326,7 +327,9 @@ impl<
             "GitHub poller started"
         );
 
-        // Spawn a background task to listen for external merge events
+        // Spawn a background task to listen for external merge events.
+        // We use a dedicated session ID "system.pr_merged" to avoid
+        // interfering with other system messages.
         let poller = Arc::new(Self {
             ctx: self.ctx.clone(),
             poll_interval: self.poll_interval,
@@ -343,25 +346,44 @@ impl<
                     .ctx
                     .event_queue()
                     .wait_for_event(
-                        "system",
+                        "system.pr_merged",
                         &["agent_message".to_string()],
                         Duration::from_secs(30),
                         last_event_id,
                     )
                     .await
                 {
-                    Ok(event) => {
-                        last_event_id = event.event_id;
-                        if let Some(EventType::AgentMessage(msg)) = event.event_type {
+                    Ok(event) => match event.event_type {
+                        Some(EventType::Timeout(_)) => {
+                            // Timeout is expected; keep waiting without rewinding last_event_id.
+                        }
+                        Some(EventType::AgentMessage(msg)) => {
+                            last_event_id = event.event_id;
                             if msg.status == "pr.merged" {
                                 if let Ok(pr_num) = msg.message.parse::<u64>() {
-                                    poller_for_events.mark_merged(PRNumber::new(pr_num)).await;
+                                    match PRNumber::try_from(pr_num) {
+                                        Ok(pr_number) => {
+                                            poller_for_events.mark_merged(pr_number).await;
+                                        }
+                                        Err(e) => {
+                                            warn!(
+                                                pr_num,
+                                                message = %msg.message,
+                                                error = %e,
+                                                "Ignoring invalid merged PR event"
+                                            );
+                                        }
+                                    }
                                 }
                             }
                         }
-                    }
-                    Err(_) => {
-                        // Timeout is expected, just loop
+                        _ => {
+                            last_event_id = event.event_id;
+                        }
+                    },
+                    Err(e) => {
+                        warn!("Failed waiting for GitHub poller event: {}", e);
+                        tokio::time::sleep(Duration::from_secs(1)).await;
                     }
                 }
             }
@@ -1677,7 +1699,10 @@ mod tests {
                 changes: vec![],
             })),
         };
-        services.event_queue().notify_event("system", event).await;
+        services
+            .event_queue()
+            .notify_event("system.pr_merged", event)
+            .await;
 
         // Wait for listener to react
         let mut success = false;


### PR DESCRIPTION
Addressed Copilot review comments:
- Use dedicated `system.pr_merged` session ID to avoid dropping unrelated system messages.
- Explicitly handle `EventType::Timeout` in the listener loop to avoid rewinding `last_event_id`.
- Use `PRNumber::try_from` for safer parsing of PR numbers from events.
- Improved doc comment for `mark_merged` to reflect the EventQueue-driven integration.
- Added error logging and backoff for listener loop failures.
