### PR TITLE
fix(merge_pr): report honest success reflecting merge AND local sync state (rebased)

### DIFF
--- a/.exo/roles/devswarm/RootRole.hs
+++ b/.exo/roles/devswarm/RootRole.hs
@@ -76,7 +76,7 @@ instance MCPTool RootMergePR where
     case result of
       Left err -> pure $ errorResult err
       Right output -> do
-        when (mpoSuccess output) $ do
+        when (mpoMerged output) $ do
           case extractAgentName (mpoBranchName output) of
             Just slug -> do
               branch <- getCurrentBranch

--- a/.exo/roles/devswarm/TLRole.hs
+++ b/.exo/roles/devswarm/TLRole.hs
@@ -64,7 +64,7 @@ instance MCPTool TLMergePR where
     case result of
       Left err -> pure $ errorResult err
       Right output -> do
-        when (mpoSuccess output) $ do
+        when (mpoMerged output) $ do
           case extractAgentName (mpoBranchName output) of
             Just slug -> do
               branch <- getCurrentBranch

--- a/haskell/wasm-guest/src/ExoMonad/Guest/Tools/MergePR.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Guest/Tools/MergePR.hs
@@ -26,7 +26,7 @@ import Data.Aeson qualified as Aeson
 import Data.Aeson.Types (Parser, explicitParseField, explicitParseFieldMaybe)
 import Data.ByteString.Lazy qualified as BSL
 import Data.Map qualified as Map
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, isJust)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.Lazy qualified as TL
@@ -43,7 +43,7 @@ import ExoMonad.Effects.GitHub (GitHubGetPullRequest)
 import ExoMonad.Effects.Log (LogEmitEvent, LogError, LogInfo)
 import ExoMonad.Effects.MergePR (MergePRMergePr)
 import ExoMonad.Effects.Process (ProcessRun)
-import ExoMonad.Guest.Tool.Class (Effects, MCPCallOutput (..), MCPTool (..), errorResult, successResult)
+import ExoMonad.Guest.Tool.Class (Effects, MCPCallOutput (..))
 import ExoMonad.Guest.Tool.Schema (genericToolSchemaWith)
 import ExoMonad.Guest.Tool.SuspendEffect (suspendEffect, suspendEffect_)
 import GHC.Generics (Generic)
@@ -196,13 +196,28 @@ mergePRRender output =
             "pull_error" .= mpoPullError output,
             "next" .= nextGuidance output
           ]
-   in MCPCallOutput fullySuccess (Just res) (if fullySuccess then Nothing else Just (nextGuidance output))
+   in MCPCallOutput fullySuccess (Just res) (mergePRError output)
+
+mergePRError :: MergePROutput -> Maybe Text
+mergePRError output
+  | fullySuccess = Nothing
+  | isJust pullErr = Just (guidance <> " Pull error: " <> fromMaybe "" pullErr)
+  | not (T.null msg) = Just (guidance <> " Details: " <> msg)
+  | otherwise = Just guidance
+  where
+    fullySuccess = mpoMerged output && mpoLocalSynced output
+    guidance = nextGuidance output
+    pullErr = mpoPullError output
+    msg = mpoMessage output
 
 nextGuidance :: MergePROutput -> Text
 nextGuidance output
   | not (mpoMerged output) = "Merge did not complete. Check `message` for the reason."
   | not (mpoLocalSynced output) = "PR merged but local branch is out of sync. Run `git pull --rebase` manually, then verify build with `cargo check --workspace`."
-  | not (mpoCleanupOk output) = "PR merged and synced, but post-merge cleanup failed. Run `git branch -D <branch>` and cleanup the worktree manually if needed."
+  | not (mpoCleanupOk output) =
+      "PR merged and synced, but post-merge cleanup failed. Run `git branch -D "
+        <> mpoBranchName output
+        <> "` and cleanup the worktree manually if needed."
   | otherwise = "Verify build: cargo check --workspace."
 
 -- | Copilot review readiness.
@@ -355,7 +370,7 @@ doMerge args = do
               Nothing -> pure True
 
             pure (syncOk, syncErr, cleanOk)
-          else pure (True, Nothing, True)
+          else pure (False, Nothing, True)
 
       pure $
         Right $

--- a/haskell/wasm-guest/src/ExoMonad/Guest/Tools/MergePR.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Guest/Tools/MergePR.hs
@@ -43,7 +43,7 @@ import ExoMonad.Effects.GitHub (GitHubGetPullRequest)
 import ExoMonad.Effects.Log (LogEmitEvent, LogError, LogInfo)
 import ExoMonad.Effects.MergePR (MergePRMergePr)
 import ExoMonad.Effects.Process (ProcessRun)
-import ExoMonad.Guest.Tool.Class (Effects, MCPCallOutput, MCPTool (..), errorResult, successResult)
+import ExoMonad.Guest.Tool.Class (Effects, MCPCallOutput (..), MCPTool (..), errorResult, successResult)
 import ExoMonad.Guest.Tool.Schema (genericToolSchemaWith)
 import ExoMonad.Guest.Tool.SuspendEffect (suspendEffect, suspendEffect_)
 import GHC.Generics (Generic)
@@ -95,22 +95,24 @@ parseFlexibleBool v =
   fail ("force must be a Bool or bool-shaped String, got: " <> show v)
 
 data MergePROutput = MergePROutput
-  { mpoSuccess :: Bool,
+  { mpoMerged :: Bool,        -- ^ The GitHub PR was successfully merged.
+    mpoLocalSynced :: Bool,   -- ^ Local working branch is in sync with remote after the merge.
+    mpoCleanupOk :: Bool,     -- ^ The post-merge cleanup (close tab, remove worktree) succeeded.
     mpoMessage :: Text,
-    mpoGitFetched :: Bool,
     mpoBranchName :: Text,
-    mpoPullOk :: Bool
+    mpoPullError :: Maybe Text  -- ^ When mpoLocalSynced is False, the git pull stderr/reason.
   }
   deriving (Show, Eq, Generic)
 
 instance Aeson.ToJSON MergePROutput where
-  toJSON (MergePROutput s m g b p) =
+  toJSON out =
     object
-      [ "success" .= s,
-        "message" .= m,
-        "git_fetched" .= g,
-        "branch_name" .= b,
-        "pull_ok" .= p
+      [ "merged" .= mpoMerged out,
+        "local_synced" .= mpoLocalSynced out,
+        "cleanup_ok" .= mpoCleanupOk out,
+        "message" .= mpoMessage out,
+        "branch_name" .= mpoBranchName out,
+        "pull_error" .= mpoPullError out
       ]
 
 -- | Shared tool description for merge_pr.
@@ -182,17 +184,26 @@ mergePRCore args = do
 -- | Render a MergePROutput to MCPCallOutput.
 mergePRRender :: MergePROutput -> MCPCallOutput
 mergePRRender output =
-  successResult $
-    object
-      [ "success" .= mpoSuccess output,
-        "message" .= mpoMessage output,
-        "git_fetched" .= mpoGitFetched output,
-        "next"
-          .= ( if mpoPullOk output
-                 then "Verify build: cargo check --workspace. Especially important after parallel merges — changes may interact." :: Text
-                 else "git pull failed — run 'git pull --rebase' manually to sync your local branch. Then verify build: cargo check --workspace." :: Text
-             )
-      ]
+  let fullySuccess = mpoMerged output && mpoLocalSynced output
+      res =
+        object
+          [ "success" .= fullySuccess,
+            "merged" .= mpoMerged output,
+            "local_synced" .= mpoLocalSynced output,
+            "cleanup_ok" .= mpoCleanupOk output,
+            "message" .= mpoMessage output,
+            "branch_name" .= mpoBranchName output,
+            "pull_error" .= mpoPullError output,
+            "next" .= nextGuidance output
+          ]
+   in MCPCallOutput fullySuccess (Just res) (if fullySuccess then Nothing else Just (nextGuidance output))
+
+nextGuidance :: MergePROutput -> Text
+nextGuidance output
+  | not (mpoMerged output) = "Merge did not complete. Check `message` for the reason."
+  | not (mpoLocalSynced output) = "PR merged but local branch is out of sync. Run `git pull --rebase` manually, then verify build with `cargo check --workspace`."
+  | not (mpoCleanupOk output) = "PR merged and synced, but post-merge cleanup failed. Run `git branch -D <branch>` and cleanup the worktree manually if needed."
+  | otherwise = "Verify build: cargo check --workspace."
 
 -- | Copilot review readiness.
 data Readiness = Ready | NotReady Text
@@ -272,11 +283,10 @@ doMerge args = do
       let branchName = TL.toStrict (MP.mergePrResponseBranchName resp)
           mergeSuccess = MP.mergePrResponseSuccess resp
           mergeMsg = TL.toStrict (MP.mergePrResponseMessage resp)
-          gitFetched = MP.mergePrResponseGitFetched resp
 
       void $ suspendEffect_ @LogInfo (Log.InfoRequest {Log.infoRequestMessage = TL.fromStrict ("MergePR: " <> mergeMsg), Log.infoRequestFields = ""})
 
-      pullOk <-
+      (localSynced, pullError, cleanupOk) <-
         if mergeSuccess
           then do
             let eventPayload =
@@ -296,7 +306,7 @@ doMerge args = do
                 )
 
             -- Fast-forward local branch after merge
-            pullOkStatus <- do
+            (syncOk, syncErr) <- do
               let pullReq =
                     Proc.RunRequest
                       { Proc.runRequestCommand = "git",
@@ -307,11 +317,14 @@ doMerge args = do
                       }
               pullResult <- suspendEffect @ProcessRun pullReq
               case pullResult of
-                Left _ -> pure False
-                Right pullResp -> pure (Proc.runResponseExitCode pullResp == 0)
+                Left err -> pure (False, Just (T.pack (show err)))
+                Right pullResp ->
+                  if Proc.runResponseExitCode pullResp == 0
+                    then pure (True, Nothing)
+                    else pure (False, Just (TL.toStrict (Proc.runResponseStderr pullResp)))
 
             -- Auto-cleanup: close agent tab, remove worktree, unregister
-            case extractAgentName branchName of
+            cleanOk <- case extractAgentName branchName of
               Just slug -> do
                 let cleanupReq =
                       Agent.CleanupRequest
@@ -321,7 +334,7 @@ doMerge args = do
                         }
                 cleanupResult <- suspendEffect @AgentCleanup cleanupReq
                 case cleanupResult of
-                  Left cleanupErr ->
+                  Left cleanupErr -> do
                     void $
                       suspendEffect_ @LogInfo
                         ( Log.InfoRequest
@@ -329,7 +342,8 @@ doMerge args = do
                               Log.infoRequestFields = ""
                             }
                         )
-                  Right _ ->
+                    pure False
+                  Right _ -> do
                     void $
                       suspendEffect_ @LogInfo
                         ( Log.InfoRequest
@@ -337,17 +351,19 @@ doMerge args = do
                               Log.infoRequestFields = ""
                             }
                         )
-              Nothing -> pure ()
+                    pure True
+              Nothing -> pure True
 
-            pure pullOkStatus
-          else pure True
+            pure (syncOk, syncErr, cleanOk)
+          else pure (True, Nothing, True)
 
       pure $
         Right $
           MergePROutput
-            { mpoSuccess = mergeSuccess,
+            { mpoMerged = mergeSuccess,
+              mpoLocalSynced = localSynced,
+              mpoCleanupOk = cleanupOk,
               mpoMessage = mergeMsg,
-              mpoGitFetched = gitFetched,
               mpoBranchName = branchName,
-              mpoPullOk = pullOk
+              mpoPullError = pullError
             }

--- a/haskell/wasm-guest/src/ExoMonad/Guest/Tools/MergePRTests.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Guest/Tools/MergePRTests.hs
@@ -1,11 +1,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 module ExoMonad.Guest.Tools.MergePRTests where
 
-import Data.Aeson (Value, object, (.=), encode)
-import Data.Text (Text)
 import ExoMonad.Guest.Tool.Class (MCPCallOutput (..))
 import ExoMonad.Guest.Tools.MergePR
-import qualified Data.ByteString.Lazy.Char8 as BSL
 
 -- Note: These are manual verification tests since a full test runner 
 -- isn't yet configured for the WASM guest in this environment.

--- a/haskell/wasm-guest/src/ExoMonad/Guest/Tools/MergePRTests.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Guest/Tools/MergePRTests.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE OverloadedStrings #-}
+module ExoMonad.Guest.Tools.MergePRTests where
+
+import Data.Aeson (Value, object, (.=), encode)
+import Data.Text (Text)
+import ExoMonad.Guest.Tool.Class (MCPCallOutput (..))
+import ExoMonad.Guest.Tools.MergePR
+import qualified Data.ByteString.Lazy.Char8 as BSL
+
+-- Note: These are manual verification tests since a full test runner 
+-- isn't yet configured for the WASM guest in this environment.
+
+test_render_all_success :: MCPCallOutput
+test_render_all_success = mergePRRender $ MergePROutput
+  { mpoMerged = True
+  , mpoLocalSynced = True
+  , mpoCleanupOk = True
+  , mpoMessage = "PR #1 merged"
+  , mpoBranchName = "main.feat-1"
+  , mpoPullError = Nothing
+  }
+-- Expected: success=true, next says "Verify build"
+
+test_render_merged_but_pull_failed :: MCPCallOutput
+test_render_merged_but_pull_failed = mergePRRender $ MergePROutput
+  { mpoMerged = True
+  , mpoLocalSynced = False
+  , mpoCleanupOk = True
+  , mpoMessage = "PR #1 merged"
+  , mpoBranchName = "main.feat-1"
+  , mpoPullError = Just "fatal: some error"
+  }
+-- Expected: success=false, next says "run git pull --rebase manually"
+
+test_render_merged_pull_ok_cleanup_failed :: MCPCallOutput
+test_render_merged_pull_ok_cleanup_failed = mergePRRender $ MergePROutput
+  { mpoMerged = True
+  , mpoLocalSynced = True
+  , mpoCleanupOk = False
+  , mpoMessage = "PR #1 merged"
+  , mpoBranchName = "main.feat-1"
+  , mpoPullError = Nothing
+  }
+-- Expected: success=true, next mentions manual cleanup
+
+test_render_merge_itself_failed :: MCPCallOutput
+test_render_merge_itself_failed = mergePRRender $ MergePROutput
+  { mpoMerged = False
+  , mpoLocalSynced = True -- shouldn't happen but testing the logic
+  , mpoCleanupOk = True
+  , mpoMessage = "Merge failed"
+  , mpoBranchName = "main.feat-1"
+  , mpoPullError = Nothing
+  }
+-- Expected: success=false, next says "Merge did not complete"
+
+test_render_includes_pull_error_when_set :: MCPCallOutput
+test_render_includes_pull_error_when_set = mergePRRender $ MergePROutput
+  { mpoMerged = True
+  , mpoLocalSynced = False
+  , mpoCleanupOk = True
+  , mpoMessage = "PR #1 merged"
+  , mpoBranchName = "main.feat-1"
+  , mpoPullError = Just "fatal: some error"
+  }
+-- Expected: JSON includes "pull_error": "fatal: some error"

--- a/haskell/wasm-guest/src/ExoMonad/Guest/Tools/MergePRTests.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Guest/Tools/MergePRTests.hs
@@ -4,7 +4,7 @@ module ExoMonad.Guest.Tools.MergePRTests where
 import ExoMonad.Guest.Tool.Class (MCPCallOutput (..))
 import ExoMonad.Guest.Tools.MergePR
 
--- Note: These are manual verification tests since a full test runner 
+-- Note: These are manual verification tests since a full test runner
 -- isn't yet configured for the WASM guest in this environment.
 
 test_render_all_success :: MCPCallOutput

--- a/haskell/wasm-guest/wasm-guest.cabal
+++ b/haskell/wasm-guest/wasm-guest.cabal
@@ -65,6 +65,7 @@ library wasm-guest-internal
         -- Tools
         ExoMonad.Guest.Tools.FilePR
         ExoMonad.Guest.Tools.MergePR
+        ExoMonad.Guest.Tools.MergePRTests
         ExoMonad.Guest.Tools.Spawn
         ExoMonad.Guest.Tools.Events
         ExoMonad.Guest.Tools.Tasks

--- a/haskell/wasm-guest/wasm-guest.cabal
+++ b/haskell/wasm-guest/wasm-guest.cabal
@@ -65,7 +65,6 @@ library wasm-guest-internal
         -- Tools
         ExoMonad.Guest.Tools.FilePR
         ExoMonad.Guest.Tools.MergePR
-        ExoMonad.Guest.Tools.MergePRTests
         ExoMonad.Guest.Tools.Spawn
         ExoMonad.Guest.Tools.Events
         ExoMonad.Guest.Tools.Tasks
@@ -113,6 +112,8 @@ library wasm-guest-internal
         ExoMonad.Types
         -- Permissions
         ExoMonad.Permissions
+    other-modules:
+        ExoMonad.Guest.Tools.MergePRTests
     -- Additional dependencies (shared stanza provides common deps)
     build-depends:
         exomonad-pdk,


### PR DESCRIPTION
Successfully rebased onto `main` to pick up sibling PR changes.
All verification passed (WASM build + Rust check).
PR still contains:
- Honest success reporting (merge + sync).
- Copilot review addressed.
- No trailing whitespace.
- Test module in other-modules.
