### PR TITLE
fix(teams): reconcile TeamRegistry in-memory state with config.json on disk

### DIFF
--- a/rust/claude-teams-bridge/src/config.rs
+++ b/rust/claude-teams-bridge/src/config.rs
@@ -26,6 +26,9 @@ pub struct TeamMember {
     pub model: String,
     pub joined_at: u64,
     pub cwd: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub backend_type: Option<String>,
 }
 
 /// Read team config from `~/.claude/teams/{team}/config.json`.
@@ -76,6 +79,7 @@ mod tests {
                 model: "opus".into(),
                 joined_at: 1700000001,
                 cwd: "/tmp".into(),
+                backend_type: None,
             }],
         }
     }

--- a/rust/claude-teams-bridge/src/registry.rs
+++ b/rust/claude-teams-bridge/src/registry.rs
@@ -43,14 +43,30 @@ impl TeamRegistry {
     }
 
     pub async fn register(&self, key: &str, info: TeamInfo) {
+        let team_name = info.team_name.clone();
         info!(
             key = %key,
-            team_name = %info.team_name,
+            team_name = %team_name,
             inbox_name = %info.inbox_name,
             "Registering Claude Teams info"
         );
         let mut map = self.inner.lock().await;
         map.insert(key.to_string(), info);
+        drop(map);
+
+        // Best-effort sync to disk for backward-compatible API
+        if let Err(e) = self.persist_config(&team_name).await {
+            debug!(team = %team_name, error = %e, "Failed to sync team config to disk (non-fatal)");
+        }
+    }
+
+    /// Explicitly register a member and sync to disk. Returns IO error if persistence fails.
+    pub async fn register_member(&self, key: &str, info: TeamInfo) -> std::io::Result<()> {
+        let team_name = info.team_name.clone();
+        let mut map = self.inner.lock().await;
+        map.insert(key.to_string(), info);
+        drop(map);
+        self.persist_config(&team_name).await
     }
 
     pub async fn get(&self, key: &str) -> Option<TeamInfo> {
@@ -162,7 +178,94 @@ impl TeamRegistry {
     pub async fn deregister(&self, key: &str) {
         info!(key = %key, "Deregistering Claude Teams info");
         let mut map = self.inner.lock().await;
+        let team_name = map.get(key).map(|info| info.team_name.clone());
         map.remove(key);
+        drop(map);
+
+        if let Some(team) = team_name {
+            // Best-effort sync to disk for backward-compatible API
+            if let Err(e) = self.persist_config(&team).await {
+                debug!(team = %team, error = %e, "Failed to sync team config to disk after deregister (non-fatal)");
+            }
+        }
+    }
+
+    /// Explicitly deregister a member and sync to disk. Returns IO error if persistence fails.
+    pub async fn remove_member(&self, key: &str) -> std::io::Result<()> {
+        let mut map = self.inner.lock().await;
+        let team_name = map.get(key).map(|info| info.team_name.clone());
+        map.remove(key);
+        drop(map);
+
+        if let Some(team) = team_name {
+            self.persist_config(&team).await?;
+        }
+        Ok(())
+    }
+
+    /// Synchronize in-memory registry state for a team with its on-disk config.json.
+    ///
+    /// CC-native members (those without backendType: "exomonad") are preserved.
+    /// Exomonad members are updated or added based on the current in-memory registry.
+    /// Members deduplicated by inbox_name.
+    async fn persist_config(&self, team_name: &str) -> std::io::Result<()> {
+        let mut config = match crate::config::read_team_config(team_name) {
+            Ok(c) => c,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                // If config doesn't exist, we can't persist to it.
+                // Claude Code owns the team lifecycle; we only augment existing teams.
+                return Ok(());
+            }
+            Err(e) => return Err(e),
+        };
+
+        let in_memory = self.get_all_for_team(team_name).await;
+        if in_memory.is_empty()
+            && config
+                .members
+                .iter()
+                .all(|m| m.backend_type.as_deref() != Some("exomonad"))
+        {
+            // Optimization: nothing to do if no in-memory entries and no exomonad members on disk
+            return Ok(());
+        }
+
+        // 1. Collect CC-native members to keep
+        let mut new_members: Vec<crate::config::TeamMember> = config
+            .members
+            .into_iter()
+            .filter(|m| m.backend_type.as_deref() != Some("exomonad"))
+            .collect();
+
+        // 2. Add/update in-memory members (deduplicated by inbox_name)
+        let mut unique_in_memory = HashMap::new();
+        for (key, info) in in_memory {
+            // Prefer the key that matches the inbox_name if available (usually the agent name)
+            if !unique_in_memory.contains_key(&info.inbox_name) || key == info.inbox_name {
+                unique_in_memory.insert(info.inbox_name.clone(), key);
+            }
+        }
+
+        for (inbox_name, key) in unique_in_memory {
+            let existing = new_members.iter().find(|m| m.name == inbox_name);
+            if existing.is_none() {
+                new_members.push(crate::config::TeamMember {
+                    agent_id: key,
+                    name: inbox_name,
+                    agent_type: "exomonad-agent".into(),
+                    model: "gemini".into(),
+                    joined_at: chrono::Utc::now().timestamp_millis() as u64,
+                    cwd: std::env::current_dir()
+                        .unwrap_or_default()
+                        .to_string_lossy()
+                        .to_string(),
+                    backend_type: Some("exomonad".into()),
+                });
+            }
+        }
+
+        config.members = new_members;
+        crate::config::write_team_config(team_name, &config)
     }
 }
 
@@ -338,6 +441,7 @@ mod tests {
                     model: "opus".into(),
                     joined_at: 0,
                     cwd: "/tmp".into(),
+                    backend_type: None,
                 },
                 crate::config::TeamMember {
                     agent_id: "uuid-worker".into(),
@@ -346,6 +450,7 @@ mod tests {
                     model: "haiku".into(),
                     joined_at: 0,
                     cwd: "/tmp".into(),
+                    backend_type: None,
                 },
             ],
         };
@@ -442,6 +547,7 @@ mod tests {
                 model: "opus".into(),
                 joined_at: 0,
                 cwd: "/tmp".into(),
+                backend_type: None,
             }],
         };
         crate::config::write_team_config(team_name, &config).unwrap();
@@ -479,6 +585,7 @@ mod tests {
                     model: "opus".into(),
                     joined_at: 0,
                     cwd: cwd.into(),
+                    backend_type: None,
                 }],
             };
             crate::config::write_team_config(team, &config).unwrap();

--- a/rust/claude-teams-bridge/src/registry.rs
+++ b/rust/claude-teams-bridge/src/registry.rs
@@ -51,12 +51,20 @@ impl TeamRegistry {
             "Registering Claude Teams info"
         );
         let mut map = self.inner.lock().await;
-        map.insert(key.to_string(), info);
+        let previous = map.insert(key.to_string(), info);
+        let old_team_name = previous
+            .and_then(|prev| (prev.team_name != team_name).then_some(prev.team_name));
         drop(map);
 
         // Best-effort sync to disk for backward-compatible API
         if let Err(e) = self.persist_config(&team_name).await {
             debug!(team = %team_name, error = %e, "Failed to sync team config to disk (non-fatal)");
+        }
+
+        if let Some(old_team) = old_team_name {
+            if let Err(e) = self.persist_config(&old_team).await {
+                debug!(team = %old_team, error = %e, "Failed to sync previous team config after move (non-fatal)");
+            }
         }
     }
 
@@ -64,9 +72,17 @@ impl TeamRegistry {
     pub async fn register_member(&self, key: &str, info: TeamInfo) -> std::io::Result<()> {
         let team_name = info.team_name.clone();
         let mut map = self.inner.lock().await;
-        map.insert(key.to_string(), info);
+        let previous = map.insert(key.to_string(), info);
+        let old_team_name = previous
+            .and_then(|prev| (prev.team_name != team_name).then_some(prev.team_name));
         drop(map);
-        self.persist_config(&team_name).await
+
+        self.persist_config(&team_name).await?;
+
+        if let Some(old_team) = old_team_name {
+            self.persist_config(&old_team).await?;
+        }
+        Ok(())
     }
 
     pub async fn get(&self, key: &str) -> Option<TeamInfo> {
@@ -205,16 +221,28 @@ impl TeamRegistry {
 
     /// Synchronize in-memory registry state for a team with its on-disk config.json.
     ///
-    /// CC-native members (those without backendType: "exomonad") are preserved.
+    /// CC-native members (those without backendType: "exomonad") are preserved as-is.
     /// Exomonad members are updated or added based on the current in-memory registry.
-    /// Members deduplicated by inbox_name.
+    /// Deduplication by inbox_name applies only to exomonad/in-memory entries written
+    /// by this bridge; existing CC-native members already present on disk are not
+    /// deduplicated or otherwise validated here.
     async fn persist_config(&self, team_name: &str) -> std::io::Result<()> {
+        let path = crate::paths::config_path(team_name).ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::NotFound, "HOME directory not found")
+        })?;
+
+        // Acquire advisory lock to prevent read-modify-write races
+        let _lock = crate::file_lock::FileLock::acquire(&path, std::time::Duration::from_secs(10))?;
+
         let mut config = match crate::config::read_team_config(team_name) {
             Ok(c) => c,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                 // If config doesn't exist, we can't persist to it.
                 // Claude Code owns the team lifecycle; we only augment existing teams.
-                return Ok(());
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    format!("team config.json not found for team '{team_name}'"),
+                ));
             }
             Err(e) => return Err(e),
         };
@@ -254,7 +282,7 @@ impl TeamRegistry {
                     name: inbox_name,
                     agent_type: "exomonad-agent".into(),
                     model: "gemini".into(),
-                    joined_at: chrono::Utc::now().timestamp_millis() as u64,
+                    joined_at: chrono::Utc::now().timestamp() as u64,
                     cwd: std::env::current_dir()
                         .unwrap_or_default()
                         .to_string_lossy()

--- a/rust/claude-teams-bridge/tests/integration.rs
+++ b/rust/claude-teams-bridge/tests/integration.rs
@@ -1499,3 +1499,78 @@ async fn test_cc_native_members_preserved() {
     assert!(disk_config.members.iter().any(|m| m.name == "native-1"));
     assert!(disk_config.members.iter().any(|m| m.name == "worker-1"));
 }
+
+#[tokio::test]
+#[serial]
+async fn test_register_member_moves_between_teams() {
+    let tmp = tempdir().unwrap();
+    let _home = ScopedHome::new(tmp.path());
+
+    let team1 = "team-1";
+    let team2 = "team-2";
+
+    for team in [team1, team2] {
+        let config = TeamConfig {
+            name: team.into(),
+            description: "test".into(),
+            created_at: 0,
+            lead_agent_id: "lead".into(),
+            lead_session_id: "session".into(),
+            members: vec![TeamMember {
+                agent_id: "lead".into(),
+                name: "lead".into(),
+                agent_type: "claude".into(),
+                model: "opus".into(),
+                joined_at: 0,
+                cwd: "/tmp".into(),
+                backend_type: None,
+            }],
+        };
+        write_team_config(team, &config).unwrap();
+    }
+
+    let registry = TeamRegistry::new();
+
+    // Register in team 1
+    registry
+        .register_member(
+            "agent-x",
+            TeamInfo {
+                team_name: team1.into(),
+                inbox_name: "agent-x".into(),
+            },
+        )
+        .await
+        .unwrap();
+
+    assert!(read_team_config(team1)
+        .unwrap()
+        .members
+        .iter()
+        .any(|m| m.name == "agent-x"));
+
+    // Move to team 2
+    registry
+        .register_member(
+            "agent-x",
+            TeamInfo {
+                team_name: team2.into(),
+                inbox_name: "agent-x".into(),
+            },
+        )
+        .await
+        .unwrap();
+
+    // Should be in team 2
+    assert!(read_team_config(team2)
+        .unwrap()
+        .members
+        .iter()
+        .any(|m| m.name == "agent-x"));
+    // Should be GONE from team 1
+    assert!(!read_team_config(team1)
+        .unwrap()
+        .members
+        .iter()
+        .any(|m| m.name == "agent-x"));
+}

--- a/rust/claude-teams-bridge/tests/integration.rs
+++ b/rust/claude-teams-bridge/tests/integration.rs
@@ -1,7 +1,7 @@
 use claude_teams_bridge::{
     config_path, inbox_path, is_message_read, list_inboxes, list_teams, read_inbox,
-    write_team_config, write_to_inbox, TeamConfig, TeamInfo, TeamMember, TeamRegistry,
-    TeamsMessage,
+    read_team_config, write_team_config, write_to_inbox, TeamConfig, TeamInfo, TeamMember,
+    TeamRegistry, TeamsMessage,
 };
 use serial_test::serial;
 use std::env;
@@ -75,6 +75,7 @@ fn config_json_matches_cc_format() {
             model: "opus".into(),
             joined_at: 1711022401,
             cwd: "/tmp".into(),
+            backend_type: None,
         }],
     };
 
@@ -310,6 +311,7 @@ async fn resolve_tier2_e2e_inbox_delivery() {
                 model: "opus".into(),
                 joined_at: 1711022401,
                 cwd: "/tmp/exo".into(),
+                backend_type: None,
             },
             TeamMember {
                 agent_id: "cc-supervisor-uuid".into(),
@@ -318,6 +320,7 @@ async fn resolve_tier2_e2e_inbox_delivery() {
                 model: "opus".into(),
                 joined_at: 1711022402,
                 cwd: "/tmp/cc".into(),
+                backend_type: None,
             },
         ],
     };
@@ -548,6 +551,7 @@ async fn lead_deregistered_still_resolves_via_config() {
                 model: "opus".into(),
                 joined_at: 1711022400,
                 cwd: "/tmp".into(),
+                backend_type: None,
             },
             TeamMember {
                 agent_id: "w1-uuid".into(),
@@ -556,6 +560,7 @@ async fn lead_deregistered_still_resolves_via_config() {
                 model: "haiku".into(),
                 joined_at: 1711022401,
                 cwd: "/tmp".into(),
+                backend_type: None,
             },
             TeamMember {
                 agent_id: "w2-uuid".into(),
@@ -564,6 +569,7 @@ async fn lead_deregistered_still_resolves_via_config() {
                 model: "haiku".into(),
                 joined_at: 1711022402,
                 cwd: "/tmp".into(),
+                backend_type: None,
             },
         ],
     };
@@ -620,6 +626,7 @@ async fn lead_replaced_config_authoritative() {
                 model: "opus".into(),
                 joined_at: 1711022400,
                 cwd: "/tmp".into(),
+                backend_type: None,
             },
             TeamMember {
                 agent_id: "uuid-new-lead".into(),
@@ -628,6 +635,7 @@ async fn lead_replaced_config_authoritative() {
                 model: "opus".into(),
                 joined_at: 1711022401,
                 cwd: "/tmp".into(),
+                backend_type: None,
             },
         ],
     };
@@ -697,6 +705,7 @@ async fn cross_team_name_collision() {
             model: "opus".into(),
             joined_at: 1711022401,
             cwd: "/tmp".into(),
+            backend_type: None,
         }],
     };
 
@@ -758,10 +767,12 @@ async fn orphaned_agent_returns_none() {
             name: "lead".into(),
             agent_type: "claude".into(),
             model: "opus".into(),
-            joined_at: 1711022400,
+            joined_at: 1711022401,
             cwd: "/tmp".into(),
+            backend_type: None,
         }],
     };
+
     write_team_config(team, &config).unwrap();
 
     let registry = TeamRegistry::new();
@@ -804,6 +815,7 @@ async fn resolve_lead_name_match_fallback() {
                 model: "opus".into(),
                 joined_at: 1711022400,
                 cwd: "/tmp".into(),
+                backend_type: None,
             },
             TeamMember {
                 agent_id: "uuid-worker".into(),
@@ -812,6 +824,7 @@ async fn resolve_lead_name_match_fallback() {
                 model: "haiku".into(),
                 joined_at: 1711022401,
                 cwd: "/tmp".into(),
+                backend_type: None,
             },
         ],
     };
@@ -835,10 +848,12 @@ async fn resolve_lead_name_match_fallback() {
             name: "someone".into(),
             agent_type: "claude".into(),
             model: "opus".into(),
-            joined_at: 1711022400,
+            joined_at: 1711022401,
             cwd: "/tmp".into(),
+            backend_type: None,
         }],
     };
+
     write_team_config(team2, &config2).unwrap();
 
     // No in-memory entries → None (config doesn't match by UUID or name)
@@ -880,6 +895,7 @@ async fn inbox_survives_config_restructuring() {
             model: "opus".into(),
             joined_at: 1711022401,
             cwd: "/tmp".into(),
+            backend_type: None,
         }],
     };
     write_team_config(team, &config_v1).unwrap();
@@ -909,6 +925,7 @@ async fn inbox_survives_config_restructuring() {
             model: "opus".into(),
             joined_at: 1711022401,
             cwd: "/tmp".into(),
+            backend_type: None,
         }],
     };
     write_team_config(team, &config_v2).unwrap();
@@ -990,6 +1007,7 @@ async fn supervisor_to_lead_routing_chain() {
                 model: "opus".into(),
                 joined_at: 1711022400,
                 cwd: "/tmp".into(),
+                backend_type: None,
             },
             TeamMember {
                 agent_id: "child-uuid".into(),
@@ -998,6 +1016,7 @@ async fn supervisor_to_lead_routing_chain() {
                 model: "haiku".into(),
                 joined_at: 1711022401,
                 cwd: "/tmp".into(),
+                backend_type: None,
             },
         ],
     };
@@ -1319,4 +1338,164 @@ async fn live_teams_e2e() {
     );
     println!("[e2e] CC's InboxPoller will deliver them to the agents");
     println!("[e2e] Lead inbox: check for messages from 'e2e-test-runner', 'e2e-worker-alpha', 'e2e-worker-beta', 'e2e-worker-gamma'");
+}
+
+// --- Sync persistence tests ---
+
+#[tokio::test]
+#[serial]
+async fn test_register_syncs_to_disk() {
+    let tmp = tempdir().unwrap();
+    let _home = ScopedHome::new(tmp.path());
+
+    let team = "drift-team";
+    let config = TeamConfig {
+        name: team.into(),
+        description: "Drift test".into(),
+        created_at: 1711022400,
+        lead_agent_id: "lead".into(),
+        lead_session_id: "session".into(),
+        members: vec![TeamMember {
+            agent_id: "lead".into(),
+            name: "lead".into(),
+            agent_type: "claude".into(),
+            model: "opus".into(),
+            joined_at: 1711022400,
+            cwd: "/tmp".into(),
+            backend_type: None,
+        }],
+    };
+    write_team_config(team, &config).unwrap();
+
+    let registry = TeamRegistry::new();
+
+    // Register a new member in-memory
+    registry
+        .register(
+            "worker-1",
+            TeamInfo {
+                team_name: team.into(),
+                inbox_name: "worker-1".into(),
+            },
+        )
+        .await;
+
+    // Verify it's ON disk (fix: register now syncs to disk)
+    let disk_config = read_team_config(team).unwrap();
+    let on_disk = disk_config.members.iter().any(|m| m.name == "worker-1");
+    assert!(on_disk, "Fix: member in-memory should also be on disk");
+
+    let member = disk_config
+        .members
+        .iter()
+        .find(|m| m.name == "worker-1")
+        .unwrap();
+    assert_eq!(member.backend_type.as_deref(), Some("exomonad"));
+}
+
+#[tokio::test]
+#[serial]
+async fn test_remove_member_persists_to_disk() {
+    let tmp = tempdir().unwrap();
+    let _home = ScopedHome::new(tmp.path());
+
+    let team = "remove-sync-team";
+    let config = TeamConfig {
+        name: team.into(),
+        description: "test".into(),
+        created_at: 0,
+        lead_agent_id: "lead".into(),
+        lead_session_id: "session".into(),
+        members: vec![TeamMember {
+            agent_id: "lead".into(),
+            name: "lead".into(),
+            agent_type: "claude".into(),
+            model: "opus".into(),
+            joined_at: 0,
+            cwd: "/tmp".into(),
+            backend_type: None,
+        }],
+    };
+    write_team_config(team, &config).unwrap();
+
+    let registry = TeamRegistry::new();
+    registry
+        .register(
+            "worker-1",
+            TeamInfo {
+                team_name: team.into(),
+                inbox_name: "worker-1".into(),
+            },
+        )
+        .await;
+
+    // Verify it's on disk
+    assert!(read_team_config(team)
+        .unwrap()
+        .members
+        .iter()
+        .any(|m| m.name == "worker-1"));
+
+    // Remove it
+    registry.deregister("worker-1").await;
+
+    // Verify it's GONE from disk
+    let disk_config = read_team_config(team).unwrap();
+    assert!(!disk_config.members.iter().any(|m| m.name == "worker-1"));
+    // Lead should still be there
+    assert!(disk_config.members.iter().any(|m| m.name == "lead"));
+}
+
+#[tokio::test]
+#[serial]
+async fn test_cc_native_members_preserved() {
+    let tmp = tempdir().unwrap();
+    let _home = ScopedHome::new(tmp.path());
+
+    let team = "preserve-team";
+    let config = TeamConfig {
+        name: team.into(),
+        description: "test".into(),
+        created_at: 0,
+        lead_agent_id: "lead".into(),
+        lead_session_id: "session".into(),
+        members: vec![
+            TeamMember {
+                agent_id: "lead".into(),
+                name: "lead".into(),
+                agent_type: "haiku".into(),
+                model: "opus".into(),
+                joined_at: 0,
+                cwd: "/tmp".into(),
+                backend_type: None, // CC-native
+            },
+            TeamMember {
+                agent_id: "native-1".into(),
+                name: "native-1".into(),
+                agent_type: "haiku".into(),
+                model: "opus".into(),
+                joined_at: 0,
+                cwd: "/tmp".into(),
+                backend_type: None, // CC-native
+            },
+        ],
+    };
+    write_team_config(team, &config).unwrap();
+
+    let registry = TeamRegistry::new();
+    registry
+        .register(
+            "worker-1",
+            TeamInfo {
+                team_name: team.into(),
+                inbox_name: "worker-1".into(),
+            },
+        )
+        .await;
+
+    let disk_config = read_team_config(team).unwrap();
+    assert_eq!(disk_config.members.len(), 3);
+    assert!(disk_config.members.iter().any(|m| m.name == "lead"));
+    assert!(disk_config.members.iter().any(|m| m.name == "native-1"));
+    assert!(disk_config.members.iter().any(|m| m.name == "worker-1"));
 }


### PR DESCRIPTION
Rebased on main.

Fixed TeamRegistry in-memory drift from on-disk config.json. `TeamDelete` (Claude Code tool) refuses to delete teams claiming active members that are not present in the on-disk members array. This was due to some members being registered in the in-memory registry (Tier 1) but not written to `config.json` (Tier 2).

Changes:
- Added `backend_type: Option<String>` to `TeamMember` struct in `claude-teams-bridge/src/config.rs` to identify exomonad-managed members.
- Implemented `persist_config` in `TeamRegistry` (`registry.rs`) to synchronize in-memory state with on-disk `config.json`.
- Updated `register` and `deregister` to call `persist_config` best-effort.
- Added explicit `register_member` and `remove_member` methods that return `Result`.
- Reconciled members by `inbox_name`, preserving CC-native members (without `backendType: "exomonad"`).
- Added comprehensive tests to `integration.rs` to verify synchronization and preservation of CC-native members.

Test count added: 3 new E2E tests in `integration.rs` plus updated all existing tests.
Verified with `cargo test -p claude-teams-bridge` and `cargo clippy`.
