### PR TITLE
fix(notify_parent): require non-empty message, remove tasks_completed to prevent report loss

### DIFF
--- a/haskell/wasm-guest/src/ExoMonad/Guest/Records/Events.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Guest/Records/Events.hs
@@ -10,7 +10,6 @@ module ExoMonad.Guest.Records.Events
     notifyParentDescription,
     notifyParentSchema,
     NotifyStatus (..),
-    TaskReport (..),
 
     -- * Shutdown (core + shared schema, no MCPTool instance)
     Shutdown,

--- a/haskell/wasm-guest/src/ExoMonad/Guest/Tools/Events.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Guest/Tools/Events.hs
@@ -109,12 +109,11 @@ notifyParentSchema =
 -- Returns Left on delivery failure, Right () on success.
 notifyParentCore :: NotifyParentArgs -> Eff Effects (Either Text ())
 notifyParentCore args = do
-  let richMessage = composeNotifyMessage args
-
   -- Validate: message must not be empty
-  if T.null (T.strip richMessage)
+  if T.null (T.strip (npMessage args))
     then pure $ Left "notify_parent: `message` is required and must not be empty. Put your report text in the `message` argument."
     else do
+      let richMessage = composeNotifyMessage args
       -- Emit event via suspend
       let eventPayload =
             BSL.toStrict $

--- a/haskell/wasm-guest/src/ExoMonad/Guest/Tools/Events.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Guest/Tools/Events.hs
@@ -27,7 +27,6 @@ module ExoMonad.Guest.Tools.Events
     -- * Args types (role wrappers need these)
     NotifyParentArgs (..),
     NotifyStatus (..),
-    TaskReport (..),
     ShutdownArgs (..),
 
     -- * Helpers
@@ -71,33 +70,10 @@ instance ToJSON NotifyStatus where
   toJSON Success = Aeson.String "success"
   toJSON Failure = Aeson.String "failure"
 
--- | Structured task report for enriched notifications.
-data TaskReport = TaskReport
-  { trWhat :: Text,
-    trHow :: Text
-  }
-  deriving (Generic, Show)
-
-instance JsonSchema TaskReport where
-  toSchema =
-    Aeson.Object $
-      genericToolSchemaWith @TaskReport
-        [ ("what", "task description"),
-          ("how", "verification command that was run")
-        ]
-
-instance FromJSON TaskReport where
-  parseJSON = withObject "TaskReport" $ \v ->
-    TaskReport <$> v .: "what" <*> v .: "how"
-
-instance ToJSON TaskReport where
-  toJSON (TaskReport w h) = object ["what" .= w, "how" .= h]
-
 data NotifyParentArgs = NotifyParentArgs
   { npStatus :: NotifyStatus,
     npMessage :: Text,
-    npPrNumber :: Maybe Int,
-    npTasksCompleted :: Maybe [TaskReport]
+    npPrNumber :: Maybe Int
   }
   deriving (Generic, Show)
 
@@ -107,82 +83,80 @@ instance FromJSON NotifyParentArgs where
       <$> v .: "status"
       <*> v .: "message"
       <*> v .:? "pr_number"
-      <*> v .:? "tasks_completed"
 
 instance ToJSON NotifyParentArgs where
   toJSON args =
     object
       [ "status" .= npStatus args,
         "message" .= npMessage args,
-        "pr_number" .= npPrNumber args,
-        "tasks_completed" .= npTasksCompleted args
+        "pr_number" .= npPrNumber args
       ]
 
 -- | Shared tool description for notify_parent.
 notifyParentDescription :: Text
-notifyParentDescription = "Send a message to your parent agent. Use for status updates, progress reports, or failure escalation. Messages are delivered as-is with lightweight attribution. For PR-based workflows, the system auto-notifies your parent when Copilot approves — you don't need to signal completion yourself."
+notifyParentDescription = "Send a message to your parent agent. The `message` argument IS the report — put all text the parent should read there. Parents see the full `message` string as a native teammate-message in their conversation. Do not use structured fields for report content — they are not delivered. Use this tool to report task completion, request help, send status updates, or escalate failures."
 
 -- | Shared tool schema for notify_parent.
 notifyParentSchema :: Aeson.Object
 notifyParentSchema =
   genericToolSchemaWith @NotifyParentArgs
     [ ("status", "'success' = normal message (status update, progress report). 'failure' = escalation, something went wrong."),
-      ("message", "The message to send. Be concise — one or two sentences."),
-      ("pr_number", "PR number if relevant. Helps parent locate the PR without searching."),
-      ("tasks_completed", "Array of {what, how} pairs. 'what' = task description, 'how' = verification command that was run.")
+      ("message", "The entire text the parent agent will see. Put your full report here in plain text or markdown. This tool does not have any other fields for status content — anything you want your parent to read must be in `message`."),
+      ("pr_number", "PR number if relevant. Helps parent locate the PR without searching.")
     ]
 
 -- | Core notify_parent I/O: emit event + deliver message to parent.
 -- Returns Left on delivery failure, Right () on success.
 notifyParentCore :: NotifyParentArgs -> Eff Effects (Either Text ())
 notifyParentCore args = do
-  -- Emit event via suspend
-  let eventPayload =
-        BSL.toStrict $
-          Aeson.encode $
-            object
-              [ "status" .= npStatus args,
-                "message" .= npMessage args,
-                "pr_number" .= npPrNumber args,
-                "tasks_completed" .= npTasksCompleted args
-              ]
-  void $
-    suspendEffect_ @LogEmitEvent
-      ( Log.EmitEventRequest
-          { Log.emitEventRequestEventType = "agent.completed",
-            Log.emitEventRequestPayload = eventPayload,
-            Log.emitEventRequestTimestamp = 0
-          }
-      )
-
   let richMessage = composeNotifyMessage args
-  let statusText = case npStatus args of
-        Success -> "success" :: Text
-        Failure -> "failure"
-  result <-
-    suspendEffect @ProtoEvents.EventsNotifyParent
-      ( ProtoEvents.NotifyParentRequest
-          { ProtoEvents.notifyParentRequestAgentId = "",
-            ProtoEvents.notifyParentRequestStatus = TL.fromStrict statusText,
-            ProtoEvents.notifyParentRequestMessage = TL.fromStrict richMessage,
-            ProtoEvents.notifyParentRequestOverrideRecipient = Nothing
-          }
-      )
-  case result of
-    Left err -> pure $ Left (T.pack (show err))
-    Right _ -> pure $ Right ()
 
--- | Compose enriched notification message with PR number and task reports.
+  -- Validate: message must not be empty
+  if T.null (T.strip richMessage)
+    then pure $ Left "notify_parent: `message` is required and must not be empty. Put your report text in the `message` argument."
+    else do
+      -- Emit event via suspend
+      let eventPayload =
+            BSL.toStrict $
+              Aeson.encode $
+                object
+                  [ "status" .= npStatus args,
+                    "message" .= npMessage args,
+                    "pr_number" .= npPrNumber args
+                  ]
+      void $
+        suspendEffect_ @LogEmitEvent
+          ( Log.EmitEventRequest
+              { Log.emitEventRequestEventType = "agent.completed",
+                Log.emitEventRequestPayload = eventPayload,
+                Log.emitEventRequestTimestamp = 0
+              }
+          )
+
+      let statusText = case npStatus args of
+            Success -> "success" :: Text
+            Failure -> "failure"
+      result <-
+        suspendEffect @ProtoEvents.EventsNotifyParent
+          ( ProtoEvents.NotifyParentRequest
+              { ProtoEvents.notifyParentRequestAgentId = "",
+                ProtoEvents.notifyParentRequestStatus = TL.fromStrict statusText,
+                ProtoEvents.notifyParentRequestMessage = TL.fromStrict richMessage,
+                ProtoEvents.notifyParentRequestOverrideRecipient = Nothing
+              }
+          )
+      case result of
+        Left err -> pure $ Left (T.pack (show err))
+        Right _ -> pure $ Right ()
+
+-- | Compose enriched notification message with PR number.
 composeNotifyMessage :: NotifyParentArgs -> Text
 composeNotifyMessage args =
   let base = npMessage args
       prSuffix = case npPrNumber args of
         Just n -> " (PR #" <> T.pack (show n) <> ")"
         Nothing -> ""
-      taskLines = case npTasksCompleted args of
-        Just tasks -> T.concat ["\n  - " <> trWhat t <> " (verified: " <> trHow t <> ")" | t <- tasks]
-        Nothing -> ""
-   in base <> prSuffix <> taskLines
+   in base <> prSuffix
 
 -- | Send message tool (stays in SDK — no state transitions needed)
 data SendMessage = SendMessage

--- a/rust/exomonad-core/tests/wasm_integration.rs
+++ b/rust/exomonad-core/tests/wasm_integration.rs
@@ -738,6 +738,72 @@ async fn wasm_notify_parent_roundtrip() {
     assert_tool_success(&output, "notify_parent");
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn wasm_notify_parent_rejects_empty_message() {
+    let runtime = build_test_runtime().await;
+
+    let output = call_tool(
+        &runtime,
+        "tl",
+        "notify_parent",
+        json!({
+            "status": "success",
+            "message": ""
+        }),
+    )
+    .await;
+
+    assert_tool_error(&output, "notify_parent");
+    let error = output["error"].as_str().unwrap();
+    assert!(error.contains("`message` is required and must not be empty"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn wasm_notify_parent_rejects_whitespace_only_message() {
+    let runtime = build_test_runtime().await;
+
+    let output = call_tool(
+        &runtime,
+        "tl",
+        "notify_parent",
+        json!({
+            "status": "success",
+            "message": "   \n\t "
+        }),
+    )
+    .await;
+
+    assert_tool_error(&output, "notify_parent");
+    let error = output["error"].as_str().unwrap();
+    assert!(error.contains("`message` is required and must not be empty"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn wasm_notify_parent_ignores_tasks_completed() {
+    let runtime = build_test_runtime().await;
+
+    let output = call_tool(
+        &runtime,
+        "tl",
+        "notify_parent",
+        json!({
+            "status": "success",
+            "message": "Report with legacy field",
+            "tasks_completed": [
+                {"what": "task1", "how": "cmd1"}
+            ]
+        }),
+    )
+    .await;
+
+    // Aeson's default is to ignore extra fields if they are not mapped.
+    // Since we removed it from NotifyParentArgs, it should just be ignored.
+    assert_tool_success(&output, "notify_parent");
+}
+
 // ============================================================================
 // Argument Validation Tests
 // ============================================================================

--- a/rust/exomonad-core/tests/wasm_integration.rs
+++ b/rust/exomonad-core/tests/wasm_integration.rs
@@ -782,6 +782,28 @@ async fn wasm_notify_parent_rejects_whitespace_only_message() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
+async fn wasm_notify_parent_rejects_empty_message_with_pr() {
+    let runtime = build_test_runtime().await;
+
+    let output = call_tool(
+        &runtime,
+        "tl",
+        "notify_parent",
+        json!({
+            "status": "success",
+            "message": "",
+            "pr_number": 123
+        }),
+    )
+    .await;
+
+    assert_tool_error(&output, "notify_parent");
+    let error = output["error"].as_str().unwrap();
+    assert!(error.contains("`message` is required and must not be empty"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
 async fn wasm_notify_parent_ignores_tasks_completed() {
     let runtime = build_test_runtime().await;
 


### PR DESCRIPTION
## Problem
Gemini agents often call `notify_parent` with an empty `message` and a populated `tasks_completed` field. However, the delivery pipeline only threads the `message` through to the parent (human) view, causing structured reports in `tasks_completed` to be silently dropped.

## Solution (Option A)
1. **Removed `tasks_completed`**: Since it was unused downstream (except for a log event) and its presence encouraged agents to put report content in the wrong field, it has been removed from the `NotifyParentArgs` and the tool schema.
2. **Enforced non-empty message**: Added a check in `notifyParentCore` that rejects empty or whitespace-only messages with a clear error: `notify_parent: `message` is required and must not be empty. Put your report text in the `message` argument.`
3. **Updated description**: Rewrote the tool description to be unambiguous about `message` being the primary report channel.
4. **Added tests**: Added integration tests in `rust/exomonad-core/tests/wasm_integration.rs` to verify rejection of empty/whitespace messages and that `tasks_completed` is now ignored if provided.

## Verification
- WASM rebuild: `just wasm-all` (successful)
- Integration tests: `cargo test -p exomonad-core --test wasm_integration wasm_notify_parent_` (all 4 passed)
- Clippy/Fmt: `cargo clippy` and `just fmt` (clean)

Existing failures in `wasm_integration.rs` related to `spawn_workers` and `spawn_leaf_subtree` appear to be pre-existing and unrelated to these changes.
