### PR TITLE
fix(merge_pr): default working_dir to "." and normalize empty/whitespace

### DIFF
--- a/haskell/wasm-guest/src/ExoMonad/Guest/Tools/MergePR.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Guest/Tools/MergePR.hs
@@ -283,7 +283,12 @@ extractAgentName branch
 
 -- | Helper for working directory defaults (defaults to ".").
 workingDirOrDefault :: Maybe Text -> TL.Text
-workingDirOrDefault = maybe "." TL.fromStrict
+workingDirOrDefault mWorkingDir =
+  case fmap T.strip mWorkingDir of
+    Nothing -> "."
+    Just dir
+      | T.null dir -> "."
+      | otherwise -> TL.fromStrict dir
 
 -- | Execute the actual merge after readiness check passes.
 doMerge :: MergePRArgs -> Eff Effects (Either Text MergePROutput)

--- a/haskell/wasm-guest/src/ExoMonad/Guest/Tools/MergePR.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Guest/Tools/MergePR.hs
@@ -16,6 +16,7 @@ module ExoMonad.Guest.Tools.MergePR
     mergePRSchema,
     mergePRRender,
     extractAgentName,
+    workingDirOrDefault,
   )
 where
 
@@ -280,6 +281,10 @@ extractAgentName branch
       [] -> Nothing
       (slug : _) -> Just slug
 
+-- | Helper for working directory defaults (defaults to ".").
+workingDirOrDefault :: Maybe Text -> TL.Text
+workingDirOrDefault = maybe "." TL.fromStrict
+
 -- | Execute the actual merge after readiness check passes.
 doMerge :: MergePRArgs -> Eff Effects (Either Text MergePROutput)
 doMerge args = do
@@ -287,7 +292,7 @@ doMerge args = do
         MP.MergePrRequest
           { MP.mergePrRequestPrNumber = fromIntegral (mprPrNumber args),
             MP.mergePrRequestStrategy = maybe "" TL.fromStrict (mprStrategy args),
-            MP.mergePrRequestWorkingDir = maybe "" TL.fromStrict (mprWorkingDir args)
+            MP.mergePrRequestWorkingDir = workingDirOrDefault (mprWorkingDir args)
           }
   result <- suspendEffect @MergePRMergePr req
   case result of
@@ -326,7 +331,7 @@ doMerge args = do
                     Proc.RunRequest
                       { Proc.runRequestCommand = "git",
                         Proc.runRequestArgs = V.fromList ["pull"],
-                        Proc.runRequestWorkingDir = maybe "" TL.fromStrict (mprWorkingDir args),
+                        Proc.runRequestWorkingDir = workingDirOrDefault (mprWorkingDir args),
                         Proc.runRequestEnv = Map.empty,
                         Proc.runRequestTimeoutMs = 30000
                       }

--- a/haskell/wasm-guest/src/ExoMonad/Guest/Tools/MergePRTests.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Guest/Tools/MergePRTests.hs
@@ -62,9 +62,11 @@ test_render_includes_pull_error_when_set = mergePRRender $ MergePROutput
   }
 -- Expected: JSON includes "pull_error": "fatal: some error"
 
--- | Test that working directory defaults to "." when Nothing is provided.
+-- | Test that working directory defaults to "." when Nothing, "", or whitespace is provided.
 -- This verifies the fix for the regression where "" was passed.
 test_working_dir_defaults_to_dot :: Bool
 test_working_dir_defaults_to_dot =
   workingDirOrDefault Nothing == "." &&
+  workingDirOrDefault (Just "") == "." &&
+  workingDirOrDefault (Just "  ") == "." &&
   workingDirOrDefault (Just "some/dir") == "some/dir"

--- a/haskell/wasm-guest/src/ExoMonad/Guest/Tools/MergePRTests.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Guest/Tools/MergePRTests.hs
@@ -61,3 +61,10 @@ test_render_includes_pull_error_when_set = mergePRRender $ MergePROutput
   , mpoPullError = Just "fatal: some error"
   }
 -- Expected: JSON includes "pull_error": "fatal: some error"
+
+-- | Test that working directory defaults to "." when Nothing is provided.
+-- This verifies the fix for the regression where "" was passed.
+test_working_dir_defaults_to_dot :: Bool
+test_working_dir_defaults_to_dot =
+  workingDirOrDefault Nothing == "." &&
+  workingDirOrDefault (Just "some/dir") == "some/dir"


### PR DESCRIPTION
Addressed Copilot review comments:
- Updated `workingDirOrDefault` to normalize `Just ""` and whitespace-only strings to `"."`.
- Updated `test_working_dir_defaults_to_dot` to cover these new normalization cases.

Verified with `wasm32-wasi-cabal build`. A full WASM test suite is not currently present in the project, so these manual verification tests remain the primary way to check logic in this module.