### PR TITLE
refactor(services): plug EXOMONAD_TMUX_SESSION env leaks via HasTmuxIpc

### DIFF
--- a/rust/exomonad-core/src/handlers/copilot.rs
+++ b/rust/exomonad-core/src/handlers/copilot.rs
@@ -6,24 +6,27 @@ use crate::effects::{
     dispatch_copilot_effect, CopilotEffects, EffectHandler, EffectResult, ResultExt,
 };
 use crate::services::copilot_review;
+use crate::services::HasTmuxIpc;
 use async_trait::async_trait;
 use exomonad_proto::effects::copilot::*;
+use std::sync::Arc;
 
 /// Copilot effect handler.
 ///
 /// Handles all effects in the `copilot.*` namespace by delegating to
 /// the generated `dispatch_copilot_effect` function.
-#[derive(Default)]
-pub struct CopilotHandler;
+pub struct CopilotHandler<C> {
+    ctx: Arc<C>,
+}
 
-impl CopilotHandler {
-    pub fn new() -> Self {
-        Self
+impl<C: HasTmuxIpc + 'static> CopilotHandler<C> {
+    pub fn new(ctx: Arc<C>) -> Self {
+        Self { ctx }
     }
 }
 
 #[async_trait]
-impl EffectHandler for CopilotHandler {
+impl<C: HasTmuxIpc + 'static> EffectHandler for CopilotHandler<C> {
     fn namespace(&self) -> &str {
         "copilot"
     }
@@ -39,7 +42,7 @@ impl EffectHandler for CopilotHandler {
 }
 
 #[async_trait]
-impl CopilotEffects for CopilotHandler {
+impl<C: HasTmuxIpc + 'static> CopilotEffects for CopilotHandler<C> {
     async fn wait_for_copilot_review(
         &self,
         req: WaitForCopilotReviewRequest,
@@ -65,7 +68,7 @@ impl CopilotEffects for CopilotHandler {
             },
         };
 
-        let output = copilot_review::wait_for_copilot_review(&input)
+        let output = copilot_review::wait_for_copilot_review(&input, self.ctx.tmux_ipc())
             .await
             .effect_err("copilot")?;
 
@@ -94,13 +97,15 @@ mod tests {
 
     #[test]
     fn test_copilot_handler_new() {
-        let handler = CopilotHandler;
+        let services = std::sync::Arc::new(crate::services::Services::test());
+        let handler = CopilotHandler::new(services);
         assert_eq!(handler.namespace(), "copilot");
     }
 
     #[test]
     fn test_copilot_handler_namespace() {
-        let handler = CopilotHandler;
+        let services = std::sync::Arc::new(crate::services::Services::test());
+        let handler = CopilotHandler::new(services);
         assert_eq!(handler.namespace(), "copilot");
     }
 }

--- a/rust/exomonad-core/src/handlers/file_pr.rs
+++ b/rust/exomonad-core/src/handlers/file_pr.rs
@@ -13,7 +13,7 @@ use exomonad_proto::effects::file_pr::*;
 use std::sync::Arc;
 use tracing::instrument;
 
-use crate::services::{HasEventLog, HasGitHubClient, HasGitWorktreeService};
+use crate::services::{HasEventLog, HasGitHubClient, HasGitWorktreeService, HasTmuxIpc};
 
 /// File PR effect handler.
 ///
@@ -23,14 +23,14 @@ pub struct FilePRHandler<C> {
     ctx: Arc<C>,
 }
 
-impl<C: HasGitHubClient + HasEventLog + HasGitWorktreeService + 'static> FilePRHandler<C> {
+impl<C: HasGitHubClient + HasEventLog + HasGitWorktreeService + HasTmuxIpc + 'static> FilePRHandler<C> {
     pub fn new(ctx: Arc<C>) -> Self {
         Self { ctx }
     }
 }
 
 #[async_trait]
-impl<C: HasGitHubClient + HasEventLog + HasGitWorktreeService + 'static> EffectHandler
+impl<C: HasGitHubClient + HasEventLog + HasGitWorktreeService + HasTmuxIpc + 'static> EffectHandler
     for FilePRHandler<C>
 {
     fn namespace(&self) -> &str {
@@ -48,7 +48,7 @@ impl<C: HasGitHubClient + HasEventLog + HasGitWorktreeService + 'static> EffectH
 }
 
 #[async_trait]
-impl<C: HasGitHubClient + HasEventLog + HasGitWorktreeService + 'static> FilePrEffects
+impl<C: HasGitHubClient + HasEventLog + HasGitWorktreeService + HasTmuxIpc + 'static> FilePrEffects
     for FilePRHandler<C>
 {
     #[instrument(skip_all, fields(agent_name = %ctx.agent_name, pr_title = %req.title))]
@@ -73,6 +73,7 @@ impl<C: HasGitHubClient + HasEventLog + HasGitWorktreeService + 'static> FilePrE
             &input,
             self.ctx.git_worktree_service().clone(),
             self.ctx.github_client().map(|arc| arc.as_ref()),
+            self.ctx.tmux_ipc(),
         )
         .await
         .effect_err("file_pr")?;

--- a/rust/exomonad-core/src/handlers/groups.rs
+++ b/rust/exomonad-core/src/handlers/groups.rs
@@ -31,7 +31,7 @@ pub fn git_handlers(services: Arc<Services>, git: Arc<GitService>) -> Vec<Box<dy
         Box::new(GitHandler::new(git)),
         Box::new(FilePRHandler::new(services.clone())),
         Box::new(MergePRHandler::new(services.clone())),
-        Box::new(CopilotHandler::new()),
+        Box::new(CopilotHandler::new(services.clone())),
     ];
     if let Some(client) = services.github_client() {
         handlers.push(Box::new(GitHubHandler::new(GitHubService::new(

--- a/rust/exomonad-core/src/services/copilot_review.rs
+++ b/rust/exomonad-core/src/services/copilot_review.rs
@@ -204,6 +204,7 @@ async fn fetch_pr_reviews(
 /// Main wait_for_copilot_review implementation
 pub async fn wait_for_copilot_review(
     input: &WaitForCopilotReviewInput,
+    tmux_ipc: &crate::services::tmux_ipc::TmuxIpc,
 ) -> Result<CopilotReviewOutput> {
     info!(
         "[CopilotReview] Waiting for Copilot review on PR #{} (timeout: {}s, poll: {}s)",
@@ -224,27 +225,26 @@ pub async fn wait_for_copilot_review(
         if !comments.is_empty() {
             info!("[CopilotReview] Found {} Copilot comments", comments.len());
 
-            // Emit copilot:reviewed event (only if in tmux session)
-            if let Ok(session) = std::env::var("EXOMONAD_TMUX_SESSION") {
-                if let Ok(branch) = git::get_current_branch() {
-                    if let Some(agent_id_str) = git::extract_agent_id(branch.as_str()) {
-                        match crate::ui_protocol::AgentId::try_from(agent_id_str) {
-                            Ok(agent_id) => {
-                                let event = crate::ui_protocol::AgentEvent::CopilotReviewed {
-                                    agent_id,
-                                    comment_count: comments.len() as u32,
-                                    timestamp: tmux_events::now_iso8601(),
-                                };
-                                if let Err(e) = tmux_events::emit_event(&session, &event) {
-                                    warn!("Failed to emit copilot:reviewed event: {}", e);
-                                }
+            // Emit copilot:reviewed event
+            if let Ok(branch) = git::get_current_branch() {
+                if let Some(agent_id_str) = git::extract_agent_id(branch.as_str()) {
+                    match crate::ui_protocol::AgentId::try_from(agent_id_str) {
+                        Ok(agent_id) => {
+                            let event = crate::ui_protocol::AgentEvent::CopilotReviewed {
+                                agent_id,
+                                comment_count: comments.len() as u32,
+                                timestamp: tmux_events::now_iso8601(),
+                            };
+                            if let Err(e) = tmux_events::emit_event(tmux_ipc.session_name(), &event)
+                            {
+                                warn!("Failed to emit copilot:reviewed event: {}", e);
                             }
-                            Err(e) => {
-                                warn!(
-                                    "Invalid agent_id in branch '{}', skipping event: {}",
-                                    branch, e
-                                );
-                            }
+                        }
+                        Err(e) => {
+                            warn!(
+                                "Invalid agent_id in branch '{}', skipping event: {}",
+                                branch, e
+                            );
                         }
                     }
                 }
@@ -260,27 +260,26 @@ pub async fn wait_for_copilot_review(
         if fetch_pr_reviews(&owner, &repo, input.pr_number).await? {
             info!("[CopilotReview] Found Copilot review (no inline comments)");
 
-            // Emit copilot:reviewed event with 0 comments (only if in tmux session)
-            if let Ok(session) = std::env::var("EXOMONAD_TMUX_SESSION") {
-                if let Ok(branch) = git::get_current_branch() {
-                    if let Some(agent_id_str) = git::extract_agent_id(branch.as_str()) {
-                        match crate::ui_protocol::AgentId::try_from(agent_id_str) {
-                            Ok(agent_id) => {
-                                let event = crate::ui_protocol::AgentEvent::CopilotReviewed {
-                                    agent_id,
-                                    comment_count: 0,
-                                    timestamp: tmux_events::now_iso8601(),
-                                };
-                                if let Err(e) = tmux_events::emit_event(&session, &event) {
-                                    warn!("Failed to emit copilot:reviewed event: {}", e);
-                                }
+            // Emit copilot:reviewed event with 0 comments
+            if let Ok(branch) = git::get_current_branch() {
+                if let Some(agent_id_str) = git::extract_agent_id(branch.as_str()) {
+                    match crate::ui_protocol::AgentId::try_from(agent_id_str) {
+                        Ok(agent_id) => {
+                            let event = crate::ui_protocol::AgentEvent::CopilotReviewed {
+                                agent_id,
+                                comment_count: 0,
+                                timestamp: tmux_events::now_iso8601(),
+                            };
+                            if let Err(e) = tmux_events::emit_event(tmux_ipc.session_name(), &event)
+                            {
+                                warn!("Failed to emit copilot:reviewed event: {}", e);
                             }
-                            Err(e) => {
-                                warn!(
-                                    "Invalid agent_id in branch '{}', skipping event: {}",
-                                    branch, e
-                                );
-                            }
+                        }
+                        Err(e) => {
+                            warn!(
+                                "Invalid agent_id in branch '{}', skipping event: {}",
+                                branch, e
+                            );
                         }
                     }
                 }

--- a/rust/exomonad-core/src/services/file_pr.rs
+++ b/rust/exomonad-core/src/services/file_pr.rs
@@ -163,6 +163,7 @@ pub async fn file_pr_async(
     input: &FilePRInput,
     git_wt: Arc<GitWorktreeService>,
     github: Option<&GitHubClient>,
+    tmux_ipc: &crate::services::tmux_ipc::TmuxIpc,
 ) -> Result<FilePROutput> {
     let dir = input.working_dir.as_deref().unwrap_or(".");
     let octo = match github {
@@ -236,26 +237,24 @@ pub async fn file_pr_async(
     )
     .await?;
 
-    // Emit pr:filed event (only if in tmux session)
-    if let Ok(session) = std::env::var("EXOMONAD_TMUX_SESSION") {
-        if let Some(agent_id_str) = git::extract_agent_id(head.as_str()) {
-            match crate::ui_protocol::AgentId::try_from(agent_id_str) {
-                Ok(agent_id) => {
-                    let event = crate::ui_protocol::AgentEvent::PrFiled {
-                        agent_id,
-                        pr_number: PRNumber::new(pr.number),
-                        timestamp: tmux_events::now_iso8601(),
-                    };
-                    if let Err(e) = tmux_events::emit_event(&session, &event) {
-                        warn!("Failed to emit pr:filed event: {}", e);
-                    }
+    // Emit pr:filed event
+    if let Some(agent_id_str) = git::extract_agent_id(head.as_str()) {
+        match crate::ui_protocol::AgentId::try_from(agent_id_str) {
+            Ok(agent_id) => {
+                let event = crate::ui_protocol::AgentEvent::PrFiled {
+                    agent_id,
+                    pr_number: PRNumber::new(pr.number),
+                    timestamp: tmux_events::now_iso8601(),
+                };
+                if let Err(e) = tmux_events::emit_event(tmux_ipc.session_name(), &event) {
+                    warn!("Failed to emit pr:filed event: {}", e);
                 }
-                Err(e) => {
-                    warn!(
-                        "Invalid agent_id in branch '{}', skipping event: {}",
-                        head, e
-                    );
-                }
+            }
+            Err(e) => {
+                warn!(
+                    "Invalid agent_id in branch '{}', skipping event: {}",
+                    head, e
+                );
             }
         }
     }
@@ -397,7 +396,11 @@ mod tests {
             working_dir: Some(temp_dir.path().to_string_lossy().to_string()),
         };
 
-        let result = file_pr_async(&input, git_wt, None).await;
+        let tmux_ipc = crate::services::tmux_ipc::TmuxIpc::new_with_socket(
+            "test-session",
+            Some("exomonad-test-dummy".to_string()),
+        );
+        let result = file_pr_async(&input, git_wt, None, &tmux_ipc).await;
         assert!(result.is_err());
 
         Ok(())
@@ -450,7 +453,11 @@ mod tests {
             working_dir: Some(dir.to_string_lossy().to_string()),
         };
 
-        let result = file_pr_async(&input, git_wt, None).await;
+        let tmux_ipc = crate::services::tmux_ipc::TmuxIpc::new_with_socket(
+            "test-session",
+            Some("exomonad-test-dummy".to_string()),
+        );
+        let result = file_pr_async(&input, git_wt, None, &tmux_ipc).await;
 
         if let Err(ref e) = result {
             let err_msg = e.to_string();

--- a/rust/exomonad-core/src/services/tmux_events.rs
+++ b/rust/exomonad-core/src/services/tmux_events.rs
@@ -12,9 +12,9 @@ use super::tmux_ipc::{PaneId, TmuxIpc};
 
 /// Emit an agent event. Log-only — no tmux interaction.
 /// Keeps function signature for callers.
-pub fn emit_event(_session: &str, event: &AgentEvent) -> Result<()> {
+pub fn emit_event(session: &str, event: &AgentEvent) -> Result<()> {
     let json = serde_json::to_string(event).context("Failed to serialize event")?;
-    info!("[TmuxEvents] Event: {}", json);
+    info!("[TmuxEvents][{}] Event: {}", session, json);
     Ok(())
 }
 


### PR DESCRIPTION
This PR plugs 3 direct `std::env::var("EXOMONAD_TMUX_SESSION")` leaks in `file_pr_async` and `wait_for_copilot_review` by threading `&TmuxIpc` through the callers.

- Modified `file_pr_async` in `rust/exomonad-core/src/services/file_pr.rs` to take `&TmuxIpc`.
- Modified `wait_for_copilot_review` in `rust/exomonad-core/src/services/copilot_review.rs` to take `&TmuxIpc`.
- Updated `FilePRHandler` to include `HasTmuxIpc` bound and pass the IPC handle.
- Refactored `CopilotHandler` to be generic over `C: HasTmuxIpc` and take a context `Arc<C>`.
- Updated `git_handlers` in `rust/exomonad-core/src/handlers/groups.rs` to pass `services` to `CopilotHandler`.
- Updated all relevant test call sites and confirmed with `cargo build` and `cargo test`.
- Verified code quality with `cargo clippy`.

These changes ensure that tmux access is centralized, allowing tests to isolate via per-test sockets (`IsolatedTmux`).