### PR TITLE
feat: implement GC for stale agent directories in exomonad init

### DIFF
--- a/rust/exomonad-core/src/services/agent_control/cleanup.rs
+++ b/rust/exomonad-core/src/services/agent_control/cleanup.rs
@@ -52,7 +52,13 @@ impl<
                 Ok(routing) => {
                     let is_live = if let Some(wid) = &routing.window_id {
                         match self.tmux() {
-                            Ok(tmux) => tmux.window_exists(wid).await.unwrap_or(false),
+                            Ok(tmux) => match tmux.window_exists(wid).await {
+                                Ok(exists) => exists,
+                                Err(e) => {
+                                    warn!(path = %path.display(), error = %e, "Tmux liveness check failed, skipping agent");
+                                    true
+                                }
+                            }
                             Err(_) => {
                                 warn!(path = %path.display(), "Tmux session unavailable, skipping liveness check for agent");
                                 stats.kept_live += 1;
@@ -61,7 +67,13 @@ impl<
                         }
                     } else if let Some(pid) = &routing.pane_id {
                         match self.tmux() {
-                            Ok(tmux) => tmux.pane_exists(pid).await.unwrap_or(false),
+                            Ok(tmux) => match tmux.pane_exists(pid).await {
+                                Ok(exists) => exists,
+                                Err(e) => {
+                                    warn!(path = %path.display(), error = %e, "Tmux liveness check failed, skipping agent");
+                                    true
+                                }
+                            }
                             Err(_) => {
                                 warn!(path = %path.display(), "Tmux session unavailable, skipping liveness check for agent");
                                 stats.kept_live += 1;

--- a/rust/exomonad-core/src/services/agent_control/cleanup.rs
+++ b/rust/exomonad-core/src/services/agent_control/cleanup.rs
@@ -53,12 +53,20 @@ impl<
                     let is_live = if let Some(wid) = &routing.window_id {
                         match self.tmux() {
                             Ok(tmux) => tmux.window_exists(wid).await.unwrap_or(false),
-                            Err(_) => false,
+                            Err(_) => {
+                                warn!(path = %path.display(), "Tmux session unavailable, skipping liveness check for agent");
+                                stats.kept_live += 1;
+                                continue;
+                            }
                         }
                     } else if let Some(pid) = &routing.pane_id {
                         match self.tmux() {
                             Ok(tmux) => tmux.pane_exists(pid).await.unwrap_or(false),
-                            Err(_) => false,
+                            Err(_) => {
+                                warn!(path = %path.display(), "Tmux session unavailable, skipping liveness check for agent");
+                                stats.kept_live += 1;
+                                continue;
+                            }
                         }
                     } else {
                         info!(path = %path.display(), reason = "neither window_id nor pane_id set in routing.json", "Pruning orphan agent directory");
@@ -531,7 +539,7 @@ mod tests {
             Arc::new(crate::services::GitWorktreeService::new(project_dir.clone())),
             Arc::new(isolated.ipc.clone()),
         ).build();
-        let service = AgentControlService::new(Arc::new(services))
+        let service = AgentControlService::new(Arc::new(services.clone()))
             .with_tmux_session(isolated.session.clone());
 
         // 1. Live agent (window)
@@ -575,10 +583,20 @@ mod tests {
         fs::create_dir_all(&malformed_dir).await.unwrap();
         fs::write(malformed_dir.join("routing.json"), "{}").await.unwrap();
 
+        // 6. Tmux unavailable (should keep the directory)
+        let no_tmux_dir = agents_dir.join("no-tmux");
+        fs::create_dir_all(&no_tmux_dir).await.unwrap();
+        let routing = RoutingInfo {
+            window_id: Some(crate::services::tmux_ipc::WindowId::parse("@123").unwrap()),
+            pane_id: None,
+            parent_tab: None,
+        };
+        fs::write(no_tmux_dir.join("routing.json"), serde_json::to_string(&routing).unwrap()).await.unwrap();
+
         let stats = service.gc_stale_agents().await.unwrap();
-        assert_eq!(stats.scanned, 5);
-        assert_eq!(stats.kept_live, 1);
-        assert_eq!(stats.pruned_dead_tmux, 1); // dead-window
+        assert_eq!(stats.scanned, 6);
+        assert_eq!(stats.kept_live, 1); // only live-window
+        assert_eq!(stats.pruned_dead_tmux, 2); // dead-window + no-tmux (now dead)
         assert_eq!(stats.pruned_orphan, 2); // old-orphan + malformed
         assert_eq!(stats.kept_recent, 1); // recent-orphan
 
@@ -587,5 +605,22 @@ mod tests {
         assert!(!old_orphan_dir.exists());
         assert!(recent_orphan_dir.exists());
         assert!(!malformed_dir.exists());
+        assert!(!no_tmux_dir.exists());
+
+        // 7. Re-create a directory for testing fail-open without tmux session
+        let fail_open_dir = agents_dir.join("fail-open");
+        fs::create_dir_all(&fail_open_dir).await.unwrap();
+        fs::write(fail_open_dir.join("routing.json"), serde_json::to_string(&routing).unwrap()).await.unwrap();
+
+        // Test with no tmux session set (should fail open for all routing.json cases)
+        let service_no_tmux = AgentControlService::new(Arc::new(services.clone()));
+        let stats = service_no_tmux.gc_stale_agents().await.unwrap();
+        // Remaining: live-window, recent-orphan, fail-open
+        assert_eq!(stats.scanned, 3);
+        assert_eq!(stats.kept_live, 2); // live-window, fail-open (both fail-open because no session)
+        assert_eq!(stats.kept_recent, 1); // recent-orphan
+        assert_eq!(stats.pruned_dead_tmux, 0);
+        assert_eq!(stats.pruned_orphan, 0);
+        assert!(fail_open_dir.exists());
     }
 }

--- a/rust/exomonad-core/src/services/agent_control/cleanup.rs
+++ b/rust/exomonad-core/src/services/agent_control/cleanup.rs
@@ -1,5 +1,20 @@
 use super::*;
 
+/// Statistics for stale agent garbage collection.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct GcStats {
+    /// Number of directories scanned in .exo/agents/
+    pub scanned: usize,
+    /// Number of directories pruned because their tmux window/pane is gone
+    pub pruned_dead_tmux: usize,
+    /// Number of orphan directories (no routing.json) pruned because they are old
+    pub pruned_orphan: usize,
+    /// Number of live agent directories kept
+    pub kept_live: usize,
+    /// Number of recent orphan directories (likely in-flight spawn) kept
+    pub kept_recent: usize,
+}
+
 impl<
         C: super::super::HasGitHubClient
             + super::super::HasAcpRegistry
@@ -11,6 +26,104 @@ impl<
             + 'static,
     > AgentControlService<C>
 {
+    /// Garbage collect stale agent directories in `.exo/agents/`.
+    ///
+    /// Scans all subdirectories, checks liveness via tmux (from routing.json),
+    /// and prunes dead or orphan directories.
+    pub async fn gc_stale_agents(&self) -> Result<GcStats> {
+        let mut stats = GcStats::default();
+        let agents_dir = self.ctx.project_dir().join(".exo/agents");
+
+        if !agents_dir.exists() {
+            info!(path = %agents_dir.display(), "Agents directory does not exist, skipping GC");
+            return Ok(stats);
+        }
+
+        let mut dir_entries = fs::read_dir(&agents_dir).await?;
+        while let Some(entry) = dir_entries.next_entry().await? {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+
+            stats.scanned += 1;
+
+            match RoutingInfo::read_from_dir(&path).await {
+                Ok(routing) => {
+                    let is_live = if let Some(wid) = &routing.window_id {
+                        match self.tmux() {
+                            Ok(tmux) => tmux.window_exists(wid).await.unwrap_or(false),
+                            Err(_) => false,
+                        }
+                    } else if let Some(pid) = &routing.pane_id {
+                        match self.tmux() {
+                            Ok(tmux) => tmux.pane_exists(pid).await.unwrap_or(false),
+                            Err(_) => false,
+                        }
+                    } else {
+                        info!(path = %path.display(), reason = "neither window_id nor pane_id set in routing.json", "Pruning orphan agent directory");
+                        if let Err(e) = fs::remove_dir_all(&path).await {
+                            warn!(path = %path.display(), error = %e, "Failed to prune orphan agent directory");
+                        } else {
+                            stats.pruned_orphan += 1;
+                        }
+                        continue;
+                    };
+
+                    if is_live {
+                        stats.kept_live += 1;
+                    } else {
+                        info!(path = %path.display(), reason = "dead tmux target", "Pruning dead agent directory");
+                        if let Err(e) = fs::remove_dir_all(&path).await {
+                            warn!(path = %path.display(), error = %e, "Failed to prune dead agent directory");
+                        } else {
+                            stats.pruned_dead_tmux += 1;
+                        }
+                    }
+                }
+                Err(_) => {
+                    // No routing.json or parse fail
+                    match fs::metadata(&path).await {
+                        Ok(meta) => {
+                            match meta.modified() {
+                                Ok(mtime) => {
+                                    let elapsed = mtime.elapsed().unwrap_or(Duration::ZERO);
+                                    if elapsed >= Duration::from_secs(3600) {
+                                        info!(path = %path.display(), age = ?elapsed, reason = "orphan (no routing.json) and old", "Pruning orphan agent directory");
+                                        if let Err(e) = fs::remove_dir_all(&path).await {
+                                            warn!(path = %path.display(), error = %e, "Failed to prune orphan agent directory");
+                                        } else {
+                                            stats.pruned_orphan += 1;
+                                        }
+                                    } else {
+                                        stats.kept_recent += 1;
+                                    }
+                                }
+                                Err(e) => {
+                                    warn!(path = %path.display(), error = %e, "Failed to read mtime for agent directory");
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            warn!(path = %path.display(), error = %e, "Failed to read metadata for agent directory");
+                        }
+                    }
+                }
+            }
+        }
+
+        info!(
+            scanned = stats.scanned,
+            pruned_dead_tmux = stats.pruned_dead_tmux,
+            pruned_orphan = stats.pruned_orphan,
+            kept_live = stats.kept_live,
+            kept_recent = stats.kept_recent,
+            "GC stale agents completed"
+        );
+
+        Ok(stats)
+    }
+
     /// Clean up an agent by identifier (internal_name or issue_id).
     ///
     /// Kills the tmux window, unregisters from Teams config.json,
@@ -371,5 +484,108 @@ impl<
             }
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::tmux_ipc::IsolatedTmux;
+    use crate::services::HasProjectDir;
+    use std::fs::File;
+    use std::time::SystemTime;
+
+    #[tokio::test]
+    async fn test_gc_stale_agents_empty() {
+        let temp = tempfile::tempdir().unwrap();
+        let project_dir = temp.path().to_path_buf();
+        let services = crate::services::Services::test_with_project_dir(project_dir);
+        let service = AgentControlService::new(Arc::new(services));
+
+        // Missing .exo/agents/
+        let stats = service.gc_stale_agents().await.unwrap();
+        assert_eq!(stats.scanned, 0);
+
+        // Empty .exo/agents/
+        let agents_dir = service.ctx.project_dir().join(".exo/agents");
+        tokio::fs::create_dir_all(&agents_dir).await.unwrap();
+        let stats = service.gc_stale_agents().await.unwrap();
+        assert_eq!(stats.scanned, 0);
+    }
+
+    #[tokio::test]
+    async fn test_gc_stale_agents_scenarios() {
+        if !IsolatedTmux::is_available().await {
+            return;
+        }
+        let isolated = IsolatedTmux::new().await.unwrap();
+        let temp = tempfile::tempdir().unwrap();
+        let project_dir = temp.path().to_path_buf();
+        let agents_dir = project_dir.join(".exo/agents");
+        fs::create_dir_all(&agents_dir).await.unwrap();
+
+        // Use ServicesBuilder directly to ensure project_dir is set to our temp dir
+        let services = crate::services::ServicesBuilder::new(
+            project_dir.clone(),
+            project_dir.join(".exo/tasks"),
+            Arc::new(crate::services::GitWorktreeService::new(project_dir.clone())),
+            Arc::new(isolated.ipc.clone()),
+        ).build();
+        let service = AgentControlService::new(Arc::new(services))
+            .with_tmux_session(isolated.session.clone());
+
+        // 1. Live agent (window)
+        let live_window_dir = agents_dir.join("live-window");
+        fs::create_dir_all(&live_window_dir).await.unwrap();
+        let windows = isolated.ipc.list_windows().await.unwrap();
+        let live_window_id = &windows[0].window_id;
+        let routing = RoutingInfo {
+            window_id: Some(live_window_id.clone()),
+            pane_id: None,
+            parent_tab: None,
+        };
+        fs::write(live_window_dir.join("routing.json"), serde_json::to_string(&routing).unwrap()).await.unwrap();
+
+        // 2. Dead agent (window)
+        let dead_window_dir = agents_dir.join("dead-window");
+        fs::create_dir_all(&dead_window_dir).await.unwrap();
+        let routing = RoutingInfo {
+            window_id: Some(crate::services::tmux_ipc::WindowId::parse("@99999").unwrap()),
+            pane_id: None,
+            parent_tab: None,
+        };
+        fs::write(dead_window_dir.join("routing.json"), serde_json::to_string(&routing).unwrap()).await.unwrap();
+
+        // 3. Orphan (old, no routing.json)
+        let old_orphan_dir = agents_dir.join("old-orphan");
+        fs::create_dir_all(&old_orphan_dir).await.unwrap();
+        let f = File::create(old_orphan_dir.join("somefile")).unwrap();
+        let past = SystemTime::now() - Duration::from_secs(4000);
+        f.set_times(std::fs::FileTimes::new().set_modified(past)).unwrap();
+        // Also set mtime on the directory itself
+        let d = File::open(&old_orphan_dir).unwrap();
+        d.set_times(std::fs::FileTimes::new().set_modified(past)).unwrap();
+
+        // 4. Recent orphan (new, no routing.json)
+        let recent_orphan_dir = agents_dir.join("recent-orphan");
+        fs::create_dir_all(&recent_orphan_dir).await.unwrap();
+
+        // 5. Malformed (routing.json exists but empty)
+        let malformed_dir = agents_dir.join("malformed");
+        fs::create_dir_all(&malformed_dir).await.unwrap();
+        fs::write(malformed_dir.join("routing.json"), "{}").await.unwrap();
+
+        let stats = service.gc_stale_agents().await.unwrap();
+        assert_eq!(stats.scanned, 5);
+        assert_eq!(stats.kept_live, 1);
+        assert_eq!(stats.pruned_dead_tmux, 1); // dead-window
+        assert_eq!(stats.pruned_orphan, 2); // old-orphan + malformed
+        assert_eq!(stats.kept_recent, 1); // recent-orphan
+
+        assert!(live_window_dir.exists());
+        assert!(!dead_window_dir.exists());
+        assert!(!old_orphan_dir.exists());
+        assert!(recent_orphan_dir.exists());
+        assert!(!malformed_dir.exists());
     }
 }

--- a/rust/exomonad-core/src/services/agent_control/mod.rs
+++ b/rust/exomonad-core/src/services/agent_control/mod.rs
@@ -9,6 +9,7 @@ mod cleanup;
 mod internal;
 mod spawn;
 
+pub use cleanup::GcStats;
 pub(crate) use internal::SpawnRollback;
 
 pub(crate) use crate::common::TimeoutError;

--- a/rust/exomonad-core/src/services/tmux_ipc.rs
+++ b/rust/exomonad-core/src/services/tmux_ipc.rs
@@ -686,10 +686,20 @@ impl TmuxIpc {
     pub async fn pane_exists(&self, pane_id: &PaneId) -> Result<bool> {
         let status = self
             .tmux_cmd()
-            .args(["display-message", "-t", pane_id.as_str(), "-p", ""])
+            .args(["has-session", "-t", pane_id.as_str()])
             .status()
             .await
-            .context("Failed to run tmux display-message")?;
+            .context("Failed to run tmux has-session")?;
+        Ok(status.success())
+    }
+
+    pub async fn window_exists(&self, window_id: &WindowId) -> Result<bool> {
+        let status = self
+            .tmux_cmd()
+            .args(["has-session", "-t", window_id.as_str()])
+            .status()
+            .await
+            .context("Failed to run tmux has-session")?;
         Ok(status.success())
     }
 }
@@ -946,5 +956,33 @@ mod tests {
                 .await
                 .unwrap()
         );
+    }
+
+    #[tokio::test]
+    async fn test_window_exists() {
+        if !IsolatedTmux::is_available().await {
+            return;
+        }
+        let isolated = IsolatedTmux::new().await.unwrap();
+        let windows = isolated.ipc.list_windows().await.unwrap();
+        let first_window = &windows[0].window_id;
+        assert!(isolated.ipc.window_exists(first_window).await.unwrap());
+
+        let fake_window = WindowId::parse("@99999").unwrap();
+        assert!(!isolated.ipc.window_exists(&fake_window).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_pane_exists() {
+        if !IsolatedTmux::is_available().await {
+            return;
+        }
+        let isolated = IsolatedTmux::new().await.unwrap();
+        let windows = isolated.ipc.list_windows().await.unwrap();
+        let first_pane = &windows[0].pane_id;
+        assert!(isolated.ipc.pane_exists(first_pane).await.unwrap());
+
+        let fake_pane = PaneId::parse("%99999").unwrap();
+        assert!(!isolated.ipc.pane_exists(&fake_pane).await.unwrap());
     }
 }

--- a/rust/exomonad/src/init.rs
+++ b/rust/exomonad/src/init.rs
@@ -496,7 +496,8 @@ pub async fn run(session_override: Option<String>, recreate: bool) -> Result<()>
             Arc::new(ipc.clone()),
         )
         .build();
-        let agent_control = AgentControlService::new(Arc::new(services));
+        let agent_control = AgentControlService::new(Arc::new(services))
+            .with_tmux_session(session.clone());
         if let Err(e) = agent_control.gc_stale_agents().await {
             warn!(error = %e, "GC stale agents failed (non-fatal)");
         }

--- a/rust/exomonad/src/init.rs
+++ b/rust/exomonad/src/init.rs
@@ -482,6 +482,26 @@ pub async fn run(session_override: Option<String>, recreate: bool) -> Result<()>
     // 4. Poll for server socket
     wait_for_server_socket(&cwd).await?;
 
+    // GC stale agents before spawning companions
+    {
+        use exomonad_core::services::agent_control::AgentControlService;
+        use exomonad_core::services::{GitWorktreeService, ServicesBuilder};
+        use std::sync::Arc;
+
+        let git_wt = Arc::new(GitWorktreeService::new(cwd.clone()));
+        let services = ServicesBuilder::new(
+            cwd.clone(),
+            cwd.join(".exo/tasks"),
+            git_wt,
+            Arc::new(ipc.clone()),
+        )
+        .build();
+        let agent_control = AgentControlService::new(Arc::new(services));
+        if let Err(e) = agent_control.gc_stale_agents().await {
+            warn!(error = %e, "GC stale agents failed (non-fatal)");
+        }
+    }
+
     // 5. Spawn companion agents
     for companion in &config.companions {
         // Validate companion name (alphanumeric, hyphens, underscores only)


### PR DESCRIPTION
### Goal
Implement GC for stale `.exo/agents/{name}/` directories to prevent accumulation of dead agent configurations.

### Changes
- **tmux_ipc.rs**:
  - Added `window_exists` helper.
  - Fixed `pane_exists` (and `window_exists`) to use `has-session -t` instead of `display-message`, which incorrectly returned success for nonexistent targets.
  - Added unit tests for `window_exists` and `pane_exists`.
- **cleanup.rs**:
  - Defined `GcStats` struct for reporting GC results.
  - Implemented `gc_stale_agents` on `AgentControlService`.
  - Logic:
    - Scans `.exo/agents/*`.
    - If `routing.json` exists, verifies tmux liveness of the target window/pane.
    - **Robust Fail-Open**: If tmux session is unavailable OR if the liveness check itself fails, it keeps the directory and logs a warning instead of pruning.
    - If no `routing.json`, prunes directories older than 1 hour (orphans).
    - Logs decisions and summary counts.
  - Re-exported `GcStats` from `mod.rs` to fix private interface lint.
  - Added comprehensive unit tests for `gc_stale_agents` including fail-open scenarios.
- **init.rs**:
  - Wired `gc_stale_agents` into `exomonad init` after server socket availability and before spawning companions.
  - Correctly configured `AgentControlService` with the tmux session name.

### Verification
- `cargo build -p exomonad-core`
- `cargo build -p exomonad`
- `cargo test -p exomonad-core --lib gc_stale_agents`
- `cargo test -p exomonad-core --lib window_exists`
- `cargo test -p exomonad-core --lib test_pane_exists`
- `cargo test --workspace --lib`
- `cargo clippy --workspace -- -D warnings`