### PR TITLE
fix: sanitize branch names in KV store keys

### DIFF
--- a/.exo/roles/devswarm/TLRole.hs
+++ b/.exo/roles/devswarm/TLRole.hs
@@ -24,7 +24,7 @@ import ExoMonad.Guest.Tools.Spawn
     spawnGeminiCore, spawnGeminiDescription, spawnGeminiSchema, SpawnGeminiArgs,
     spawnLeafRender,
     spawnWorkerToolCore, spawnWorkerToolDescription, spawnWorkerToolSchema, SpawnWorkerToolArgs,
-    spawnAcpCore, SpawnAcpArgs
+    spawnAcpCore, spawnAcpDescription, spawnAcpSchema, SpawnAcpArgs
   )
 import ExoMonad.Guest.Effects.AgentControl (SpawnResult (..))
 import ExoMonad.Guest.Types (StopDecision(..), StopHookOutput(..), blockStopResponse, allowStopResponse, allowResponse, BeforeModelOutput (..), AfterModelOutput (..))
@@ -127,6 +127,16 @@ instance MCPTool TLSpawnWorker where
   toolSchema = spawnWorkerToolSchema
   toolHandlerEff args = spawnWorkerToolCore args
 
+-- | TL-specific spawn_acp: ACP protocol agent, no state transition.
+data TLSpawnAcp
+
+instance MCPTool TLSpawnAcp where
+  type ToolArgs TLSpawnAcp = SpawnAcpArgs
+  toolName = "spawn_acp"
+  toolDescription = spawnAcpDescription
+  toolSchema = spawnAcpSchema
+  toolHandlerEff args = spawnAcpCore args
+
 -- | TL notify_parent: thin wrapper, no phase transitions.
 data TLNotifyParent
 
@@ -145,6 +155,7 @@ data Tools mode = Tools
   { forkWave :: mode :- TLForkWave,
     spawnGemini :: mode :- TLSpawnGemini,
     spawnWorker :: mode :- TLSpawnWorker,
+    spawnAcp :: mode :- TLSpawnAcp,
     pr :: mode :- TLFilePR,
     mergePr :: mode :- TLMergePR,
     notifyParent :: mode :- TLNotifyParent,
@@ -161,6 +172,7 @@ config =
           { forkWave = mkHandler @TLForkWave,
             spawnGemini = mkHandler @TLSpawnGemini,
             spawnWorker = mkHandler @TLSpawnWorker,
+            spawnAcp = mkHandler @TLSpawnAcp,
             pr = mkHandler @TLFilePR,
             mergePr = mkHandler @TLMergePR,
             notifyParent = mkHandler @TLNotifyParent,

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,20 @@
 {
   "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1777335812,
+        "narHash": "sha256-bEg5xoAxAwsyfnGhkEX7RJViTIBIYPd8ISg4O1c0HFc=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "5e0fb2f64edff2822249f21293b8304dedaaf676",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -91,6 +106,7 @@
     },
     "root": {
       "inputs": {
+        "crane": "crane",
         "flake-utils": "flake-utils",
         "ghc-wasm-meta": "ghc-wasm-meta",
         "nixpkgs": "nixpkgs_2",

--- a/flake.nix
+++ b/flake.nix
@@ -58,6 +58,62 @@
           jujutsu  # jj
         ];
 
+        # Exomonad Rust binary
+        exomonad = pkgs.rustPlatform.buildRustPackage {
+          pname = "exomonad";
+          version = "0.1.0";
+          src = pkgs.lib.cleanSourceWith {
+            src = ./.;
+            filter = path: type:
+              let
+                baseName = builtins.baseNameOf path;
+                relPath = pkgs.lib.removePrefix (toString ./.) (toString path);
+              in
+              # Include Rust workspace files
+              baseName == "Cargo.toml" || baseName == "Cargo.lock"
+              || pkgs.lib.hasPrefix "/rust" relPath
+              # Include proto files (needed by prost-build)
+              || pkgs.lib.hasPrefix "/proto" relPath
+              # Include vendored ACP SDK (path dependency)
+              || pkgs.lib.hasPrefix "/vendor/acp-rust-sdk" relPath
+              # Allow directories to be traversed
+              || type == "directory";
+          };
+
+          cargoHash = "sha256-UeHbNtTYzto+pGt/8lfBisKk+S8CPtZhwPDukwdmLRE=";
+
+          nativeBuildInputs = with pkgs; [
+            protobuf  # protoc for prost-build
+            pkg-config
+          ];
+
+          buildInputs = with pkgs; [
+            openssl
+          ] ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isDarwin (with pkgs.darwin.apple_sdk.frameworks; [
+            Security
+            SystemConfiguration
+          ]);
+
+          # Only build the exomonad binary
+          cargoBuildFlags = [ "-p" "exomonad" ];
+          cargoTestFlags = [ "-p" "exomonad" ];
+
+          # Proto symlinks need to be resolved for the nix sandbox
+          preBuild = ''
+            # Replace proto symlinks with actual directories
+            rm -rf rust/exomonad-proto/proto/exomonad rust/exomonad-proto/proto/effects
+            cp -r proto/exomonad rust/exomonad-proto/proto/exomonad
+            cp -r proto/effects rust/exomonad-proto/proto/effects
+          '';
+
+          meta = with pkgs.lib; {
+            description = "Type-safe LLM agent orchestration";
+            homepage = "https://github.com/tidepool-heavy-industries/exomonad";
+            license = licenses.bsd3;
+            mainProgram = "exomonad";
+          };
+        };
+
         # NotebookLM MCP server (vendored, optional)
         notebooklm-mcp = pkgs.buildNpmPackage {
           pname = "notebooklm-mcp";
@@ -155,10 +211,8 @@
         };
 
         packages = {
-          default = pkgs.writeShellScriptBin "exomonad-env-check" ''
-            echo "ExoMonad environment check"
-            echo "Run 'nix develop' to enter the development shell"
-          '';
+          default = exomonad;
+          inherit exomonad;
           inherit notebooklm-mcp;
         };
       }

--- a/flake.nix
+++ b/flake.nix
@@ -7,9 +7,11 @@
     ghc-wasm-meta.url = "gitlab:haskell-wasm/ghc-wasm-meta?host=gitlab.haskell.org";
     rust-overlay.url = "github:oxalica/rust-overlay";
     rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
+    crane.url = "github:ipetkov/crane";
+    crane.inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = { self, nixpkgs, flake-utils, ghc-wasm-meta, rust-overlay }:
+  outputs = { self, nixpkgs, flake-utils, ghc-wasm-meta, rust-overlay, crane }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs {
@@ -45,6 +47,9 @@
           pkg-config
         ];
 
+        # Crane for incremental Rust builds
+        craneLib = crane.mkLib pkgs;
+
         # Rust toolchain (latest stable for edition 2024 support)
         rustToolchain = pkgs.rust-bin.stable.latest.default.override {
           extensions = [ "rust-src" "rust-analyzer" ];
@@ -58,32 +63,37 @@
           jujutsu  # jj
         ];
 
-        # Exomonad Rust binary
-        exomonad = pkgs.rustPlatform.buildRustPackage {
-          pname = "exomonad";
-          version = "0.1.0";
-          src = pkgs.lib.cleanSourceWith {
-            src = ./.;
-            filter = path: type:
-              let
-                baseName = builtins.baseNameOf path;
-                relPath = pkgs.lib.removePrefix (toString ./.) (toString path);
-              in
-              # Include Rust workspace files
-              baseName == "Cargo.toml" || baseName == "Cargo.lock"
-              || pkgs.lib.hasPrefix "/rust" relPath
-              # Include proto files (needed by prost-build)
-              || pkgs.lib.hasPrefix "/proto" relPath
-              # Include vendored ACP SDK (path dependency)
-              || pkgs.lib.hasPrefix "/vendor/acp-rust-sdk" relPath
-              # Allow directories to be traversed
-              || type == "directory";
-          };
+        # Source with proto files included
+        # Note: crane's buildDepsOnly applies cleanCargoSource which removes non-Cargo files.
+        # We work around this by including proto files as a separate derivation.
+        exomonadSource = builtins.path {
+          path = ./.;
+          name = "exomonad-source";
+          filter = path: type:
+            let
+              baseName = builtins.baseNameOf path;
+              relPath = pkgs.lib.removePrefix (toString ./.) (toString path);
+            in
+            baseName == "Cargo.toml" || baseName == "Cargo.lock"
+            || pkgs.lib.hasPrefix "/rust" relPath
+            || pkgs.lib.hasPrefix "/proto" relPath
+            || pkgs.lib.hasPrefix "/vendor/acp-rust-sdk" relPath
+            || type == "directory";
+        };
 
-          cargoHash = "sha256-UeHbNtTYzto+pGt/8lfBisKk+S8CPtZhwPDukwdmLRE=";
+        # Proto files as a separate derivation (to copy into build)
+        protoFiles = builtins.path {
+          path = ./proto;
+          name = "exomonad-proto";
+        };
+
+        # Common crane configuration
+        commonCraneArgs = {
+          src = exomonadSource;
+          cargoLock = ./Cargo.lock;
 
           nativeBuildInputs = with pkgs; [
-            protobuf  # protoc for prost-build
+            protobuf
             pkg-config
           ];
 
@@ -94,17 +104,21 @@
             SystemConfiguration
           ]);
 
-          # Only build the exomonad binary
+          preBuild = ''
+            # Copy proto files from separate derivation (crane removes them from src)
+            echo "Copying proto files from ${protoFiles}..."
+            mkdir -p rust/exomonad-proto/proto
+            cp -r ${protoFiles}/exomonad rust/exomonad-proto/proto/exomonad
+            cp -r ${protoFiles}/effects rust/exomonad-proto/proto/effects
+          '';
+        };
+
+        # Exomonad Rust binary (built with crane)
+        # Using buildPackage directly provides incremental compilation
+        exomonad = craneLib.buildPackage (commonCraneArgs // {
+          pname = "exomonad";
           cargoBuildFlags = [ "-p" "exomonad" ];
           cargoTestFlags = [ "-p" "exomonad" ];
-
-          # Proto symlinks need to be resolved for the nix sandbox
-          preBuild = ''
-            # Replace proto symlinks with actual directories
-            rm -rf rust/exomonad-proto/proto/exomonad rust/exomonad-proto/proto/effects
-            cp -r proto/exomonad rust/exomonad-proto/proto/exomonad
-            cp -r proto/effects rust/exomonad-proto/proto/effects
-          '';
 
           meta = with pkgs.lib; {
             description = "Type-safe LLM agent orchestration";
@@ -112,7 +126,7 @@
             license = licenses.bsd3;
             mainProgram = "exomonad";
           };
-        };
+        });
 
         # NotebookLM MCP server (vendored, optional)
         notebooklm-mcp = pkgs.buildNpmPackage {

--- a/flake.nix
+++ b/flake.nix
@@ -113,12 +113,18 @@
           '';
         };
 
+        # Cache workspace-wide dep compilation once, reused below.
+        cargoArtifacts = craneLib.buildDepsOnly commonCraneArgs;
+
         # Exomonad Rust binary (built with crane)
-        # Using buildPackage directly provides incremental compilation
+        # Crane attribute names: cargoBuildExtraArgs / cargoTestExtraArgs
+        # (strings). The legacy *Flags names are silently dropped, which
+        # otherwise causes `cargo test` to run workspace-wide.
         exomonad = craneLib.buildPackage (commonCraneArgs // {
           pname = "exomonad";
-          cargoBuildFlags = [ "-p" "exomonad" ];
-          cargoTestFlags = [ "-p" "exomonad" ];
+          inherit cargoArtifacts;
+          cargoBuildExtraArgs = "-p exomonad";
+          cargoTestExtraArgs = "-p exomonad";
 
           meta = with pkgs.lib; {
             description = "Type-safe LLM agent orchestration";

--- a/haskell/wasm-guest/src/ExoMonad/Guest/StateMachine.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Guest/StateMachine.hs
@@ -32,6 +32,7 @@ import Control.Monad (void)
 import Control.Monad.Freer (Eff, Member)
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Aeson qualified as Aeson
+import Data.Char (isAsciiLower, isAsciiUpper, isDigit)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.Encoding (encodeUtf8)
@@ -75,9 +76,12 @@ class (ToJSON phase, FromJSON phase, Typeable phase, Show phase) => StateMachine
   canExit :: phase -> StopCheckResult
   machineName :: Text
 
--- | Sanitize branch name for KV keys (replace dots with double-hyphens).
+-- | Sanitize branch name for KV keys.
+-- KV keys allow only [a-zA-Z0-9_-]. Any invalid character becomes a hyphen.
 sanitizeBranch :: Text -> Text
-sanitizeBranch = T.replace "." "--"
+sanitizeBranch = T.map (\c -> if isKvChar c then c else '-')
+  where
+    isKvChar c = isAsciiLower c || isAsciiUpper c || isDigit c || c == '_' || c == '-'
 
 -- | KV key scoped by machine name and branch.
 scopedPhaseKey :: forall phase event. (StateMachine phase event) => Text -> Text

--- a/haskell/wasm-guest/src/ExoMonad/Guest/Tools/Spawn.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Guest/Tools/Spawn.hs
@@ -48,6 +48,8 @@ module ExoMonad.Guest.Tools.Spawn
     spawnGeminiSchema,
     spawnWorkerToolDescription,
     spawnWorkerToolSchema,
+    spawnAcpDescription,
+    spawnAcpSchema,
 
     -- * Helpers (re-exported for role code)
     spawnErrorMessage,
@@ -604,6 +606,21 @@ instance FromJSON SpawnAcpArgs where
       <*> v .:? "permission_mode"
       <*> v .:? "allowed_tools"
       <*> v .:? "disallowed_tools"
+
+-- | Description for spawn_acp tool.
+spawnAcpDescription :: Text
+spawnAcpDescription = "Spawn a Gemini agent using ACP (Agent Client Protocol). ACP uses a structured JSON protocol over stdin/stdout instead of tmux injection. More reliable than tmux but requires gemini --acp support. Runs in the caller's directory with no git isolation."
+
+-- | Schema for spawn_acp tool.
+spawnAcpSchema :: Aeson.Object
+spawnAcpSchema =
+  genericToolSchemaWith @SpawnAcpArgs
+    [ ("name", "Agent name (messaging identity)"),
+      ("prompt", "The full prompt. Everything the agent needs in one string"),
+      ("permission_mode", "Optional permission mode (e.g., 'default')"),
+      ("allowed_tools", "Optional list of allowed tools"),
+      ("disallowed_tools", "Optional list of disallowed tools")
+    ]
 
 -- | Core spawn_acp I/O.
 spawnAcpCore :: SpawnAcpArgs -> Eff Effects MCPCallOutput

--- a/rust/claude-teams-bridge/src/config.rs
+++ b/rust/claude-teams-bridge/src/config.rs
@@ -35,8 +35,13 @@ pub struct TeamMember {
 
 /// Read team config from `~/.claude/teams/{team}/config.json`.
 pub fn read_team_config(team: &str) -> io::Result<TeamConfig> {
-    let path = paths::config_path(team)
+    let base = dirs::home_dir()
         .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "HOME directory not found"))?;
+    read_team_config_at_base(&base, team)
+}
+
+pub(crate) fn read_team_config_at_base(base: &Path, team: &str) -> io::Result<TeamConfig> {
+    let path = paths::config_path_at(base, team);
     let content = std::fs::read_to_string(&path)?;
     serde_json::from_str(&content)
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))
@@ -44,8 +49,17 @@ pub fn read_team_config(team: &str) -> io::Result<TeamConfig> {
 
 /// Write team config atomically.
 pub fn write_team_config(team: &str, config: &TeamConfig) -> io::Result<()> {
-    let path = paths::config_path(team)
+    let base = dirs::home_dir()
         .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "HOME directory not found"))?;
+    write_team_config_at_base(&base, team, config)
+}
+
+pub(crate) fn write_team_config_at_base(
+    base: &Path,
+    team: &str,
+    config: &TeamConfig,
+) -> io::Result<()> {
+    let path = paths::config_path_at(base, team);
     write_team_config_at(&path, config)
 }
 

--- a/rust/claude-teams-bridge/src/registry.rs
+++ b/rust/claude-teams-bridge/src/registry.rs
@@ -13,6 +13,7 @@
 //! that already know the team name).
 
 use std::collections::HashMap;
+use std::path::Path;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tracing::{debug, info};
@@ -111,8 +112,17 @@ impl TeamRegistry {
     /// a member name. Falls back to the first in-memory entry if config.json
     /// is unavailable or the lead is not a member.
     pub async fn resolve_lead(&self, team_name: &str) -> Option<String> {
+        let base = dirs::home_dir()?;
+        self.resolve_lead_at_base(&base, team_name).await
+    }
+
+    pub(crate) async fn resolve_lead_at_base(
+        &self,
+        base: &Path,
+        team_name: &str,
+    ) -> Option<String> {
         // Primary: read config.json's leadAgentId and map to member name
-        if let Ok(config) = crate::config::read_team_config(team_name) {
+        if let Ok(config) = crate::config::read_team_config_at_base(base, team_name) {
             if let Some(member) = config
                 .members
                 .iter()
@@ -181,7 +191,16 @@ impl TeamRegistry {
     /// as inbox key. Useful for callers that already know the team name and want
     /// to skip the in-memory check.
     pub fn resolve_from_config(team_name: &str, recipient: &str) -> Option<TeamInfo> {
-        let config = crate::config::read_team_config(team_name).ok()?;
+        let base = dirs::home_dir()?;
+        Self::resolve_from_config_at_base(&base, team_name, recipient)
+    }
+
+    pub(crate) fn resolve_from_config_at_base(
+        base: &Path,
+        team_name: &str,
+        recipient: &str,
+    ) -> Option<TeamInfo> {
+        let config = crate::config::read_team_config_at_base(base, team_name).ok()?;
         let member = config
             .members
             .iter()
@@ -507,6 +526,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_resolve_lead_from_config() {
+        let tmp = tempfile::tempdir().unwrap();
         let team_name = "test-resolve-lead";
         let config = crate::config::TeamConfig {
             name: team_name.into(),
@@ -537,18 +557,13 @@ mod tests {
                 },
             ],
         };
-        crate::config::write_team_config(team_name, &config).unwrap();
+        crate::config::write_team_config_at_base(tmp.path(), team_name, &config).unwrap();
 
         let reg = TeamRegistry::new();
         // Without config.json, alphabetical "alpha-worker" would have been picked.
         // With resolve_lead, "team-lead" is picked via leadAgentId.
-        let lead = reg.resolve_lead(team_name).await;
+        let lead = reg.resolve_lead_at_base(tmp.path(), team_name).await;
         assert_eq!(lead, Some("team-lead".to_string()));
-
-        // Cleanup
-        if let Some(dir) = crate::paths::teams_base_dir() {
-            let _ = std::fs::remove_dir_all(dir.join(team_name));
-        }
     }
 
     #[tokio::test]
@@ -624,7 +639,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_resolve_tier2_from_config() {
-        // Create a real team config on disk
+        let tmp = tempfile::tempdir().unwrap();
         let team_name = "test-resolve-tier2";
         let config = crate::config::TeamConfig {
             name: team_name.into(),
@@ -643,25 +658,24 @@ mod tests {
                 aliases: Vec::new(),
             }],
         };
-        crate::config::write_team_config(team_name, &config).unwrap();
+        crate::config::write_team_config_at_base(tmp.path(), team_name, &config).unwrap();
 
         // Resolve via Tier 2
-        let result = TeamRegistry::resolve_from_config(team_name, "supervisor").unwrap();
+        let result =
+            TeamRegistry::resolve_from_config_at_base(tmp.path(), team_name, "supervisor").unwrap();
         assert_eq!(result.team_name, team_name);
         assert_eq!(result.inbox_name, "supervisor");
 
         // Non-member returns None
-        assert!(TeamRegistry::resolve_from_config(team_name, "nonexistent").is_none());
-
-        // Cleanup
-        if let Some(dir) = crate::paths::teams_base_dir() {
-            let _ = std::fs::remove_dir_all(dir.join(team_name));
-        }
+        assert!(
+            TeamRegistry::resolve_from_config_at_base(tmp.path(), team_name, "nonexistent")
+                .is_none()
+        );
     }
 
     #[tokio::test]
     async fn test_resolve_tier2_scoped_by_sender_team() {
-        // Create two teams with same member name
+        let tmp = tempfile::tempdir().unwrap();
         let team_a = "test-resolve-scope-a";
         let team_b = "test-resolve-scope-b";
         for (team, cwd) in [(team_a, "/tmp/a"), (team_b, "/tmp/b")] {
@@ -682,33 +696,16 @@ mod tests {
                     aliases: Vec::new(),
                 }],
             };
-            crate::config::write_team_config(team, &config).unwrap();
+            crate::config::write_team_config_at_base(tmp.path(), team, &config).unwrap();
         }
 
-        let reg = TeamRegistry::new();
-        // Sender is in team_a → resolve "team-lead" picks team_a's config
-        reg.register(
-            "sender",
-            TeamInfo {
-                team_name: team_a.into(),
-                inbox_name: "sender".into(),
-                agent_type: "exomonad-agent".into(),
-                model: "gemini".into(),
-                backend_type: None,
-            },
-        )
-        .await;
-
-        let result = reg.resolve("team-lead", Some(team_a)).await.unwrap();
+        // Sender is in team_a → resolve "team-lead" via team_a's config
+        let result =
+            TeamRegistry::resolve_from_config_at_base(tmp.path(), team_a, "team-lead").unwrap();
         assert_eq!(result.team_name, team_a);
 
-        let result_b = reg.resolve("team-lead", Some(team_b)).await.unwrap();
+        let result_b =
+            TeamRegistry::resolve_from_config_at_base(tmp.path(), team_b, "team-lead").unwrap();
         assert_eq!(result_b.team_name, team_b);
-
-        // Cleanup
-        if let Some(dir) = crate::paths::teams_base_dir() {
-            let _ = std::fs::remove_dir_all(dir.join(team_a));
-            let _ = std::fs::remove_dir_all(dir.join(team_b));
-        }
     }
 }

--- a/rust/exomonad-core/src/handlers/agent.rs
+++ b/rust/exomonad-core/src/handlers/agent.rs
@@ -433,7 +433,11 @@ impl<
             ctx,
         )
         .await;
-        self.register_child_supervisor(&req.name, ctx).await;
+
+        // Register supervisor mapping using child's full birth_branch
+        // (not just req.name) so notify_parent can resolve the parent
+        let child_birth_branch = ctx.birth_branch.child(result.agent_name.as_str());
+        self.register_child_supervisor(child_birth_branch.as_str(), ctx).await;
 
         Ok(SpawnWorkerResponse {
             agent: Some(agent_info),
@@ -520,7 +524,10 @@ impl<
             );
         }
 
-        self.register_child_supervisor(&req.branch_name, ctx).await;
+        // Register supervisor mapping using child's full birth_branch
+        // (not just req.branch_name) so notify_parent can resolve the parent
+        let child_birth_branch = ctx.birth_branch.child(result.agent_name.as_str());
+        self.register_child_supervisor(child_birth_branch.as_str(), ctx).await;
 
         // Register sub-TL as synthetic member so it can receive Teams inbox messages
         let child_identity = crate::services::agent_control::AgentIdentity::new(
@@ -599,7 +606,11 @@ impl<
             ctx,
         )
         .await;
-        self.register_child_supervisor(&req.branch_name, ctx).await;
+
+        // Register supervisor mapping using child's full birth_branch
+        // (not just req.branch_name) so notify_parent can resolve the parent
+        let child_birth_branch = ctx.birth_branch.child(result.agent_name.as_str());
+        self.register_child_supervisor(child_birth_branch.as_str(), ctx).await;
 
         Ok(SpawnLeafSubtreeResponse {
             agent: Some(agent_info),

--- a/rust/exomonad-core/src/services/agent_control/internal.rs
+++ b/rust/exomonad-core/src/services/agent_control/internal.rs
@@ -410,11 +410,18 @@ impl<
             format!("{} {}", env_prefix, agent_command)
         };
 
-        // Wrap in nix develop shell if flake.nix exists in cwd
+        // Wrap in nix develop shell if flake.nix exists in cwd.
+        // --impure + DEVENV_ROOT are needed for devenv-based flakes, which read
+        // DEVENV_ROOT during nix evaluation (impossible in pure mode, and devenv
+        // can't auto-detect the project root from a git worktree path).
         if cwd.join("flake.nix").exists() {
             info!("Wrapping agent command in nix develop shell");
             let escaped = full_command.replace('\'', "'\\''");
-            format!("nix develop -c sh -c '{}'", escaped)
+            let cwd_str = shell_escape::escape(cwd.display().to_string().into());
+            format!(
+                "DEVENV_ROOT={} nix develop --impure -c sh -c '{}'",
+                cwd_str, escaped
+            )
         } else {
             full_command
         }

--- a/rust/exomonad-core/src/services/agent_control/internal.rs
+++ b/rust/exomonad-core/src/services/agent_control/internal.rs
@@ -331,6 +331,7 @@ impl<
     /// with arbitrary prompt content (apostrophes, backticks, $(), etc.).
     pub(crate) fn build_agent_command(
         agent_type: AgentType,
+        cmd: &str,
         prompt_file: Option<&Path>,
         fork_session_id: Option<&str>,
         env_vars: &HashMap<String, String>,
@@ -338,7 +339,6 @@ impl<
         claude_flags: Option<&ClaudeSpawnFlags>,
         yolo: bool,
     ) -> String {
-        let cmd = agent_type.command();
 
         // Build permission flags for Claude agents
         let perms_flags = match agent_type {
@@ -466,6 +466,7 @@ impl<
 
         let full_command = Self::build_agent_command(
             agent_type,
+            self.command_for(agent_type),
             prompt_file.as_deref(),
             fork_session_id,
             &env_vars,
@@ -569,6 +570,7 @@ impl<
 
         let full_command = Self::build_agent_command(
             agent_type,
+            self.command_for(agent_type),
             prompt_file.as_deref(),
             None,
             &env_vars,

--- a/rust/exomonad-core/src/services/agent_control/mod.rs
+++ b/rust/exomonad-core/src/services/agent_control/mod.rs
@@ -537,6 +537,10 @@ pub struct AgentControlService<C> {
     pub(crate) wasm_name: String,
     /// Pre-serialized extra MCP servers to include in spawned agent configs.
     pub(crate) extra_mcp_servers: HashMap<String, serde_json::Value>,
+    /// Override for the Claude binary (default: "claude"). May include args.
+    pub(crate) claude_command: Option<String>,
+    /// Override for the Gemini binary (default: "gemini"). May include args.
+    pub(crate) gemini_command: Option<String>,
 }
 
 impl<
@@ -561,6 +565,8 @@ impl<
             yolo: false,
             wasm_name: "devswarm".to_string(),
             extra_mcp_servers: HashMap::new(),
+            claude_command: None,
+            gemini_command: None,
         }
     }
 
@@ -598,6 +604,33 @@ impl<
     pub fn with_extra_mcp_servers(mut self, servers: HashMap<String, serde_json::Value>) -> Self {
         self.extra_mcp_servers = servers;
         self
+    }
+
+    /// Override the binary used when spawning Claude agents.
+    pub fn with_claude_command(mut self, cmd: Option<String>) -> Self {
+        self.claude_command = cmd;
+        self
+    }
+
+    /// Override the binary used when spawning Gemini agents.
+    pub fn with_gemini_command(mut self, cmd: Option<String>) -> Self {
+        self.gemini_command = cmd;
+        self
+    }
+
+    /// Resolve the binary command for a given agent type, applying overrides.
+    pub(crate) fn command_for(&self, agent_type: AgentType) -> &str {
+        match agent_type {
+            AgentType::Claude => self
+                .claude_command
+                .as_deref()
+                .unwrap_or_else(|| agent_type.command()),
+            AgentType::Gemini => self
+                .gemini_command
+                .as_deref()
+                .unwrap_or_else(|| agent_type.command()),
+            _ => agent_type.command(),
+        }
     }
 
     /// Project root directory (from capability context).

--- a/rust/exomonad-core/src/services/agent_control/spawn.rs
+++ b/rust/exomonad-core/src/services/agent_control/spawn.rs
@@ -332,19 +332,34 @@ impl<
                     .await?;
             rollback.set_prompt_file(prompt_path.clone());
 
-            let window_id = self
-                .new_tmux_window(
-                    &display_name,
-                    &worktree_path,
-                    options.agent_type,
-                    Some(prompt_path),
-                    env_vars,
-                )
-                .await?;
-            rollback.set_window(window_id.clone());
-
-            // Store window_id for message delivery and cleanup
-            let routing = RoutingInfo::window(window_id);
+            // Gemini agents get panes, Claude agents get windows
+            let routing = if options.agent_type == AgentType::Gemini {
+                let pane_id = self
+                    .new_tmux_pane(
+                        &display_name,
+                        &worktree_path,
+                        options.agent_type,
+                        Some(prompt_path),
+                        env_vars,
+                        None, // parent_window_name: None = use first window in session
+                        None, // claude_flags: not used for Gemini
+                    )
+                    .await?;
+                rollback.set_pane(pane_id.clone());
+                RoutingInfo::pane(pane_id, &display_name)
+            } else {
+                let window_id = self
+                    .new_tmux_window(
+                        &display_name,
+                        &worktree_path,
+                        options.agent_type,
+                        Some(prompt_path),
+                        env_vars,
+                    )
+                    .await?;
+                rollback.set_window(window_id.clone());
+                RoutingInfo::window(window_id)
+            };
             let effective_birth = self.effective_birth_branch(Some(caller_bb));
             let child_birth = effective_birth.child(agent_name.as_str());
             let identity_record = AgentIdentityRecord {
@@ -937,20 +952,35 @@ impl<
             let prompt_path = Self::write_prompt_file(self.project_dir(), agent_name.as_str(), &task).await?;
             rollback.set_prompt_file(prompt_path.clone());
 
-            // Open tmux window (not pane)
+            // Gemini agents get panes, Claude agents get windows
             // Task already includes leaf completion protocol — rendered by Haskell Prompt builder.
-            let window_id = self.new_tmux_window(
-                &display_name,
-                &worktree_path,
-                agent_type,
-                Some(prompt_path),
-                env_vars,
-            )
-            .await?;
-            rollback.set_window(window_id.clone());
-
-            // Store window_id for message delivery and cleanup
-            let routing = RoutingInfo::window(window_id);
+            let routing = if agent_type == AgentType::Gemini {
+                let pane_id = self
+                    .new_tmux_pane(
+                        &display_name,
+                        &worktree_path,
+                        agent_type,
+                        Some(prompt_path),
+                        env_vars,
+                        None, // parent_window_name: None = use first window in session
+                        None, // claude_flags: not used for Gemini
+                    )
+                    .await?;
+                rollback.set_pane(pane_id.clone());
+                RoutingInfo::pane(pane_id, &display_name)
+            } else {
+                let window_id = self
+                    .new_tmux_window(
+                        &display_name,
+                        &worktree_path,
+                        agent_type,
+                        Some(prompt_path),
+                        env_vars,
+                    )
+                    .await?;
+                rollback.set_window(window_id.clone());
+                RoutingInfo::window(window_id)
+            };
             let identity_record = AgentIdentityRecord {
                 agent_name: agent_name.clone(),
                 slug: Slug::from(identity.slug()),

--- a/rust/exomonad/src/config.rs
+++ b/rust/exomonad/src/config.rs
@@ -109,6 +109,14 @@ pub struct RawConfig {
 
     /// GitHub poller interval in seconds (default: 60).
     pub poll_interval: Option<u64>,
+
+    /// Override the binary used when spawning Claude agents (default: "claude").
+    /// May include args (e.g., "claude --model opus").
+    pub claude_command: Option<String>,
+
+    /// Override the binary used when spawning Gemini agents (default: "gemini").
+    /// May include args (e.g., "gemini --model gemini-2.0-flash").
+    pub gemini_command: Option<String>,
 }
 
 /// Final resolved configuration.
@@ -148,6 +156,12 @@ pub struct Config {
 
     /// GitHub poller interval in seconds (default: 60).
     pub poll_interval: Option<u64>,
+
+    /// Override the binary used when spawning Claude agents (default: "claude").
+    pub claude_command: Option<String>,
+
+    /// Override the binary used when spawning Gemini agents (default: "gemini").
+    pub gemini_command: Option<String>,
 }
 
 impl Config {
@@ -282,6 +296,10 @@ impl Config {
         // Resolve poll_interval: local > global
         let poll_interval = local_raw.poll_interval.or(global_raw.poll_interval);
 
+        // Resolve claude_command / gemini_command: local > global
+        let claude_command = local_raw.claude_command.or(global_raw.claude_command);
+        let gemini_command = local_raw.gemini_command.or(global_raw.gemini_command);
+
         Ok(Self {
             project_dir,
             role,
@@ -300,6 +318,8 @@ impl Config {
             otlp_endpoint,
             model,
             poll_interval,
+            claude_command,
+            gemini_command,
         })
     }
 
@@ -335,6 +355,8 @@ impl Default for Config {
             otlp_endpoint: None,
             model: None,
             poll_interval: None,
+            claude_command: None,
+            gemini_command: None,
         }
     }
 }

--- a/rust/exomonad/src/serve.rs
+++ b/rust/exomonad/src/serve.rs
@@ -997,6 +997,8 @@ Run `exomonad recompile` first to build it.",
         agent_control.with_birth_branch(resolve_agent_birth_branch(&worktree_base, "root").await?);
     agent_control = agent_control.with_tmux_session(config.tmux_session.clone());
     agent_control = agent_control.with_yolo(config.yolo);
+    agent_control = agent_control.with_claude_command(config.claude_command.clone());
+    agent_control = agent_control.with_gemini_command(config.gemini_command.clone());
     agent_control = agent_control
         .with_extra_mcp_servers(serialize_extra_mcp_servers(&config.extra_mcp_servers));
     let event_session_id = uuid::Uuid::new_v4().to_string();


### PR DESCRIPTION
## Summary
- Branch names containing `/` (e.g. `hcentner/sanitize-branch`) cause KV store key validation errors because the key `phase-tl--hcentner/sanitize-branch` contains invalid characters
- `sanitizeBranch` now uses an allowlist (`[a-zA-Z0-9_-]`) instead of replacing only `.`, so any git-legal-but-KV-illegal character (including `/`, `@`, `+`) is replaced with `-`

## Test plan
- [x] `just wasm-all` compiles cleanly
- [ ] Branch names with `/` no longer cause `Invalid input` errors from the KV handler
- [ ] Existing dot-separated branch names (e.g. `main.feature-a`) still produce valid keys