### PR TITLE
feat(teams): persist birth-branch aliases to config.json

### DIFF
--- a/rust/claude-teams-bridge/src/config.rs
+++ b/rust/claude-teams-bridge/src/config.rs
@@ -29,6 +29,8 @@ pub struct TeamMember {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     pub backend_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub aliases: Vec<String>,
 }
 
 /// Read team config from `~/.claude/teams/{team}/config.json`.
@@ -80,6 +82,7 @@ mod tests {
                 joined_at: 1700000001,
                 cwd: "/tmp".into(),
                 backend_type: None,
+                aliases: Vec::new(),
             }],
         }
     }

--- a/rust/claude-teams-bridge/src/registry.rs
+++ b/rust/claude-teams-bridge/src/registry.rs
@@ -52,8 +52,8 @@ impl TeamRegistry {
         );
         let mut map = self.inner.lock().await;
         let previous = map.insert(key.to_string(), info);
-        let old_team_name = previous
-            .and_then(|prev| (prev.team_name != team_name).then_some(prev.team_name));
+        let old_team_name =
+            previous.and_then(|prev| (prev.team_name != team_name).then_some(prev.team_name));
         drop(map);
 
         // Best-effort sync to disk for backward-compatible API
@@ -73,8 +73,8 @@ impl TeamRegistry {
         let team_name = info.team_name.clone();
         let mut map = self.inner.lock().await;
         let previous = map.insert(key.to_string(), info);
-        let old_team_name = previous
-            .and_then(|prev| (prev.team_name != team_name).then_some(prev.team_name));
+        let old_team_name =
+            previous.and_then(|prev| (prev.team_name != team_name).then_some(prev.team_name));
         drop(map);
 
         self.persist_config(&team_name).await?;
@@ -179,7 +179,10 @@ impl TeamRegistry {
     /// to skip the in-memory check.
     pub fn resolve_from_config(team_name: &str, recipient: &str) -> Option<TeamInfo> {
         let config = crate::config::read_team_config(team_name).ok()?;
-        let member = config.members.iter().find(|m| m.name == recipient)?;
+        let member = config
+            .members
+            .iter()
+            .find(|m| m.name == recipient || m.aliases.iter().any(|a| a == recipient))?;
         debug!(
             team = %team_name,
             recipient = %recipient,
@@ -266,19 +269,24 @@ impl TeamRegistry {
             .collect();
 
         // 2. Add/update in-memory members (deduplicated by inbox_name)
-        let mut unique_in_memory = HashMap::new();
+        let mut grouped_in_memory: HashMap<String, Vec<String>> = HashMap::new();
         for (key, info) in in_memory {
-            // Prefer the key that matches the inbox_name if available (usually the agent name)
-            if !unique_in_memory.contains_key(&info.inbox_name) || key == info.inbox_name {
-                unique_in_memory.insert(info.inbox_name.clone(), key);
-            }
+            grouped_in_memory
+                .entry(info.inbox_name.clone())
+                .or_default()
+                .push(key);
         }
 
-        for (inbox_name, key) in unique_in_memory {
+        for (inbox_name, mut keys) in grouped_in_memory {
+            // Pick primary key: prefers key matching inbox_name
+            let primary_idx = keys.iter().position(|k| k == &inbox_name).unwrap_or(0);
+            let primary_key = keys.remove(primary_idx);
+            let aliases = keys; // remaining keys are aliases
+
             let existing = new_members.iter().find(|m| m.name == inbox_name);
             if existing.is_none() {
                 new_members.push(crate::config::TeamMember {
-                    agent_id: key,
+                    agent_id: primary_key,
                     name: inbox_name,
                     agent_type: "exomonad-agent".into(),
                     model: "gemini".into(),
@@ -288,6 +296,7 @@ impl TeamRegistry {
                         .to_string_lossy()
                         .to_string(),
                     backend_type: Some("exomonad".into()),
+                    aliases,
                 });
             }
         }
@@ -470,6 +479,7 @@ mod tests {
                     joined_at: 0,
                     cwd: "/tmp".into(),
                     backend_type: None,
+                    aliases: Vec::new(),
                 },
                 crate::config::TeamMember {
                     agent_id: "uuid-worker".into(),
@@ -479,6 +489,7 @@ mod tests {
                     joined_at: 0,
                     cwd: "/tmp".into(),
                     backend_type: None,
+                    aliases: Vec::new(),
                 },
             ],
         };
@@ -576,6 +587,7 @@ mod tests {
                 joined_at: 0,
                 cwd: "/tmp".into(),
                 backend_type: None,
+                aliases: Vec::new(),
             }],
         };
         crate::config::write_team_config(team_name, &config).unwrap();
@@ -614,6 +626,7 @@ mod tests {
                     joined_at: 0,
                     cwd: cwd.into(),
                     backend_type: None,
+                    aliases: Vec::new(),
                 }],
             };
             crate::config::write_team_config(team, &config).unwrap();

--- a/rust/claude-teams-bridge/tests/integration.rs
+++ b/rust/claude-teams-bridge/tests/integration.rs
@@ -76,6 +76,7 @@ fn config_json_matches_cc_format() {
             joined_at: 1711022401,
             cwd: "/tmp".into(),
             backend_type: None,
+            aliases: Vec::new(),
         }],
     };
 
@@ -312,6 +313,7 @@ async fn resolve_tier2_e2e_inbox_delivery() {
                 joined_at: 1711022401,
                 cwd: "/tmp/exo".into(),
                 backend_type: None,
+                aliases: Vec::new(),
             },
             TeamMember {
                 agent_id: "cc-supervisor-uuid".into(),
@@ -321,6 +323,7 @@ async fn resolve_tier2_e2e_inbox_delivery() {
                 joined_at: 1711022402,
                 cwd: "/tmp/cc".into(),
                 backend_type: None,
+                aliases: Vec::new(),
             },
         ],
     };
@@ -552,6 +555,7 @@ async fn lead_deregistered_still_resolves_via_config() {
                 joined_at: 1711022400,
                 cwd: "/tmp".into(),
                 backend_type: None,
+                aliases: Vec::new(),
             },
             TeamMember {
                 agent_id: "w1-uuid".into(),
@@ -561,6 +565,7 @@ async fn lead_deregistered_still_resolves_via_config() {
                 joined_at: 1711022401,
                 cwd: "/tmp".into(),
                 backend_type: None,
+                aliases: Vec::new(),
             },
             TeamMember {
                 agent_id: "w2-uuid".into(),
@@ -570,6 +575,7 @@ async fn lead_deregistered_still_resolves_via_config() {
                 joined_at: 1711022402,
                 cwd: "/tmp".into(),
                 backend_type: None,
+                aliases: Vec::new(),
             },
         ],
     };
@@ -627,6 +633,7 @@ async fn lead_replaced_config_authoritative() {
                 joined_at: 1711022400,
                 cwd: "/tmp".into(),
                 backend_type: None,
+                aliases: Vec::new(),
             },
             TeamMember {
                 agent_id: "uuid-new-lead".into(),
@@ -636,6 +643,7 @@ async fn lead_replaced_config_authoritative() {
                 joined_at: 1711022401,
                 cwd: "/tmp".into(),
                 backend_type: None,
+                aliases: Vec::new(),
             },
         ],
     };
@@ -706,6 +714,7 @@ async fn cross_team_name_collision() {
             joined_at: 1711022401,
             cwd: "/tmp".into(),
             backend_type: None,
+            aliases: Vec::new(),
         }],
     };
 
@@ -770,6 +779,7 @@ async fn orphaned_agent_returns_none() {
             joined_at: 1711022401,
             cwd: "/tmp".into(),
             backend_type: None,
+            aliases: Vec::new(),
         }],
     };
 
@@ -816,6 +826,7 @@ async fn resolve_lead_name_match_fallback() {
                 joined_at: 1711022400,
                 cwd: "/tmp".into(),
                 backend_type: None,
+                aliases: Vec::new(),
             },
             TeamMember {
                 agent_id: "uuid-worker".into(),
@@ -825,6 +836,7 @@ async fn resolve_lead_name_match_fallback() {
                 joined_at: 1711022401,
                 cwd: "/tmp".into(),
                 backend_type: None,
+                aliases: Vec::new(),
             },
         ],
     };
@@ -851,6 +863,7 @@ async fn resolve_lead_name_match_fallback() {
             joined_at: 1711022401,
             cwd: "/tmp".into(),
             backend_type: None,
+            aliases: Vec::new(),
         }],
     };
 
@@ -896,6 +909,7 @@ async fn inbox_survives_config_restructuring() {
             joined_at: 1711022401,
             cwd: "/tmp".into(),
             backend_type: None,
+            aliases: Vec::new(),
         }],
     };
     write_team_config(team, &config_v1).unwrap();
@@ -926,6 +940,7 @@ async fn inbox_survives_config_restructuring() {
             joined_at: 1711022401,
             cwd: "/tmp".into(),
             backend_type: None,
+            aliases: Vec::new(),
         }],
     };
     write_team_config(team, &config_v2).unwrap();
@@ -1008,6 +1023,7 @@ async fn supervisor_to_lead_routing_chain() {
                 joined_at: 1711022400,
                 cwd: "/tmp".into(),
                 backend_type: None,
+                aliases: Vec::new(),
             },
             TeamMember {
                 agent_id: "child-uuid".into(),
@@ -1017,6 +1033,7 @@ async fn supervisor_to_lead_routing_chain() {
                 joined_at: 1711022401,
                 cwd: "/tmp".into(),
                 backend_type: None,
+                aliases: Vec::new(),
             },
         ],
     };
@@ -1363,6 +1380,7 @@ async fn test_register_syncs_to_disk() {
             joined_at: 1711022400,
             cwd: "/tmp".into(),
             backend_type: None,
+            aliases: Vec::new(),
         }],
     };
     write_team_config(team, &config).unwrap();
@@ -1414,6 +1432,7 @@ async fn test_remove_member_persists_to_disk() {
             joined_at: 0,
             cwd: "/tmp".into(),
             backend_type: None,
+            aliases: Vec::new(),
         }],
     };
     write_team_config(team, &config).unwrap();
@@ -1467,7 +1486,8 @@ async fn test_cc_native_members_preserved() {
                 model: "opus".into(),
                 joined_at: 0,
                 cwd: "/tmp".into(),
-                backend_type: None, // CC-native
+                backend_type: None,
+                aliases: Vec::new(), // CC-native
             },
             TeamMember {
                 agent_id: "native-1".into(),
@@ -1476,7 +1496,8 @@ async fn test_cc_native_members_preserved() {
                 model: "opus".into(),
                 joined_at: 0,
                 cwd: "/tmp".into(),
-                backend_type: None, // CC-native
+                backend_type: None,
+                aliases: Vec::new(), // CC-native
             },
         ],
     };
@@ -1524,6 +1545,7 @@ async fn test_register_member_moves_between_teams() {
                 joined_at: 0,
                 cwd: "/tmp".into(),
                 backend_type: None,
+                aliases: Vec::new(),
             }],
         };
         write_team_config(team, &config).unwrap();
@@ -1573,4 +1595,109 @@ async fn test_register_member_moves_between_teams() {
         .members
         .iter()
         .any(|m| m.name == "agent-x"));
+}
+
+#[tokio::test]
+#[serial]
+async fn test_alias_persistence_across_restart() {
+    let tmp = tempdir().unwrap();
+    let _home = ScopedHome::new(tmp.path());
+
+    let team = "alias-persist-team";
+    let config = TeamConfig {
+        name: team.into(),
+        description: "test".into(),
+        created_at: 0,
+        lead_agent_id: "lead".into(),
+        lead_session_id: "session".into(),
+        members: vec![TeamMember {
+            agent_id: "lead".into(),
+            name: "lead".into(),
+            agent_type: "claude".into(),
+            model: "opus".into(),
+            joined_at: 0,
+            cwd: "/tmp".into(),
+            backend_type: None,
+            aliases: Vec::new(),
+        }],
+    };
+    write_team_config(team, &config).unwrap();
+
+    let registry = TeamRegistry::new();
+    let info = TeamInfo {
+        team_name: team.into(),
+        inbox_name: "agent-1".into(),
+    };
+
+    // Register under 3 keys
+    registry.register("agent-1", info.clone()).await;
+    registry.register("birth-branch-x", info.clone()).await;
+    registry.register("agent-1-slug", info.clone()).await;
+
+    // Verify disk content
+    let disk_config = read_team_config(team).unwrap();
+    let member = disk_config
+        .members
+        .iter()
+        .find(|m| m.name == "agent-1")
+        .unwrap();
+    assert_eq!(member.name, "agent-1");
+    assert!(member.aliases.contains(&"birth-branch-x".to_string()));
+    assert!(member.aliases.contains(&"agent-1-slug".to_string()));
+    assert_eq!(member.aliases.len(), 2);
+
+    // Simulate restart by using a fresh registry but same disk
+    let registry2 = TeamRegistry::new();
+
+    // Resolve by all 3 keys (Tier 2 should kick in for all)
+    let res1 = registry2.resolve("agent-1", Some(team)).await.unwrap();
+    let res2 = registry2
+        .resolve("birth-branch-x", Some(team))
+        .await
+        .unwrap();
+    let res3 = registry2.resolve("agent-1-slug", Some(team)).await.unwrap();
+
+    assert_eq!(res1.inbox_name, "agent-1");
+    assert_eq!(res2.inbox_name, "agent-1");
+    assert_eq!(res3.inbox_name, "agent-1");
+}
+
+#[tokio::test]
+#[serial]
+async fn test_config_json_written_by_claude_code_still_parses() {
+    let tmp = tempdir().unwrap();
+    let _home = ScopedHome::new(tmp.path());
+
+    let team = "old-config-team";
+    // Raw JSON without "aliases" field
+    let raw_json = r#"{
+  "name": "old-config-team",
+  "description": "test",
+  "createdAt": 0,
+  "leadAgentId": "lead",
+  "leadSessionId": "session",
+  "members": [
+    {
+      "agentId": "lead",
+      "name": "lead",
+      "agentType": "claude",
+      "model": "opus",
+      "joinedAt": 0,
+      "cwd": "/tmp"
+    }
+  ]
+}"#;
+
+    let config_dir = tmp.path().join(".claude").join("teams").join(team);
+    fs::create_dir_all(&config_dir).unwrap();
+    fs::write(config_dir.join("config.json"), raw_json).unwrap();
+
+    // Should parse without error
+    let config = read_team_config(team).unwrap();
+    assert_eq!(config.members[0].name, "lead");
+    assert!(config.members[0].aliases.is_empty());
+
+    // resolve_from_config should work
+    let res = TeamRegistry::resolve_from_config(team, "lead").unwrap();
+    assert_eq!(res.inbox_name, "lead");
 }


### PR DESCRIPTION
Fix TeamRegistry so birth-branch aliases persist to disk, not just primary agent names.
Currently, `persist_config` dedups by `inbox_name`, causing additional keys (agent_name, birth_branch, slug) to be dropped during serialization to `config.json`. After server restart, `notify_parent` lookups by birth-branch miss TeamRegistry because they are not in the primary `name` field of `config.json`.

Changes:
- Added `aliases: Vec<String>` field to `TeamMember` in `config.json` (camelCase `aliases` on disk).
- Updated `TeamMember` struct with `#[serde(default, skip_serializing_if = "Vec::is_empty")]` for backward compatibility.
- Updated `persist_config` in `registry.rs` to group all in-memory keys for an agent and save non-primary keys into the `aliases` list.
- Updated `resolve_from_config` to also check the `aliases` field when resolving a member.
- Updated all manual `TeamMember` initializers to include the new field.
- Added integration tests to verify alias persistence across "restarts" and backward compatibility with old `config.json` files.

Closes #850 (continuation)
