### PR TITLE
fix(teams+tmux): model drift, dotted window names, design doc

### DIFF
--- a/docs/decisions/sub-tl-team-membership.md
+++ b/docs/decisions/sub-tl-team-membership.md
@@ -1,0 +1,113 @@
+# Sub-TL Team Membership
+
+**Status:** Proposed
+
+## Question
+
+When a TL calls `fork_wave` to spawn a Claude sub-TL, should the sub-TL:
+
+- **(A) Create its own team** via `TeamCreate` (the current SessionStart hook nudges it to)
+- **(B) Join the parent's team directly** — zero `TeamCreate`, zero team-per-subtree
+- **(C) Own a subtree team** nested under the parent (distinct team, per-subtree task isolation)
+
+## Context
+
+The SessionStart hook currently prompts every spawned Claude agent with
+"Create a team using TeamCreate before proceeding." This produced every
+sub-TL creating its own team (e.g. `fixup-wave`, `messaging-tl`,
+`cleanup-tl`, etc.) — one team per subtree.
+
+In parallel, `AgentHandler::propagate_team_to_child` registers the sub-TL
+in the **parent's** `TeamRegistry` under the child's identity keys, so
+that when the sub-TL spawns workers/leaves, `register_synthetic_member`
+writes them into the parent's `~/.claude/teams/{parent-team}/config.json`.
+
+Net effect today: **two sources of truth**. The sub-TL owns a team
+(from TeamCreate) AND is simultaneously a member of the parent's team
+(from propagation). Messages sent to the sub-TL land in whichever lookup
+wins — which is why the sub-TL-inbox bug (#864) required a targeted fix.
+
+## Recommendation: Option B (flat team per tree)
+
+One team per top-level root. All sub-TLs, leaves, and workers are
+synthetic members of that single team. Sub-TLs do not call `TeamCreate`.
+
+### Rationale
+
+**The hylomorphic model is about context isolation, not team isolation.**
+Each sub-TL has its own worktree, own context window, own branch — the
+tree structure. The team is just a **messaging namespace**, and a flat
+namespace per-tree is the simplest thing that works.
+
+**Parent's team already works for everyone in the subtree.**
+`propagate_team_to_child` registers the sub-TL in the parent's team;
+`register_synthetic_member` writes grandchildren there too. Task lists
+are shared. Names are unique via the `{slug}-{type}` convention. No
+nesting needed.
+
+**Two sources of truth is a bug farm.** When a sub-TL creates its own
+team AND is registered in parent's team, any messaging code that
+resolves by name might hit either registry and get a different answer.
+#864 was one such bug; the `model: "gemini"` hardcode was another.
+Collapsing to one source eliminates a class of drift bugs.
+
+**The TeamCreate prompt is a footgun.** If a sub-TL forgets (or the
+hook fails to fire), the tree still partly works — propagation saves
+it — but messaging is subtly wrong. Silent partial failure is the worst
+kind.
+
+### Tradeoffs
+
+- **Task list crowding at depth.** A 3-deep tree with 3-branch fanout has
+  ~13 agents, all sharing one task list. Mitigation: structured task
+  naming + ownership filtering in `task_list`. This is already
+  conventional — the alternative is 13 separate task lists scattered
+  across teams, which is worse for surface-level visibility.
+
+- **Cross-subtree noise.** Gemini in subtree A sees tasks for subtree B.
+  Mostly harmless: agents filter by `owner`. If it becomes painful,
+  add team-scoped task views without changing team topology.
+
+### Implementation
+
+1. **Remove the SessionStart `additionalContext` nudge** that tells
+   Claude sub-TLs to call `TeamCreate`. Root still creates the team
+   (via the initial `exomonad init` session).
+
+2. **Make `propagate_team_to_child` the only source of truth.** Already
+   wired — no change required. After removing the TeamCreate nudge,
+   sub-TLs simply *are* members of the parent's team via propagation.
+
+3. **Document the convention in `rust/CLAUDE.md`:** "One team per
+   root TL. Sub-TLs and leaves are synthetic members. Agents are
+   named uniquely via `{slug}-{type}`."
+
+4. **Followup — extend `TeamInfo`** to carry `agent_type`/`model`, so
+   the reconcile-add-missing-member path in `claude-teams-bridge/
+   src/registry.rs:284` stops hardcoding "gemini". Orthogonal to this
+   decision but removes the last source of model drift.
+
+## Why not Option C (subtree teams)
+
+On paper, per-subtree task isolation is appealing. In practice:
+
+- CC's Teams SendMessage/inbox targeting is per-team. Cross-team messaging
+  requires resolver code that knows about the hierarchy — more drift risk.
+- The delivery pipeline already resolves through one `TeamRegistry`. Adding
+  a tree of teams means either each agent needs to know about multiple
+  teams (complex) or delivery does N lookups (slow).
+- The problem Option C solves (task crowding) is better solved at the
+  *query* layer (filter by owner/parent) than at the *storage* layer
+  (split into N teams).
+
+Option C is the "correct" model if you squint at the hylomorphism, but
+the practical cost of threading multi-team awareness through every
+delivery path is not worth the task-list cleanliness.
+
+## Why not the current hybrid
+
+Every sub-TL owning its own team AND being registered in parent's team
+is the worst of both worlds: doubled storage, ambiguous resolution,
+no isolation benefit (tasks still end up shared via propagation into
+parent's team anyway). The current behavior exists because both
+mechanisms grew independently — not because anyone chose it.

--- a/rust/exomonad-core/src/handlers/CLAUDE.md
+++ b/rust/exomonad-core/src/handlers/CLAUDE.md
@@ -175,7 +175,7 @@ The delivery verifier (background task that polls `is_message_read` for 30s) ski
 
 ### Session-Qualified Targets
 
-`TmuxIpc::inject_input` session-qualifies all targets (`{session}:{target}`) to ensure `paste-buffer` and `send-keys` resolve to the same pane deterministically. Without qualification, tmux resolves display-name targets against the "most recently used" session, which is nondeterministic for subprocess calls.
+`TmuxIpc::inject_input` qualifies targets with the session name (`{session}:{target}`) to ensure deterministic resolution. Stable global identifiers starting with `@` (window ID) or `%` (pane ID) are used as-is, as prefixing with a session name is invalid for panes and redundant for windows. Targets already containing a `:` are also used as-is.
 
 ### Injection Locking
 

--- a/rust/exomonad-core/src/handlers/agent.rs
+++ b/rust/exomonad-core/src/handlers/agent.rs
@@ -94,10 +94,16 @@ impl<
     /// Resolves the team from TeamRegistry (same pattern as `register_child_supervisor`)
     /// so the child is registered in the user-created team (e.g., "gh-issues"), not
     /// a hardcoded "exo-{branch}" team that CC doesn't recognize.
+    ///
+    /// `agent_type` populates the `model` field honestly (claude/gemini/shoal/process)
+    /// so CC's routing doesn't treat every synthetic member as "gemini". `kind` is
+    /// the semantic role label written to `agentType` (e.g. "claude-subtree",
+    /// "gemini-leaf", "gemini-worker", "gemini-acp").
     async fn register_synthetic_member(
         &self,
         member_name: &AgentName,
-        agent_type: &str,
+        agent_type: crate::services::agent_control::AgentType,
+        kind: &str,
         ctx: &crate::effects::EffectContext,
     ) {
         let team_reg = self.ctx.team_registry();
@@ -117,6 +123,7 @@ impl<
             &team_name,
             member_name,
             agent_type,
+            kind,
         ) {
             warn!(
                 member = %member_name,
@@ -416,8 +423,13 @@ impl<
             crate::services::agent_control::slugify(&req.name),
             crate::services::agent_control::AgentType::Gemini,
         );
-        self.register_synthetic_member(&identity.internal_name(), "gemini-worker", ctx)
-            .await;
+        self.register_synthetic_member(
+            &identity.internal_name(),
+            crate::services::agent_control::AgentType::Gemini,
+            "gemini-worker",
+            ctx,
+        )
+        .await;
         self.register_child_supervisor(&req.name, ctx).await;
 
         Ok(SpawnWorkerResponse {
@@ -512,8 +524,13 @@ impl<
             crate::services::agent_control::slugify(&req.branch_name),
             crate::services::agent_control::AgentType::Claude,
         );
-        self.register_synthetic_member(&child_identity.internal_name(), "claude-subtree", ctx)
-            .await;
+        self.register_synthetic_member(
+            &child_identity.internal_name(),
+            crate::services::agent_control::AgentType::Claude,
+            "claude-subtree",
+            ctx,
+        )
+        .await;
 
         // Propagate parent's team to sub-TL's identity keys so the sub-TL can
         // register its own workers as synthetic members when it spawns them
@@ -572,8 +589,13 @@ impl<
             crate::services::agent_control::slugify(&req.branch_name),
             crate::services::agent_control::AgentType::Gemini,
         );
-        self.register_synthetic_member(&leaf_identity.internal_name(), "gemini-leaf", ctx)
-            .await;
+        self.register_synthetic_member(
+            &leaf_identity.internal_name(),
+            crate::services::agent_control::AgentType::Gemini,
+            "gemini-leaf",
+            ctx,
+        )
+        .await;
         self.register_child_supervisor(&req.branch_name, ctx).await;
 
         Ok(SpawnLeafSubtreeResponse {
@@ -642,8 +664,13 @@ impl<
         registry.register(conn).await;
 
         // Register as synthetic team member (uses TL's actual team, not hardcoded exo-{branch})
-        self.register_synthetic_member(&agent_name, "gemini-acp", ctx)
-            .await;
+        self.register_synthetic_member(
+            &agent_name,
+            crate::services::agent_control::AgentType::Gemini,
+            "gemini-acp",
+            ctx,
+        )
+        .await;
 
         info!(agent = %agent_name, "ACP agent spawned and registered");
 

--- a/rust/exomonad-core/src/services/synthetic_members.rs
+++ b/rust/exomonad-core/src/services/synthetic_members.rs
@@ -1,4 +1,5 @@
 use crate::domain::{AgentName, TeamName};
+use crate::services::agent_control::AgentType;
 use anyhow::{Context, Result};
 use claude_teams_bridge::file_lock::{fsync_dir, FileLock};
 use serde_json::Value;
@@ -10,20 +11,33 @@ use tracing::{info, warn};
 /// Register a synthetic member in a Claude Teams config.json.
 ///
 /// Reads the existing config, appends to the members array, writes back atomically.
+///
+/// `agent_type` is the runtime type (Claude/Gemini/Shoal/Process) and populates
+/// the `model` field honestly — not hardcoded "gemini". `kind` is the semantic
+/// role label written to the `agentType` field (e.g. "claude-subtree",
+/// "gemini-leaf", "gemini-worker", "gemini-acp").
 pub fn register_synthetic_member(
     team_name: &TeamName,
     member_name: &AgentName,
-    agent_type: &str,
+    agent_type: AgentType,
+    kind: &str,
 ) -> Result<()> {
     let config_path = team_config_path(team_name)?;
-    register_synthetic_member_at_path(&config_path, team_name, member_name.as_str(), agent_type)
+    register_synthetic_member_at_path(
+        &config_path,
+        team_name,
+        member_name.as_str(),
+        agent_type,
+        kind,
+    )
 }
 
 fn register_synthetic_member_at_path(
     config_path: &PathBuf,
     team_name: &TeamName,
     member_name: &str,
-    agent_type: &str,
+    agent_type: AgentType,
+    kind: &str,
 ) -> Result<()> {
     // Read existing config
     let _lock = FileLock::acquire(config_path, Duration::from_secs(30)).with_context(|| {
@@ -57,8 +71,8 @@ fn register_synthetic_member_at_path(
     let entry = serde_json::json!({
         "agentId": agent_id,
         "name": member_name,
-        "agentType": agent_type,
-        "model": "gemini",
+        "agentType": kind,
+        "model": agent_type.suffix(),
         "color": "green",
         "planModeRequired": false,
         "joinedAt": now,
@@ -239,16 +253,34 @@ mod tests {
         fs::write(&config_path, serde_json::to_string_pretty(&initial_config)?)?;
 
         // Register new member
-        register_synthetic_member_at_path(&config_path, &team_name, "gemini-1", "gemini-worker")?;
+        register_synthetic_member_at_path(
+            &config_path,
+            &team_name,
+            "gemini-1",
+            AgentType::Gemini,
+            "gemini-worker",
+        )?;
 
         let content = fs::read_to_string(&config_path)?;
         let config: Value = serde_json::from_str(&content)?;
         let members = config["members"].as_array().unwrap();
         assert_eq!(members.len(), 2);
         assert!(members.iter().any(|m| m["name"] == "gemini-1"));
+        let new_entry = members
+            .iter()
+            .find(|m| m["name"] == "gemini-1")
+            .expect("gemini-1 entry present");
+        assert_eq!(new_entry["model"], "gemini");
+        assert_eq!(new_entry["agentType"], "gemini-worker");
 
         // Idempotent registration
-        register_synthetic_member_at_path(&config_path, &team_name, "gemini-1", "gemini-worker")?;
+        register_synthetic_member_at_path(
+            &config_path,
+            &team_name,
+            "gemini-1",
+            AgentType::Gemini,
+            "gemini-worker",
+        )?;
         let content = fs::read_to_string(&config_path)?;
         let config: Value = serde_json::from_str(&content)?;
         assert_eq!(config["members"].as_array().unwrap().len(), 2);
@@ -261,6 +293,35 @@ mod tests {
         assert_eq!(members.len(), 1);
         assert!(!members.iter().any(|m| m["name"] == "gemini-1"));
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_register_claude_subtree_writes_claude_model() -> Result<()> {
+        // Regression for the hardcoded `model: "gemini"` bug: every synthetic
+        // member was registered as "gemini" regardless of actual agent type.
+        // Sub-TLs are Claude but were misreported, risking wrong routing in CC.
+        let dir = tempdir()?;
+        let team_name = TeamName::from("test-team");
+        let config_path = dir.path().join("config.json");
+        fs::write(
+            &config_path,
+            serde_json::to_string_pretty(&serde_json::json!({"members": []}))?,
+        )?;
+
+        register_synthetic_member_at_path(
+            &config_path,
+            &team_name,
+            "sub-tl",
+            AgentType::Claude,
+            "claude-subtree",
+        )?;
+
+        let config: Value = serde_json::from_str(&fs::read_to_string(&config_path)?)?;
+        let entry = &config["members"].as_array().unwrap()[0];
+        assert_eq!(entry["model"], "claude");
+        assert_eq!(entry["agentType"], "claude-subtree");
+        assert_eq!(entry["backendType"], "exomonad");
         Ok(())
     }
 

--- a/rust/exomonad-core/src/services/tmux_ipc.rs
+++ b/rust/exomonad-core/src/services/tmux_ipc.rs
@@ -146,6 +146,44 @@ impl TmuxIpc {
         }
     }
 
+    /// Resolve a tmux target, converting display names with `.` to stable
+    /// `@window_id` identifiers.
+    ///
+    /// tmux parses target specifiers as `{session}:{window}.{pane}` — a `.`
+    /// in the display name is interpreted as the window/pane separator. A
+    /// window named `💎 main.foo-gemini` becomes window=`💎 main`, pane=
+    /// `foo-gemini` and tmux errors with "can't find window: 💎 main".
+    /// There is no escape syntax for `.`; only @-prefixed IDs are safe.
+    ///
+    /// Returns IDs (`@N`, `%N`, `$N`) and already-qualified targets (those
+    /// containing `:`) unchanged. For plain display names containing `.`,
+    /// queries `list-windows` and returns the matching `@window_id`. Display
+    /// names without `.` are returned unchanged — they resolve correctly
+    /// without lookup.
+    async fn resolve_target(&self, target: &str) -> Result<String> {
+        if target.starts_with('@')
+            || target.starts_with('%')
+            || target.starts_with('$')
+            || target.contains(':')
+        {
+            return Ok(target.to_string());
+        }
+        if !target.contains('.') {
+            return Ok(target.to_string());
+        }
+        let windows = self.list_windows().await?;
+        for w in &windows {
+            if w.window_name == target {
+                return Ok(w.window_id.as_str().to_string());
+            }
+        }
+        anyhow::bail!(
+            "tmux window not found by display name: '{}' (session: {})",
+            target,
+            self.session_name
+        )
+    }
+
     fn tmux_cmd(&self) -> Command {
         let mut cmd = Command::new("tmux");
         if let Some(socket) = &self.socket_name {
@@ -471,9 +509,11 @@ impl TmuxIpc {
     /// display-name targets against the "most recently used" session, which is
     /// nondeterministic for subprocess calls.
     pub async fn inject_input(&self, target: &str, text: &str) -> Result<()> {
-        // Session-qualify the target so paste-buffer and send-keys resolve
-        // to the same pane deterministically.
-        let qualified_target = self.qualify_target(target);
+        // Resolve display names containing `.` to stable @window_id first,
+        // since tmux parses `.` as window-pane separator in targets. Then
+        // qualify with session name for deterministic pane resolution.
+        let resolved = self.resolve_target(target).await?;
+        let qualified_target = self.qualify_target(&resolved);
 
         // Serialize injections to the same target to prevent interleaving.
         // Uses Weak refs so lock entries are reclaimed when not in use.
@@ -627,7 +667,8 @@ impl TmuxIpc {
     /// until a terminal event arrives. A +1/-1 column resize triggers SIGWINCH,
     /// which wakes the event loop to process buffered input.
     pub async fn wake_pane(&self, target: &str) -> Result<()> {
-        let qualified = self.qualify_target(target);
+        let resolved = self.resolve_target(target).await?;
+        let qualified = self.qualify_target(&resolved);
 
         // Read current window dimensions
         let output = self
@@ -1052,5 +1093,67 @@ mod tests {
         assert_eq!(ipc.qualify_target("Server"), "mysession:Server");
         assert_eq!(ipc.qualify_target("3"), "mysession:3");
         assert_eq!(ipc.qualify_target("."), "mysession:.");
+    }
+
+    #[tokio::test]
+    async fn test_resolve_target_passes_through_ids() {
+        let ipc = TmuxIpc::new("mysession");
+        assert_eq!(ipc.resolve_target("@42").await.unwrap(), "@42");
+        assert_eq!(ipc.resolve_target("%17").await.unwrap(), "%17");
+        assert_eq!(ipc.resolve_target("$1").await.unwrap(), "$1");
+        assert_eq!(
+            ipc.resolve_target("session:window").await.unwrap(),
+            "session:window"
+        );
+        // Names without '.' resolve correctly without lookup
+        assert_eq!(ipc.resolve_target("plain-name").await.unwrap(), "plain-name");
+    }
+
+    #[tokio::test]
+    async fn test_inject_input_resolves_dotted_window_name() {
+        // Regression: tmux parses `.` in target as window/pane separator, so
+        // a window named `💎 main.foo-bar-gemini` used to fail injection with
+        // "can't find window: 💎 main". The fix resolves display names with
+        // `.` to stable @window_id first.
+        if !IsolatedTmux::is_available().await {
+            return;
+        }
+        let isolated = IsolatedTmux::new().await.unwrap();
+        let dotted_name = "\u{1F48E} main.foo-bar-gemini";
+        let output = isolated
+            .ipc
+            .tmux_cmd()
+            .args([
+                "new-window",
+                "-t",
+                &isolated.session,
+                "-n",
+                dotted_name,
+                "-d",
+            ])
+            .output()
+            .await
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "new-window failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        isolated
+            .ipc
+            .inject_input(dotted_name, "hello")
+            .await
+            .expect("inject_input should succeed for dot-containing display name");
+    }
+
+    #[tokio::test]
+    async fn test_resolve_target_not_found_errors() {
+        if !IsolatedTmux::is_available().await {
+            return;
+        }
+        let isolated = IsolatedTmux::new().await.unwrap();
+        let result = isolated.ipc.resolve_target("💎 does.not.exist").await;
+        assert!(result.is_err());
     }
 }

--- a/rust/exomonad-core/src/services/tmux_ipc.rs
+++ b/rust/exomonad-core/src/services/tmux_ipc.rs
@@ -132,6 +132,20 @@ impl TmuxIpc {
         &self.session_name
     }
 
+    /// Qualify a tmux target (window or pane) with the session name if it is not
+    /// already qualified or a stable global identifier.
+    ///
+    /// Global IDs (@N, %N) and already-qualified targets (session:target)
+    /// should be used as-is. Prefixing global IDs with session names
+    /// is redundant for windows and invalid for panes.
+    fn qualify_target(&self, target: &str) -> String {
+        if target.starts_with('@') || target.starts_with('%') || target.contains(':') {
+            target.to_string()
+        } else {
+            format!("{}:{}", self.session_name, target)
+        }
+    }
+
     fn tmux_cmd(&self) -> Command {
         let mut cmd = Command::new("tmux");
         if let Some(socket) = &self.socket_name {
@@ -408,7 +422,7 @@ impl TmuxIpc {
         window_id: &WindowId,
         layout: crate::domain::TmuxLayout,
     ) -> Result<()> {
-        let qualified = format!("{}:{}", self.session_name, window_id.as_str());
+        let qualified = self.qualify_target(window_id.as_str());
         let layout_str = layout.as_str();
         let output = self
             .tmux_cmd()
@@ -459,7 +473,7 @@ impl TmuxIpc {
     pub async fn inject_input(&self, target: &str, text: &str) -> Result<()> {
         // Session-qualify the target so paste-buffer and send-keys resolve
         // to the same pane deterministically.
-        let qualified_target = format!("{}:{}", self.session_name, target);
+        let qualified_target = self.qualify_target(target);
 
         // Serialize injections to the same target to prevent interleaving.
         // Uses Weak refs so lock entries are reclaimed when not in use.
@@ -613,7 +627,7 @@ impl TmuxIpc {
     /// until a terminal event arrives. A +1/-1 column resize triggers SIGWINCH,
     /// which wakes the event loop to process buffered input.
     pub async fn wake_pane(&self, target: &str) -> Result<()> {
-        let qualified = format!("{}:{}", self.session_name, target);
+        let qualified = self.qualify_target(target);
 
         // Read current window dimensions
         let output = self
@@ -946,5 +960,58 @@ mod tests {
                 .await
                 .unwrap()
         );
+    }
+
+    #[tokio::test]
+    async fn test_inject_input_with_pane_id() {
+        if !IsolatedTmux::is_available().await {
+            return;
+        }
+        let isolated = IsolatedTmux::new().await.unwrap();
+        let windows = isolated.ipc.list_windows().await.unwrap();
+        let pane_id = windows[0].pane_id.clone();
+
+        // This should SUCCEED after fix.
+        // It currently fails because TmuxIpc::inject_input prefixes %N with session name,
+        // resulting in "test:%N" which tmux rejects.
+        isolated
+            .ipc
+            .inject_input(pane_id.as_str(), "test content")
+            .await
+            .expect("inject_input with pane ID should succeed");
+    }
+
+    #[tokio::test]
+    async fn test_inject_input_with_window_id() {
+        if !IsolatedTmux::is_available().await {
+            return;
+        }
+        let isolated = IsolatedTmux::new().await.unwrap();
+        let windows = isolated.ipc.list_windows().await.unwrap();
+        let window_id = windows[0].window_id.clone();
+
+        isolated
+            .ipc
+            .inject_input(window_id.as_str(), "test content")
+            .await
+            .expect("inject_input with window ID should succeed");
+    }
+
+    #[tokio::test]
+    async fn test_qualify_target_logic() {
+        let ipc = TmuxIpc::new("mysession");
+
+        // Global IDs remain as-is
+        assert_eq!(ipc.qualify_target("@1"), "@1");
+        assert_eq!(ipc.qualify_target("%42"), "%42");
+
+        // Already qualified targets remain as-is
+        assert_eq!(ipc.qualify_target("othersession:Server"), "othersession:Server");
+        assert_eq!(ipc.qualify_target("mysession:3.1"), "mysession:3.1");
+
+        // Unqualified targets get prefixed
+        assert_eq!(ipc.qualify_target("Server"), "mysession:Server");
+        assert_eq!(ipc.qualify_target("3"), "mysession:3");
+        assert_eq!(ipc.qualify_target("."), "mysession:.");
     }
 }


### PR DESCRIPTION
Messaging investigation followups. Root fixed the primary jank separately (#864, register sub-TL under child name). This PR cleans up adjacent drift bugs surfaced during the investigation.

## Changes

**`fix(teams)`: populate synthetic member `model` from agent type**
`rust/exomonad-core/src/services/synthetic_members.rs` + `handlers/agent.rs`

Every synthetic member was registered with hardcoded `"model": "gemini"` regardless of actual agent type. Sub-TLs are Claude but got misreported, risking wrong routing in CC. Thread `AgentType` through `register_synthetic_member` and derive `model` from `AgentType::suffix()` ("claude"/"gemini"/"shoal"/"process"). Renamed the stringly-typed `agent_type: &str` parameter to `kind` — the kind strings ("claude-subtree", "gemini-leaf", etc.) stay as semantic role labels on the `agentType` JSON field. Regression test `test_register_claude_subtree_writes_claude_model`.

**`fix(tmux)`: resolve dotted display names to `@window_id` before injection**
`rust/exomonad-core/src/services/tmux_ipc.rs`

Sidecar log was filling with `can't find window: 💎 main` errors because tmux parses target specifiers as `{session}:{window}.{pane}` — a window named `💎 main.foo-bar-gemini` becomes window=`💎 main`, pane=`foo-bar-gemini`. No escape syntax for `.`; only `@`-prefixed IDs are safe. #868 (merged into this branch) added `qualify_target` for `@`/`%` ID short-circuit; this extends it with `resolve_target` that looks up display names with `.` via `list_windows` and returns the matching `@window_id`. Names without `.` and IDs pass through without extra tmux calls. Regression test creates `💎 main.foo-bar-gemini` via `IsolatedTmux` and asserts successful injection.

**`docs`: propose flat team-per-tree for sub-TL membership**
`docs/decisions/sub-tl-team-membership.md`

Current state has two sources of truth: sub-TLs create their own team (SessionStart hook nudges them) AND are registered in parent's team via `propagate_team_to_child`. #864 and the model hardcode were both drift symptoms of this. Recommends Option B (one team per root TL; sub-TLs and leaves are synthetic members). Alternatives C (per-subtree teams) and current hybrid analyzed. Decision is for root / human to ratify; this commit documents the analysis, not the implementation.

## Known remaining drift

`rust/claude-teams-bridge/src/registry.rs:284` in the reconcile-add-missing-member path still hardcodes `"model": "gemini"` and `"agentType": "exomonad-agent"` because `TeamInfo` doesn't carry model/agent_type info. This path is rare — only hit when in-memory `register_team` fires before `synthetic_members.rs` writes, which is a narrow race — so it's not addressed here. Followup: extend `TeamInfo` and thread the values through the `register_team` effect proto.

## Verification

```
cargo test -p exomonad-core --lib   # 558 passed
cargo clippy -p exomonad-core --lib # clean
```

## Merged into this branch

- #868 "Fix tmux target resolution for global IDs" — the Gemini leaf I spawned for the tmux fix. It covered `@`/`%` ID short-circuit; this PR adds the dotted-display-name resolution it missed.