### PR TITLE
feat: set upstream tracking for child branches on spawn

### DIFF
--- a/rust/exomonad-core/src/services/agent_control/internal.rs
+++ b/rust/exomonad-core/src/services/agent_control/internal.rs
@@ -218,6 +218,10 @@ impl<
             ));
         }
 
+        // Set upstream tracking by pushing the branch to origin.
+        // Non-fatal: supports offline use or repos without remotes.
+        ensure_branch_pushed(self.git_wt(), branch_name, worktree_path).await;
+
         Ok(())
     }
 

--- a/rust/exomonad-core/src/services/agent_control/internal.rs
+++ b/rust/exomonad-core/src/services/agent_control/internal.rs
@@ -218,9 +218,35 @@ impl<
             ));
         }
 
-        // Set upstream tracking by pushing the branch to origin.
+        // Set upstream tracking by pushing the child branch to origin.
         // Non-fatal: supports offline use or repos without remotes.
-        ensure_branch_pushed(self.git_wt(), branch_name, worktree_path).await;
+        //
+        // Run this in the background so slow networks or auth prompts do not
+        // consume the main spawn timeout budget.
+        let git_wt = self.git_wt().clone();
+        let branch_push = branch_name.clone();
+        let wt_path = worktree_path.to_path_buf();
+        tokio::spawn(async move {
+            info!(
+                branch_name = %branch_push,
+                worktree_path = %wt_path.display(),
+                "Ensuring child branch upstream in background"
+            );
+
+            if tokio::time::timeout(
+                std::time::Duration::from_secs(10),
+                ensure_branch_pushed(&git_wt, &branch_push, &wt_path),
+            )
+            .await
+            .is_err()
+            {
+                warn!(
+                    branch_name = %branch_push,
+                    worktree_path = %wt_path.display(),
+                    "Timed out while ensuring child branch upstream (non-fatal)"
+                );
+            }
+        });
 
         Ok(())
     }

--- a/rust/exomonad-core/src/services/agent_control/mod.rs
+++ b/rust/exomonad-core/src/services/agent_control/mod.rs
@@ -48,7 +48,7 @@ pub(crate) async fn ensure_branch_pushed(
     branch: &BranchName,
     project_dir: &Path,
 ) {
-    info!(branch = %branch, "Pushing parent branch to remote");
+    info!(branch = %branch, "Pushing branch to remote");
     let git_wt = git_wt.clone();
     let dir = project_dir.to_path_buf();
     let bookmark = branch.clone();
@@ -59,7 +59,7 @@ pub(crate) async fn ensure_branch_pushed(
             warn!(
                 branch = %branch,
                 error = %anyhow_err,
-                "Failed to push parent branch (non-fatal, PRs may not work)"
+                "Failed to push branch (non-fatal, remote operations may not work)"
             )
         }
         Err(e) => warn!(branch = %branch, error = %e, "Push task panicked (non-fatal)"),

--- a/rust/exomonad-core/src/services/git_worktree.rs
+++ b/rust/exomonad-core/src/services/git_worktree.rs
@@ -146,7 +146,7 @@ impl GitWorktreeService {
         info!(branch = %branch, path = %workspace_path.display(), "Pushing branch");
 
         let output = std::process::Command::new("git")
-            .args(["push", "origin", branch.as_str()])
+            .args(["push", "-u", "origin", branch.as_str()])
             .current_dir(workspace_path)
             .output()
             .map_err(|e| WorktreeError::GitError {
@@ -733,5 +733,61 @@ mod tests {
         assert_eq!(resolved_a, Some(branch_a));
         assert_eq!(resolved_b, Some(branch_b));
         assert_ne!(resolved_a, resolved_b);
+    }
+
+    #[test]
+    fn test_push_bookmark_sets_upstream() {
+        // Create a bare repo to act as remote
+        let temp_remote = TempDir::new().expect("failed to create temp remote dir");
+        let remote_path = temp_remote.path();
+        let status = Command::new("git")
+            .args(["init", "--bare"])
+            .current_dir(remote_path)
+            .status()
+            .expect("failed to run git init --bare");
+        assert!(status.success());
+
+        // Create local repo
+        let temp_local = TempDir::new().expect("failed to create temp local dir");
+        let local_path = temp_local.path();
+        let run = |args: &[&str]| {
+            let status = Command::new("git")
+                .args(args)
+                .current_dir(local_path)
+                .status()
+                .expect("failed to run git command");
+            assert!(status.success(), "git command failed: {:?}", args);
+        };
+        run(&["init"]);
+        run(&["config", "user.email", "test@example.com"]);
+        run(&["config", "user.name", "Test User"]);
+        run(&["commit", "--allow-empty", "-m", "Initial commit"]);
+        run(&["remote", "add", "origin", remote_path.to_str().unwrap()]);
+
+        let service = GitWorktreeService::new(local_path.to_path_buf());
+        let branch = BranchName::from("test-upstream-branch");
+        service.create_bookmark(local_path, &branch, None).unwrap();
+
+        // Push and verify it sets upstream
+        service.push_bookmark(local_path, &branch).unwrap();
+
+        let output = Command::new("git")
+            .args([
+                "rev-parse",
+                "--abbrev-ref",
+                "--symbolic-full-name",
+                "test-upstream-branch@{u}",
+            ])
+            .current_dir(local_path)
+            .output()
+            .unwrap();
+
+        assert!(
+            output.status.success(),
+            "Upstream not set for branch: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let upstream = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        assert_eq!(upstream, "origin/test-upstream-branch");
     }
 }

--- a/rust/exomonad-core/src/services/git_worktree.rs
+++ b/rust/exomonad-core/src/services/git_worktree.rs
@@ -135,9 +135,9 @@ impl GitWorktreeService {
         Ok(())
     }
 
-    /// Push a branch to the remote.
+    /// Push a branch to the remote and set upstream tracking.
     ///
-    /// Equivalent to: `git push origin {branch}` (run in workspace_path)
+    /// Equivalent to: `git push -u origin {branch}` (run in workspace_path)
     pub fn push_bookmark(
         &self,
         workspace_path: &Path,
@@ -762,7 +762,14 @@ mod tests {
         run(&["config", "user.email", "test@example.com"]);
         run(&["config", "user.name", "Test User"]);
         run(&["commit", "--allow-empty", "-m", "Initial commit"]);
-        run(&["remote", "add", "origin", remote_path.to_str().unwrap()]);
+
+        let status = Command::new("git")
+            .args(["remote", "add", "origin"])
+            .arg(remote_path)
+            .current_dir(local_path)
+            .status()
+            .expect("failed to run git remote add");
+        assert!(status.success(), "git command failed: remote add origin <path>");
 
         let service = GitWorktreeService::new(local_path.to_path_buf());
         let branch = BranchName::from("test-upstream-branch");


### PR DESCRIPTION
This PR implements Item #3 from `plans/post-fixup-wave-followups.md`, ensuring that child branches created by `fork_wave`/`spawn_gemini` have their upstream tracking set at spawn time.

### Changes
- Modified `GitWorktreeService::push_bookmark` in `rust/exomonad-core/src/services/git_worktree.rs` to use `git push -u origin <branch>` and updated documentation.
- Integrated backgrounded `ensure_branch_pushed` with a 10s timeout in `AgentControlService::create_worktree_checked` to establish upstream tracking without blocking spawn flows.
- Generalized logging in `ensure_branch_pushed` to support both parent and child branches.
- Added a robust regression test `test_push_bookmark_sets_upstream` avoiding UTF-8 assumptions.

### Verification
- `cargo test -p exomonad-core --lib services::git_worktree` (includes regression test)
- `cargo test -p exomonad-core --lib services::agent_control`
- `cargo clippy -p exomonad-core -- -D warnings`