### PR TITLE
feat(delivery): carve per-channel helpers and implement execute_plan

### DIFF
--- a/rust/exomonad-core/src/services/delivery.rs
+++ b/rust/exomonad-core/src/services/delivery.rs
@@ -246,7 +246,10 @@ pub enum DeliveryResultV2 {
     /// Channel handed off to an async verifier. Callers that need certainty
     /// can `.await` the receiver; fire-and-forget callers can treat this as
     /// success-pending.
-    QueuedUnverified(DeliveryChannel, tokio::sync::oneshot::Receiver<VerifyOutcome>),
+    QueuedUnverified(
+        DeliveryChannel,
+        tokio::sync::oneshot::Receiver<VerifyOutcome>,
+    ),
     /// Plan exhausted or empty.
     Failed(FailureReason),
 }
@@ -354,7 +357,10 @@ async fn resolve_and_deliver_to_lead(
     if result.is_failure() {
         DeliveryOutcome::Failed {
             original,
-            reason: format!("delivery to resolved lead '{}' failed ({:?})", lead_key, result),
+            reason: format!(
+                "delivery to resolved lead '{}' failed ({:?})",
+                lead_key, result
+            ),
         }
     } else {
         DeliveryOutcome::FallbackToLead {
@@ -980,6 +986,19 @@ fn is_acp_connection_error(e: &agent_client_protocol::Error) -> bool {
         }
     }
     false
+}
+
+pub(crate) async fn deliver_via_uds_for_testing(
+    socket_path: &std::path::Path,
+    from: &str,
+    message: &str,
+    summary: &str,
+) -> Result<(), String> {
+    deliver_via_uds(socket_path, from, message, summary).await
+}
+
+pub(crate) fn is_acp_connection_error_for_testing(e: &agent_client_protocol::Error) -> bool {
+    is_acp_connection_error(e)
 }
 
 #[cfg(test)]

--- a/rust/exomonad-core/src/services/delivery.rs
+++ b/rust/exomonad-core/src/services/delivery.rs
@@ -208,6 +208,9 @@ pub enum VerifyOutcome {
     /// Recipient's InboxPoller read the message within the verification window.
     Confirmed,
     /// Recipient did not read; verifier successfully injected via tmux.
+    ///
+    /// NOTE: Not implemented in the refactored `try_teams_channel` yet; only
+    /// produced by the legacy `deliver_to_agent` path.
     FellBackToTmux,
     /// Recipient did not read and tmux fallback was either unavailable
     /// (Tier 2 / CC-native) or failed.
@@ -988,7 +991,7 @@ fn is_acp_connection_error(e: &agent_client_protocol::Error) -> bool {
     false
 }
 
-pub(crate) async fn deliver_via_uds_for_testing(
+pub(crate) async fn deliver_via_uds_internal(
     socket_path: &std::path::Path,
     from: &str,
     message: &str,
@@ -997,7 +1000,7 @@ pub(crate) async fn deliver_via_uds_for_testing(
     deliver_via_uds(socket_path, from, message, summary).await
 }
 
-pub(crate) fn is_acp_connection_error_for_testing(e: &agent_client_protocol::Error) -> bool {
+pub(crate) fn is_acp_connection_error_internal(e: &agent_client_protocol::Error) -> bool {
     is_acp_connection_error(e)
 }
 

--- a/rust/exomonad-core/src/services/delivery_channels.rs
+++ b/rust/exomonad-core/src/services/delivery_channels.rs
@@ -117,7 +117,7 @@ pub async fn try_acp_channel<C: HasAcpRegistry>(
                 detail = ?e,
                 "[event] message.delivery"
             );
-            if super::delivery::is_acp_connection_error_for_testing(&e) {
+            if super::delivery::is_acp_connection_error_internal(&e) {
                 ctx.acp_registry().remove(agent_key).await;
             }
             Ok(ChannelOutcome::Failed(format!("acp prompt: {e:?}")))
@@ -138,7 +138,7 @@ pub async fn try_uds_channel(
             socket_path.display()
         )));
     }
-    match super::delivery::deliver_via_uds_for_testing(socket_path, from.as_str(), message, summary)
+    match super::delivery::deliver_via_uds_internal(socket_path, from.as_str(), message, summary)
         .await
     {
         Ok(()) => {
@@ -205,9 +205,9 @@ pub async fn try_tmux_channel<C: HasTmuxIpc>(
     }
 }
 
-/// Context carrying everything `execute_plan` may need to try any channel. Fields
-/// are optional so callers construct only what applies (e.g. no `team_info` ⇒
-/// Teams channel attempts report `Failed`).
+/// Context carrying everything `execute_plan` may need to try any channel.
+/// `team_info` and `uds_socket` are optional; if missing, attempts via those
+/// channels report `Failed`.
 pub struct PlanContext<'a> {
     pub agent_key: &'a str,
     pub tmux_target: &'a str,
@@ -228,17 +228,9 @@ where
     C: HasAcpRegistry + HasTmuxIpc + HasTeamRegistry + HasProjectDir,
 {
     if plan.is_empty() {
-        return DeliveryResultV2::Failed(FailureReason::Undeliverable(
-            // Undeliverable is constructed by the caller with the real RecipientMeta;
-            // use AllChannelsExhausted as a conservative default when the plan is empty
-            // but the RecipientMeta is unknown here.
-            // The higher-level wrapper (integration commit) calls delivery_plan first
-            // and short-circuits empty plans with the real meta.
-            crate::services::delivery::RecipientMeta {
-                agent_type: crate::services::agent_control::AgentType::Process,
-                backend_type: crate::services::delivery::BackendType::Exomonad,
-            },
-        ));
+        // RecipientMeta is not available here, so use the conservative default
+        // rather than fabricating metadata for Undeliverable.
+        return DeliveryResultV2::Failed(FailureReason::AllChannelsExhausted);
     }
 
     for channel in plan {
@@ -278,17 +270,12 @@ where
 mod tests {
     use super::*;
     use crate::domain::AgentName;
-    use crate::services::agent_control::AgentType;
-    use crate::services::delivery::BackendType;
     use crate::services::Services;
     use std::sync::Arc;
 
     #[tokio::test]
     async fn test_execute_plan_exhausted() {
-        let isolated = crate::services::tmux_ipc::IsolatedTmux::new()
-            .await
-            .expect("tmux unavailable");
-        let services = Services::test_with_tmux(Arc::new(isolated.ipc.clone()));
+        let services = Services::test();
 
         let from = AgentName::from("sender");
         let pctx = PlanContext {
@@ -313,10 +300,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_execute_plan_empty() {
-        let isolated = crate::services::tmux_ipc::IsolatedTmux::new()
-            .await
-            .expect("tmux unavailable");
-        let services = Services::test_with_tmux(Arc::new(isolated.ipc.clone()));
+        let services = Services::test();
 
         let from = AgentName::from("sender");
         let pctx = PlanContext {
@@ -334,11 +318,8 @@ mod tests {
         let result = execute_plan(plan, &services, &pctx).await;
 
         match result {
-            DeliveryResultV2::Failed(FailureReason::Undeliverable(meta)) => {
-                assert_eq!(meta.agent_type, AgentType::Process);
-                assert_eq!(meta.backend_type, BackendType::Exomonad);
-            }
-            _ => panic!("Expected Undeliverable, got {:?}", result),
+            DeliveryResultV2::Failed(FailureReason::AllChannelsExhausted) => {}
+            _ => panic!("Expected AllChannelsExhausted, got {:?}", result),
         }
     }
 

--- a/rust/exomonad-core/src/services/delivery_channels.rs
+++ b/rust/exomonad-core/src/services/delivery_channels.rs
@@ -1,0 +1,415 @@
+//! Per-channel delivery primitives for the capability-driven delivery pipeline.
+//!
+//! Each `try_*_channel` attempts delivery via a single transport ONCE and reports
+//! an honest `ChannelOutcome`. The executor (`execute_plan`) walks a
+//! `Vec<DeliveryChannel>` produced by `delivery_plan` and stops at the first
+//! non-`Failed` outcome. Retry + fallback are expressed as the plan list itself,
+//! not hidden inside these helpers.
+
+use crate::services::delivery::{
+    ChannelOutcome, DeliveryChannel, DeliveryResultV2, FailureReason, VerifyOutcome,
+};
+use crate::services::{HasAcpRegistry, HasProjectDir, HasTeamRegistry, HasTmuxIpc};
+use agent_client_protocol::{Agent, PromptRequest};
+use claude_teams_bridge::TeamInfo;
+use tokio::sync::oneshot;
+use tracing::{info, instrument, warn};
+
+#[instrument(skip_all, fields(team = %team_info.team_name, inbox = %team_info.inbox_name))]
+pub async fn try_teams_channel(
+    team_info: &TeamInfo,
+    from: &crate::domain::AgentName,
+    message: &str,
+    summary: &str,
+) -> Result<ChannelOutcome, String> {
+    // Mirror the existing Teams inbox write (no retry here — executor handles retry/fallback via plan list).
+    let timestamp = match claude_teams_bridge::write_to_inbox(
+        &team_info.team_name,
+        &team_info.inbox_name,
+        from.as_str(),
+        message,
+        summary,
+    ) {
+        Ok(ts) => ts,
+        Err(e) => return Ok(ChannelOutcome::Failed(format!("teams write: {e}"))),
+    };
+
+    tracing::info!(
+        otel.name = "message.delivery",
+        agent_id = %from,
+        method = "teams_inbox",
+        outcome = "success",
+        detail = format!("{}/{}", team_info.team_name, team_info.inbox_name),
+        "[event] message.delivery"
+    );
+
+    let (tx, rx) = oneshot::channel::<VerifyOutcome>();
+    let team_name = team_info.team_name.clone();
+    let inbox_name = team_info.inbox_name.clone();
+    tokio::spawn(async move {
+        let policy = crate::services::resilience::RetryPolicy::new(
+            3,
+            crate::services::resilience::Backoff::Fixed(std::time::Duration::from_secs(10)),
+        );
+        let verified = crate::services::resilience::retry(&policy, || {
+            let is_read = claude_teams_bridge::is_message_read(&team_name, &inbox_name, &timestamp);
+            async move {
+                if is_read {
+                    Ok(())
+                } else {
+                    anyhow::bail!("message not yet read")
+                }
+            }
+        })
+        .await;
+        let outcome = if verified.is_ok() {
+            VerifyOutcome::Confirmed
+        } else {
+            VerifyOutcome::VerificationFailed(format!(
+                "teams inbox {}/{} not read within verification window",
+                team_name, inbox_name
+            ))
+        };
+        let _ = tx.send(outcome);
+    });
+
+    Ok(ChannelOutcome::Queued(rx))
+}
+
+#[instrument(skip_all, fields(agent_key = %agent_key))]
+pub async fn try_acp_channel<C: HasAcpRegistry>(
+    ctx: &C,
+    agent_key: &str,
+    from: &crate::domain::AgentName,
+    message: &str,
+) -> Result<ChannelOutcome, String> {
+    let Some(conn) = ctx.acp_registry().get(agent_key).await else {
+        return Ok(ChannelOutcome::Failed("no ACP connection registered".into()));
+    };
+    match conn
+        .conn
+        .prompt(PromptRequest::new(
+            conn.session_id.clone(),
+            vec![message.into()],
+        ))
+        .await
+    {
+        Ok(_) => {
+            info!(agent = %agent_key, "Delivered message via ACP prompt");
+            tracing::info!(
+                otel.name = "message.delivery",
+                agent_id = %from,
+                recipient = %agent_key,
+                method = "acp",
+                outcome = "success",
+                "[event] message.delivery"
+            );
+            Ok(ChannelOutcome::Confirmed)
+        }
+        Err(e) => {
+            warn!(agent = %agent_key, error = ?e, "ACP prompt failed");
+            tracing::info!(
+                otel.name = "message.delivery",
+                agent_id = %from,
+                recipient = %agent_key,
+                method = "acp",
+                outcome = "failed",
+                detail = ?e,
+                "[event] message.delivery"
+            );
+            if super::delivery::is_acp_connection_error_for_testing(&e) {
+                ctx.acp_registry().remove(agent_key).await;
+            }
+            Ok(ChannelOutcome::Failed(format!("acp prompt: {e:?}")))
+        }
+    }
+}
+
+#[instrument(skip_all, fields(socket = %socket_path.display()))]
+pub async fn try_uds_channel(
+    socket_path: &std::path::Path,
+    from: &crate::domain::AgentName,
+    message: &str,
+    summary: &str,
+) -> Result<ChannelOutcome, String> {
+    if !socket_path.exists() {
+        return Ok(ChannelOutcome::Failed(format!(
+            "UDS socket not present: {}",
+            socket_path.display()
+        )));
+    }
+    match super::delivery::deliver_via_uds_for_testing(socket_path, from.as_str(), message, summary)
+        .await
+    {
+        Ok(()) => {
+            tracing::info!(
+                otel.name = "message.delivery",
+                agent_id = %from,
+                method = "unix_socket",
+                outcome = "success",
+                detail = %socket_path.to_string_lossy(),
+                "[event] message.delivery"
+            );
+            Ok(ChannelOutcome::Confirmed)
+        }
+        Err(e) => {
+            tracing::info!(
+                otel.name = "message.delivery",
+                agent_id = %from,
+                method = "unix_socket",
+                outcome = "failed",
+                detail = %e,
+                "[event] message.delivery"
+            );
+            Ok(ChannelOutcome::Failed(format!("uds: {e}")))
+        }
+    }
+}
+
+#[instrument(skip_all, fields(target = %tmux_target))]
+pub async fn try_tmux_channel<C: HasTmuxIpc>(
+    ctx: &C,
+    tmux_target: &str,
+    message: &str,
+    working_dir: &std::path::Path,
+) -> Result<ChannelOutcome, String> {
+    match crate::services::tmux_events::inject_input(
+        ctx.tmux_ipc(),
+        tmux_target,
+        message,
+        working_dir,
+    )
+    .await
+    {
+        Ok(()) => {
+            tracing::info!(
+                otel.name = "message.delivery",
+                method = "tmux",
+                outcome = "success",
+                detail = %tmux_target,
+                "[event] message.delivery"
+            );
+            Ok(ChannelOutcome::Confirmed)
+        }
+        Err(e) => {
+            warn!(target = %tmux_target, error = %e, "tmux inject_input failed");
+            tracing::info!(
+                otel.name = "message.delivery",
+                method = "tmux",
+                outcome = "failed",
+                detail = %e,
+                "[event] message.delivery"
+            );
+            Ok(ChannelOutcome::Failed(format!("tmux: {e}")))
+        }
+    }
+}
+
+/// Context carrying everything `execute_plan` may need to try any channel. Fields
+/// are optional so callers construct only what applies (e.g. no `team_info` ⇒
+/// Teams channel attempts report `Failed`).
+pub struct PlanContext<'a> {
+    pub agent_key: &'a str,
+    pub tmux_target: &'a str,
+    pub from: &'a crate::domain::AgentName,
+    pub message: &'a str,
+    pub summary: &'a str,
+    pub team_info: Option<&'a TeamInfo>,
+    pub uds_socket: Option<&'a std::path::Path>,
+    pub tmux_working_dir: &'a std::path::Path,
+}
+
+pub async fn execute_plan<C>(
+    plan: Vec<DeliveryChannel>,
+    ctx: &C,
+    pctx: &PlanContext<'_>,
+) -> DeliveryResultV2
+where
+    C: HasAcpRegistry + HasTmuxIpc + HasTeamRegistry + HasProjectDir,
+{
+    if plan.is_empty() {
+        return DeliveryResultV2::Failed(FailureReason::Undeliverable(
+            // Undeliverable is constructed by the caller with the real RecipientMeta;
+            // use AllChannelsExhausted as a conservative default when the plan is empty
+            // but the RecipientMeta is unknown here.
+            // The higher-level wrapper (integration commit) calls delivery_plan first
+            // and short-circuits empty plans with the real meta.
+            crate::services::delivery::RecipientMeta {
+                agent_type: crate::services::agent_control::AgentType::Process,
+                backend_type: crate::services::delivery::BackendType::Exomonad,
+            },
+        ));
+    }
+
+    for channel in plan {
+        let outcome_res = match channel {
+            DeliveryChannel::Teams => match pctx.team_info {
+                Some(info) => try_teams_channel(info, pctx.from, pctx.message, pctx.summary).await,
+                None => Ok(ChannelOutcome::Failed("no team_info available".into())),
+            },
+            DeliveryChannel::Acp => {
+                try_acp_channel(ctx, pctx.agent_key, pctx.from, pctx.message).await
+            }
+            DeliveryChannel::Uds => match pctx.uds_socket {
+                Some(path) => try_uds_channel(path, pctx.from, pctx.message, pctx.summary).await,
+                None => Ok(ChannelOutcome::Failed("no uds socket available".into())),
+            },
+            DeliveryChannel::Tmux => {
+                try_tmux_channel(ctx, pctx.tmux_target, pctx.message, pctx.tmux_working_dir).await
+            }
+        };
+        match outcome_res {
+            Ok(ChannelOutcome::Confirmed) => return DeliveryResultV2::Confirmed(channel),
+            Ok(ChannelOutcome::Queued(rx)) => return DeliveryResultV2::QueuedUnverified(channel, rx),
+            Ok(ChannelOutcome::Failed(reason)) => {
+                tracing::debug!(channel = ?channel, reason = %reason, "channel attempt failed; continuing plan");
+                continue;
+            }
+            Err(e) => {
+                tracing::warn!(channel = ?channel, error = %e, "channel attempt errored; continuing plan");
+                continue;
+            }
+        }
+    }
+    DeliveryResultV2::Failed(FailureReason::AllChannelsExhausted)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::AgentName;
+    use crate::services::agent_control::AgentType;
+    use crate::services::delivery::BackendType;
+    use crate::services::Services;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn test_execute_plan_exhausted() {
+        let isolated = crate::services::tmux_ipc::IsolatedTmux::new()
+            .await
+            .expect("tmux unavailable");
+        let services = Services::test_with_tmux(Arc::new(isolated.ipc.clone()));
+
+        let from = AgentName::from("sender");
+        let pctx = PlanContext {
+            agent_key: "agent",
+            tmux_target: "target",
+            from: &from,
+            message: "msg",
+            summary: "sum",
+            team_info: None,
+            uds_socket: None,
+            tmux_working_dir: std::path::Path::new("."),
+        };
+
+        let plan = vec![DeliveryChannel::Teams, DeliveryChannel::Uds];
+        let result = execute_plan(plan, &services, &pctx).await;
+
+        match result {
+            DeliveryResultV2::Failed(FailureReason::AllChannelsExhausted) => {}
+            _ => panic!("Expected AllChannelsExhausted, got {:?}", result),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_execute_plan_empty() {
+        let isolated = crate::services::tmux_ipc::IsolatedTmux::new()
+            .await
+            .expect("tmux unavailable");
+        let services = Services::test_with_tmux(Arc::new(isolated.ipc.clone()));
+
+        let from = AgentName::from("sender");
+        let pctx = PlanContext {
+            agent_key: "agent",
+            tmux_target: "target",
+            from: &from,
+            message: "msg",
+            summary: "sum",
+            team_info: None,
+            uds_socket: None,
+            tmux_working_dir: std::path::Path::new("."),
+        };
+
+        let plan = vec![];
+        let result = execute_plan(plan, &services, &pctx).await;
+
+        match result {
+            DeliveryResultV2::Failed(FailureReason::Undeliverable(meta)) => {
+                assert_eq!(meta.agent_type, AgentType::Process);
+                assert_eq!(meta.backend_type, BackendType::Exomonad);
+            }
+            _ => panic!("Expected Undeliverable, got {:?}", result),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_execute_plan_confirmed_tmux() {
+        if !crate::services::tmux_ipc::IsolatedTmux::is_available().await {
+            return;
+        }
+        let isolated = crate::services::tmux_ipc::IsolatedTmux::new()
+            .await
+            .expect("tmux unavailable");
+        let services = Services::test_with_tmux(Arc::new(isolated.ipc.clone()));
+
+        let window_id = isolated
+            .ipc
+            .new_window(
+                "test-window",
+                std::path::Path::new("/tmp"),
+                "/bin/sh",
+                "sleep 100",
+            )
+            .await
+            .unwrap();
+
+        let from = AgentName::from("sender");
+        let pctx = PlanContext {
+            agent_key: "agent",
+            tmux_target: window_id.as_str(),
+            from: &from,
+            message: "msg",
+            summary: "sum",
+            team_info: None,
+            uds_socket: None,
+            tmux_working_dir: std::path::Path::new("."),
+        };
+
+        let plan = vec![DeliveryChannel::Tmux];
+        let result = execute_plan(plan, &services, &pctx).await;
+
+        match result {
+            DeliveryResultV2::Confirmed(DeliveryChannel::Tmux) => {}
+            _ => panic!("Expected Confirmed(Tmux), got {:?}", result),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_try_tmux_channel_confirmed() {
+        if !crate::services::tmux_ipc::IsolatedTmux::is_available().await {
+            return;
+        }
+        let isolated = crate::services::tmux_ipc::IsolatedTmux::new()
+            .await
+            .expect("tmux unavailable");
+        let services = Services::test_with_tmux(Arc::new(isolated.ipc.clone()));
+
+        let window_id = isolated
+            .ipc
+            .new_window(
+                "test-window-2",
+                std::path::Path::new("/tmp"),
+                "/bin/sh",
+                "sleep 100",
+            )
+            .await
+            .unwrap();
+
+        let result = try_tmux_channel(&services, window_id.as_str(), "msg", std::path::Path::new(".")).await;
+
+        match result {
+            Ok(ChannelOutcome::Confirmed) => {}
+            _ => panic!("Expected Confirmed, got {:?}", result),
+        }
+    }
+}

--- a/rust/exomonad-core/src/services/mod.rs
+++ b/rust/exomonad-core/src/services/mod.rs
@@ -6,6 +6,7 @@ pub mod claude_session_registry;
 pub mod command;
 pub mod copilot_review;
 pub mod delivery;
+pub mod delivery_channels;
 pub mod event_log;
 pub mod event_queue;
 pub mod external;


### PR DESCRIPTION
This PR carves the per-channel delivery logic from `deliver_to_agent` into reusable `try_{teams,acp,uds,tmux}_channel` helpers and implements the `execute_plan` state machine in a new module `delivery_channels.rs`.

Each helper attempts delivery exactly once and returns an honest `ChannelOutcome`, allowing the executor (`execute_plan`) to handle fallbacks based on the totally-ordered plan list.

Key changes:
- Created `rust/exomonad-core/src/services/delivery_channels.rs` with channel helpers and `execute_plan`.
- Added internal shims in `delivery.rs` for cross-module access to private I/O primitives.
- Registered the new module in `services/mod.rs`.
- Added unit tests for `execute_plan` and `try_tmux_channel` using the `IsolatedTmux` harness.

This work is part of Wave 1 of the delivery refactor. Integration into `deliver_to_agent` will occur in a follow-up commit after the parallel `delivery-plan-pure` leaf merges.