### PR TITLE
fix(delivery): thread backend_type through TeamInfo for correct Tier 2 routing

### DIFF
--- a/rust/claude-teams-bridge/src/registry.rs
+++ b/rust/claude-teams-bridge/src/registry.rs
@@ -24,6 +24,7 @@ pub struct TeamInfo {
     pub inbox_name: String,
     pub agent_type: String,
     pub model: String,
+    pub backend_type: Option<String>,
 }
 
 /// Maps agent identity keys to Claude Teams info.
@@ -195,6 +196,7 @@ impl TeamRegistry {
             inbox_name: member.name.clone(),
             agent_type: member.agent_type.clone(),
             model: member.model.clone(),
+            backend_type: member.backend_type.clone(),
         })
     }
 
@@ -338,6 +340,7 @@ mod tests {
                 inbox_name: "root-inbox".into(),
                 agent_type: "exomonad-agent".into(),
                 model: "gemini".into(),
+                backend_type: None,
             },
         )
         .await;
@@ -356,6 +359,7 @@ mod tests {
                 inbox_name: "root-inbox".into(),
                 agent_type: "exomonad-agent".into(),
                 model: "gemini".into(),
+                backend_type: None,
             },
         )
         .await;
@@ -374,6 +378,7 @@ mod tests {
                 inbox_name: "inbox1".into(),
                 agent_type: "exomonad-agent".into(),
                 model: "gemini".into(),
+                backend_type: None,
             },
         )
         .await;
@@ -384,6 +389,7 @@ mod tests {
                 inbox_name: "inbox2".into(),
                 agent_type: "exomonad-agent".into(),
                 model: "gemini".into(),
+                backend_type: None,
             },
         )
         .await;
@@ -401,6 +407,7 @@ mod tests {
                 inbox_name: "inbox-1".into(),
                 agent_type: "exomonad-agent".into(),
                 model: "gemini".into(),
+                backend_type: None,
             },
         )
         .await;
@@ -411,6 +418,7 @@ mod tests {
                 inbox_name: "inbox-2".into(),
                 agent_type: "exomonad-agent".into(),
                 model: "gemini".into(),
+                backend_type: None,
             },
         )
         .await;
@@ -421,6 +429,7 @@ mod tests {
                 inbox_name: "inbox-3".into(),
                 agent_type: "exomonad-agent".into(),
                 model: "gemini".into(),
+                backend_type: None,
             },
         )
         .await;
@@ -458,6 +467,7 @@ mod tests {
                 inbox_name: "root-inbox".into(),
                 agent_type: "exomonad-agent".into(),
                 model: "gemini".into(),
+                backend_type: None,
             },
         )
         .await;
@@ -468,6 +478,7 @@ mod tests {
                 inbox_name: "agent-inbox".into(),
                 agent_type: "exomonad-agent".into(),
                 model: "gemini".into(),
+                backend_type: None,
             },
         )
         .await;
@@ -485,6 +496,7 @@ mod tests {
                 inbox_name: "a".into(),
                 agent_type: "exomonad-agent".into(),
                 model: "gemini".into(),
+                backend_type: None,
             },
         )
         .await;
@@ -549,6 +561,7 @@ mod tests {
                 inbox_name: "beta".into(),
                 agent_type: "exomonad-agent".into(),
                 model: "gemini".into(),
+                backend_type: None,
             },
         )
         .await;
@@ -567,6 +580,7 @@ mod tests {
                 inbox_name: "agent-1".into(),
                 agent_type: "exomonad-agent".into(),
                 model: "gemini".into(),
+                backend_type: None,
             },
         )
         .await;
@@ -593,6 +607,7 @@ mod tests {
                 inbox_name: "agent-1".into(),
                 agent_type: "exomonad-agent".into(),
                 model: "gemini".into(),
+                backend_type: None,
             },
         )
         .await;
@@ -679,6 +694,7 @@ mod tests {
                 inbox_name: "sender".into(),
                 agent_type: "exomonad-agent".into(),
                 model: "gemini".into(),
+                backend_type: None,
             },
         )
         .await;

--- a/rust/claude-teams-bridge/tests/integration.rs
+++ b/rust/claude-teams-bridge/tests/integration.rs
@@ -339,6 +339,7 @@ async fn resolve_tier2_e2e_inbox_delivery() {
                 inbox_name: "exo-worker".into(),
                 agent_type: "exomonad-agent".into(),
                 model: "gemini".into(),
+                backend_type: None,
             },
         )
         .await;
@@ -491,6 +492,7 @@ async fn live_team_resolve_and_deliver() {
                 inbox_name: "test-harness".into(),
                 agent_type: "exomonad-agent".into(),
                 model: "gemini".into(),
+                backend_type: None,
             },
         )
         .await;
@@ -594,6 +596,7 @@ async fn lead_deregistered_still_resolves_via_config() {
                 inbox_name: "team-lead".into(),
                 agent_type: "exomonad-agent".into(),
                 model: "gemini".into(),
+                backend_type: None,
             },
         )
         .await;
@@ -668,6 +671,7 @@ async fn lead_replaced_config_authoritative() {
                 inbox_name: "new-lead".into(),
                 agent_type: "exomonad-agent".into(),
                 model: "gemini".into(),
+                backend_type: None,
             },
         )
         .await;
@@ -742,6 +746,7 @@ async fn cross_team_name_collision() {
                 inbox_name: "sender".into(),
                 agent_type: "exomonad-agent".into(),
                 model: "gemini".into(),
+                backend_type: None,
             },
         )
         .await;
@@ -810,6 +815,7 @@ async fn orphaned_agent_returns_none() {
                 inbox_name: "lead".into(),
                 agent_type: "exomonad-agent".into(),
                 model: "gemini".into(),
+                backend_type: None,
             },
         )
         .await;
@@ -900,6 +906,7 @@ async fn resolve_lead_name_match_fallback() {
                 inbox_name: "fallback-agent".into(),
                 agent_type: "exomonad-agent".into(),
                 model: "gemini".into(),
+                backend_type: None,
             },
         )
         .await;
@@ -1036,7 +1043,7 @@ async fn supervisor_to_lead_routing_chain() {
         description: "Routing chain test".into(),
         created_at: 1711022400,
         lead_agent_id: "tl-uuid".into(),
-        lead_session_id: "session".into(),
+        lead_session_id: "session-1".into(),
         members: vec![
             TeamMember {
                 agent_id: "tl-uuid".into(),
@@ -1072,6 +1079,7 @@ async fn supervisor_to_lead_routing_chain() {
                 inbox_name: "team-lead".into(),
                 agent_type: "exomonad-agent".into(),
                 model: "gemini".into(),
+                backend_type: None,
             },
         )
         .await;
@@ -1256,6 +1264,7 @@ async fn live_teams_e2e() {
                 inbox_name: "e2e-test-runner".into(),
                 agent_type: "exomonad-agent".into(),
                 model: "gemini".into(),
+                backend_type: None,
             },
         )
         .await;
@@ -1598,6 +1607,7 @@ async fn test_register_member_moves_between_teams() {
                 inbox_name: "agent-x".into(),
                 agent_type: "exomonad-agent".into(),
                 model: "gemini".into(),
+                backend_type: None,
             },
         )
         .await
@@ -1618,6 +1628,7 @@ async fn test_register_member_moves_between_teams() {
                 inbox_name: "agent-x".into(),
                 agent_type: "exomonad-agent".into(),
                 model: "gemini".into(),
+                backend_type: None,
             },
         )
         .await
@@ -1669,6 +1680,7 @@ async fn test_alias_persistence_across_restart() {
         inbox_name: "agent-1".into(),
         agent_type: "exomonad-agent".into(),
         model: "gemini".into(),
+        backend_type: None,
     };
 
     // Register under 3 keys

--- a/rust/claude-teams-bridge/tests/integration.rs
+++ b/rust/claude-teams-bridge/tests/integration.rs
@@ -605,6 +605,7 @@ async fn lead_deregistered_still_resolves_via_config() {
                 inbox_name: "worker-1".into(),
                 agent_type: "exomonad-agent".into(),
                 model: "gemini".into(),
+                backend_type: None,
             },
         )
         .await;
@@ -761,6 +762,7 @@ async fn cross_team_name_collision() {
                 inbox_name: "worker".into(),
                 agent_type: "exomonad-agent".into(),
                 model: "gemini".into(),
+                backend_type: None,
             },
         )
         .await;
@@ -991,6 +993,7 @@ async fn concurrent_register_resolve_no_panic() {
                     inbox_name: name.clone(),
                     agent_type: "exomonad-agent".into(),
                     model: "gemini".into(),
+                    backend_type: None,
                 },
             )
             .await;
@@ -1420,6 +1423,7 @@ async fn test_register_syncs_to_disk() {
                 inbox_name: "worker-1".into(),
                 agent_type: "exomonad-agent".into(),
                 model: "gemini".into(),
+                backend_type: None,
             },
         )
         .await;
@@ -1472,6 +1476,7 @@ async fn test_remove_member_persists_to_disk() {
                 inbox_name: "worker-1".into(),
                 agent_type: "exomonad-agent".into(),
                 model: "gemini".into(),
+                backend_type: None,
             },
         )
         .await;
@@ -1540,6 +1545,7 @@ async fn test_cc_native_members_preserved() {
                 inbox_name: "worker-1".into(),
                 agent_type: "exomonad-agent".into(),
                 model: "gemini".into(),
+                backend_type: None,
             },
         )
         .await;

--- a/rust/exomonad-core/src/handlers/agent.rs
+++ b/rust/exomonad-core/src/handlers/agent.rs
@@ -181,6 +181,7 @@ impl<
             inbox_name: child_agent_name.to_string(),
             agent_type: "exomonad-agent".to_string(),
             model: child_identity.agent_type().default_model().to_string(),
+            backend_type: None,
         };
 
         // Register under agent_name and slug — NOT birth_branch.
@@ -1104,6 +1105,7 @@ mod tests {
                     inbox_name: parent_inbox.to_string(),
                     agent_type: "exomonad-agent".to_string(),
                     model: "claude-3-5-sonnet-20241022".to_string(),
+                    backend_type: None,
                 },
             )
             .await;

--- a/rust/exomonad-core/src/handlers/events.rs
+++ b/rust/exomonad-core/src/handlers/events.rs
@@ -372,6 +372,7 @@ mod tests {
                     inbox_name: "lead".to_string(),
                     agent_type: "exomonad-agent".to_string(),
                     model: "gemini".to_string(),
+                    backend_type: None,
                 },
             )
             .await;

--- a/rust/exomonad-core/src/handlers/session.rs
+++ b/rust/exomonad-core/src/handlers/session.rs
@@ -135,6 +135,7 @@ impl<C: HasClaudeSessionRegistry + HasTeamRegistry + HasSupervisorRegistry + 'st
             inbox_name: req.inbox_name.clone(),
             agent_type: agent_type_str.to_string(),
             model,
+            backend_type: None,
         };
 
         self.ctx

--- a/rust/exomonad-core/src/services/delivery.rs
+++ b/rust/exomonad-core/src/services/delivery.rs
@@ -653,10 +653,18 @@ fn recipient_meta_from_team_info(info: Option<&TeamInfo>, is_in_memory: bool) ->
         .unwrap_or(crate::services::agent_control::AgentType::Claude);
     let backend_type = if is_in_memory {
         BackendType::Exomonad
-    } else if info.is_some() {
-        BackendType::CcNative
     } else {
-        BackendType::Exomonad
+        match info.and_then(|i| i.backend_type.as_deref()) {
+            Some("exomonad") => BackendType::Exomonad,
+            Some(_) => BackendType::CcNative,
+            None => {
+                if info.is_some() {
+                    BackendType::CcNative
+                } else {
+                    BackendType::Exomonad
+                }
+            }
+        }
     };
     RecipientMeta {
         agent_type,
@@ -1441,5 +1449,37 @@ mod plan_tests {
         };
         assert!(delivery_plan(&meta).is_empty());
         assert!(channels_recipient_can_receive(&meta).is_empty());
+    }
+
+    #[test]
+    fn test_tier2_exomonad_synthetic_classified_as_exomonad() {
+        let info = TeamInfo {
+            team_name: "test-team".into(),
+            inbox_name: "gemini-leaf".into(),
+            agent_type: "gemini".into(),
+            model: "gemini-1.5-pro".into(),
+            backend_type: Some("exomonad".into()),
+        };
+        let meta = recipient_meta_from_team_info(Some(&info), false);
+        assert_eq!(meta.backend_type, BackendType::Exomonad);
+        assert_eq!(meta.agent_type, AgentType::Gemini);
+        assert_eq!(
+            delivery_plan(&meta),
+            vec![DeliveryChannel::Acp, DeliveryChannel::Tmux]
+        );
+    }
+
+    #[test]
+    fn test_tier2_ccnative_classified_as_ccnative() {
+        let info = TeamInfo {
+            team_name: "test-team".into(),
+            inbox_name: "gemini-native".into(),
+            agent_type: "gemini".into(),
+            model: "gemini-1.5-pro".into(),
+            backend_type: None,
+        };
+        let meta = recipient_meta_from_team_info(Some(&info), false);
+        assert_eq!(meta.backend_type, BackendType::CcNative);
+        assert!(delivery_plan(&meta).is_empty());
     }
 }


### PR DESCRIPTION
PR #878 updated to address Copilot review.

Changes:
- Thread `backend_type: Option<String>` through `TeamInfo` struct.
- Populate `backend_type` from `config.json` in `TeamRegistry::resolve_from_config`.
- Update the classifier in `recipient_meta_from_team_info` to respect `backend_type` for Tier 2 agents.
- Add unit tests verifying Tier 2 classification for both Exomonad and CcNative backends.
- Update all 40 `TeamInfo` literals across the codebase (including `tests/integration.rs`) with `backend_type: None`.

Verified with:
- `cargo test -p claude-teams-bridge --test integration`
- `cargo test -p exomonad-core --lib services::delivery`
- `cargo clippy --workspace -- -D warnings`