### PR TITLE
refactor: clean up SpawnResult and typed TmuxTarget

### DIFF
--- a/rust/exomonad-core/src/handlers/agent.rs
+++ b/rust/exomonad-core/src/handlers/agent.rs
@@ -12,7 +12,7 @@ use super::non_empty;
 use crate::services::agent_control::{
     AgentControlService, AgentInfo, AgentType as ServiceAgentType, ClaudeSpawnFlags,
     SpawnGeminiTeammateOptions, SpawnLeafOptions, SpawnOptions, SpawnSubtreeOptions,
-    SpawnWorkerOptions,
+    SpawnWorkerOptions, TmuxTarget,
 };
 use crate::services::supervisor_registry::SupervisorEntry;
 use crate::{GithubOwner, GithubRepo, IssueNumber};
@@ -106,7 +106,7 @@ impl<
         member_name: &AgentName,
         agent_type: crate::services::agent_control::AgentType,
         kind: &str,
-        tmux_target: Option<&str>,
+        tmux_target: Option<&TmuxTarget>,
         ctx: &crate::effects::EffectContext,
     ) {
         let team_reg = self.ctx.team_registry();
@@ -127,7 +127,7 @@ impl<
             member_name,
             agent_type,
             kind,
-            tmux_target.unwrap_or(""),
+            tmux_target.map(|t| t.as_str()).unwrap_or(""),
         ) {
             warn!(
                 member = %member_name,
@@ -151,7 +151,7 @@ impl<
                     .watch_inbox(
                         team_name.as_str().to_string(),
                         member_name.as_str().to_string(),
-                        target.to_string(),
+                        target.as_str().to_string(),
                         self.ctx.tmux_ipc_arc().clone(),
                         self.ctx.project_dir().to_path_buf(),
                     )
@@ -458,7 +458,7 @@ impl<
             &identity.internal_name(),
             crate::services::agent_control::AgentType::Gemini,
             "gemini-worker",
-            result.tmux_target.as_deref(),
+            result.tmux_target.as_ref(),
             ctx,
         )
         .await;
@@ -560,7 +560,7 @@ impl<
             &child_identity.internal_name(),
             crate::services::agent_control::AgentType::Claude,
             "claude-subtree",
-            result.tmux_target.as_deref(),
+            result.tmux_target.as_ref(),
             ctx,
         )
         .await;
@@ -626,7 +626,7 @@ impl<
             &leaf_identity.internal_name(),
             crate::services::agent_control::AgentType::Gemini,
             "gemini-leaf",
-            result.tmux_target.as_deref(),
+            result.tmux_target.as_ref(),
             ctx,
         )
         .await;
@@ -954,7 +954,7 @@ fn spawn_result_to_proto(
     exomonad_proto::effects::agent::AgentInfo {
         id: format!("{}-{}", issue, result.agent_type.suffix()),
         issue: issue.to_string(),
-        worktree_path: result.agent_dir.display().to_string(),
+        worktree_path: result.agent_dir.as_ref().map(|p| p.display().to_string()).unwrap_or_default(),
         branch_name: String::new(),
         agent_type: service_agent_type_to_proto(result.agent_type),
         role: 0,
@@ -976,7 +976,7 @@ fn teammate_result_to_proto(
     exomonad_proto::effects::agent::AgentInfo {
         id: result.agent_name.to_string(),
         issue: String::new(),
-        worktree_path: String::new(),
+        worktree_path: result.agent_dir.as_ref().map(|p| p.display().to_string()).unwrap_or_default(),
         branch_name: String::new(),
         agent_type: service_agent_type_to_proto(result.agent_type),
         role: 0,
@@ -998,7 +998,7 @@ fn worker_result_to_proto(
     exomonad_proto::effects::agent::AgentInfo {
         id: result.agent_name.to_string(),
         issue: String::new(),
-        worktree_path: String::new(),
+        worktree_path: result.agent_dir.as_ref().map(|p| p.display().to_string()).unwrap_or_default(),
         branch_name: String::new(),
         agent_type: AgentType::Gemini as i32,
         role: 0,
@@ -1025,7 +1025,7 @@ fn subtree_result_to_proto(
     exomonad_proto::effects::agent::AgentInfo {
         id: result.agent_name.to_string(),
         issue: String::new(),
-        worktree_path: result.agent_dir.display().to_string(),
+        worktree_path: result.agent_dir.as_ref().map(|p| p.display().to_string()).unwrap_or_default(),
         branch_name: full_branch,
         agent_type: service_agent_type_to_proto(result.agent_type),
         role: 0,
@@ -1052,7 +1052,7 @@ fn leaf_subtree_result_to_proto(
     exomonad_proto::effects::agent::AgentInfo {
         id: result.agent_name.to_string(),
         issue: String::new(),
-        worktree_path: result.agent_dir.display().to_string(),
+        worktree_path: result.agent_dir.as_ref().map(|p| p.display().to_string()).unwrap_or_default(),
         branch_name: full_branch,
         agent_type: service_agent_type_to_proto(result.agent_type),
         role: 0,

--- a/rust/exomonad-core/src/services/agent_control/mod.rs
+++ b/rust/exomonad-core/src/services/agent_control/mod.rs
@@ -414,11 +414,36 @@ pub struct SpawnLeafOptions {
     pub allowed_dirs: Vec<String>,
 }
 
+/// Target tmux surface for an agent.
+///
+/// We use a tagged enum here to preserve the distinction between panes and windows,
+/// which matches the underlying tmux object types while remaining serializable
+/// to a JSON shape similar to RoutingInfo.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum TmuxTarget {
+    /// Worker pane (%N format).
+    Pane(tmux_ipc::PaneId),
+    /// Subtree/leaf window (@N format).
+    Window(tmux_ipc::WindowId),
+}
+
+impl TmuxTarget {
+    /// Get the raw tmux identifier string.
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Pane(id) => id.as_str(),
+            Self::Window(id) => id.as_str(),
+        }
+    }
+}
+
 /// Result of spawning an agent.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SpawnResult {
-    /// Path to the agent directory (.exo/agents/{agent_id}/)
-    pub agent_dir: PathBuf,
+    /// Path to the agent directory (.exo/agents/{agent_id}/).
+    /// None for spawn variants that don't use a per-agent worktree (workers).
+    pub agent_dir: Option<PathBuf>,
     /// Agent's internal name (suffixed, e.g., "feature-a-claude").
     /// Typed as `AgentName` to prevent confusion with bare slugs.
     pub agent_name: AgentName,
@@ -434,7 +459,7 @@ pub struct SpawnResult {
     /// spawn, None on idempotent returns (registration already done) and ACP
     /// (no tmux surface).
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub tmux_target: Option<String>,
+    pub tmux_target: Option<TmuxTarget>,
 }
 
 impl FFIBoundary for SpawnResult {}

--- a/rust/exomonad-core/src/services/agent_control/spawn.rs
+++ b/rust/exomonad-core/src/services/agent_control/spawn.rs
@@ -63,7 +63,7 @@ impl<
             if self.is_tmux_window_alive(&display_name).await {
                 info!(issue_id, "Agent already running, returning existing");
                 return Ok(SpawnResult {
-                    agent_dir: self.worktree_base.join(agent_name.as_str()),
+                    agent_dir: Some(self.worktree_base.join(agent_name.as_str())),
                     agent_name,
                     issue_title: issue.title,
                     agent_type: options.agent_type,
@@ -181,12 +181,12 @@ impl<
             rollback.disarm();
 
             Ok::<SpawnResult, anyhow::Error>(SpawnResult {
-                agent_dir: agent_dir.clone(),
+                agent_dir: Some(agent_dir.clone()),
                 agent_name,
                 issue_title: issue.title,
                 agent_type: options.agent_type,
                 branch_name: Some(branch_name),
-                tmux_target: Some(window_id.to_string()),
+                tmux_target: Some(TmuxTarget::Window(window_id.clone())),
             })
         })
         .await
@@ -274,7 +274,7 @@ impl<
             if tab_alive {
                 info!(name = %options.name, "Teammate already running, returning existing");
                 return Ok(SpawnResult {
-                    agent_dir: PathBuf::new(),
+                    agent_dir: None,
                     agent_name,
                     issue_title: options.name.to_string(),
                     agent_type: options.agent_type,
@@ -375,12 +375,12 @@ impl<
             rollback.disarm();
 
             Ok::<SpawnResult, anyhow::Error>(SpawnResult {
-                agent_dir: PathBuf::new(),
+                agent_dir: None,
                 agent_name,
                 issue_title: options.name.to_string(),
                 agent_type: options.agent_type,
                 branch_name: Some(branch_name),
-                tmux_target: Some(window_id.to_string()),
+                tmux_target: Some(TmuxTarget::Window(window_id.clone())),
             })
         })
         .await
@@ -520,7 +520,7 @@ impl<
                 if pane_alive {
                     info!(name = %options.name, "Worker pane still alive, returning existing");
                     return Ok(SpawnResult {
-                        agent_dir: PathBuf::new(),
+                        agent_dir: None,
                         agent_name,
                         issue_title: options.name.to_string(),
                         agent_type: AgentType::Gemini,
@@ -617,12 +617,12 @@ impl<
             rollback.disarm();
 
             Ok::<SpawnResult, anyhow::Error>(SpawnResult {
-                agent_dir: PathBuf::new(),
+                agent_dir: None,
                 agent_name,
                 issue_title: options.name.to_string(),
                 agent_type: AgentType::Gemini,
                 branch_name: None,
-                tmux_target: Some(pane_id.to_string()),
+                tmux_target: Some(TmuxTarget::Pane(pane_id.clone())),
             })
         })
         .await
@@ -672,7 +672,7 @@ impl<
             if tab_alive {
                 info!(slug = %identity.slug(), "Subtree already running, returning existing");
                 return Ok(SpawnResult {
-                    agent_dir: self.worktree_base.join(agent_name.as_str()),
+                    agent_dir: Some(self.worktree_base.join(agent_name.as_str())),
                     agent_name,
                     issue_title: options.branch_name.clone(),
                     agent_type,
@@ -852,12 +852,12 @@ impl<
             rollback.disarm();
 
             Ok::<SpawnResult, anyhow::Error>(SpawnResult {
-                agent_dir: worktree_path.clone(),
+                agent_dir: Some(worktree_path.clone()),
                 agent_name,
                 issue_title: options.branch_name.clone(),
                 agent_type,
                 branch_name: Some(full_branch),
-                tmux_target: Some(window_id.to_string()),
+                tmux_target: Some(TmuxTarget::Window(window_id.clone())),
             })
         })
         .await
@@ -904,7 +904,7 @@ impl<
             if tab_alive {
                 info!(slug = %identity.slug(), "Leaf subtree already running, returning existing");
                 return Ok(SpawnResult {
-                    agent_dir: self.worktree_base.join(agent_name.as_str()),
+                    agent_dir: Some(self.worktree_base.join(agent_name.as_str())),
                     agent_name,
                     issue_title: options.branch_name.clone(),
                     agent_type,
@@ -989,12 +989,12 @@ impl<
             rollback.disarm();
 
             Ok::<SpawnResult, anyhow::Error>(SpawnResult {
-                agent_dir: worktree_path.clone(),
+                agent_dir: Some(worktree_path.clone()),
                 agent_name,
                 issue_title: options.branch_name.clone(),
                 agent_type,
                 branch_name: Some(branch_name),
-                tmux_target: Some(window_id.to_string()),
+                tmux_target: Some(TmuxTarget::Window(window_id.clone())),
             })
         })
         .await


### PR DESCRIPTION
Clean up the `SpawnResult` struct to avoid `PathBuf::new()` footguns and preserve tmux target types.

### Changes:
- Introduced `TmuxTarget` enum to distinguish between `PaneId` and `WindowId`.
- Changed `SpawnResult.agent_dir` from `PathBuf` to `Option<PathBuf>`.
- Changed `SpawnResult.tmux_target` from `Option<String>` to `Option<TmuxTarget>`.
- Updated all 10 construction sites in `spawn.rs` to use the new types.
- Updated `handlers/agent.rs` to handle the new `SpawnResult` structure and propagate `TmuxTarget` to `InboxWatcher`.
- Updated proto helpers in `handlers/agent.rs` to handle `Option<PathBuf>` correctly (mapping to empty string if `None`).

Verified with `cargo check`, `cargo test`, and `cargo clippy`.