### PR TITLE
feat: replace spawn anyhow errors with structured SpawnError enum

### DIFF
--- a/haskell/wasm-guest/src/ExoMonad/Guest/Tools/Spawn.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Guest/Tools/Spawn.hs
@@ -82,6 +82,7 @@ import GHC.Generics (Generic)
 -- ============================================================================
 
 -- | Helper to convert EffectError to a human-readable message.
+-- Error codes are defined in Rust: SpawnError::code().
 spawnErrorMessage :: EffectError -> Text
 spawnErrorMessage (EffectError kind) = case kind of
   Just (EffectErrorKindCustom c) -> case customCode c of

--- a/rust/exomonad-core/src/handlers/agent.rs
+++ b/rust/exomonad-core/src/handlers/agent.rs
@@ -5,7 +5,6 @@
 use crate::domain::{AgentName, AgentPermissions, BirthBranch, ClaudeSessionUuid, TeamName};
 use crate::effects::{
     dispatch_agent_effect, AgentEffects, EffectError, EffectHandler, EffectResult, ResultExt,
-    ResultExtPreserve,
 };
 
 use super::non_empty;
@@ -337,7 +336,7 @@ impl<
             .service
             .spawn_agent(issue_number, &options, &ctx.birth_branch)
             .await
-            .effect_err_preserve("agent")?;
+            .map_err(|e| EffectError::custom(e.code(), e.to_string()))?;
 
         Ok(SpawnResponse {
             agent: Some(spawn_result_to_proto(&req.issue, &result)),
@@ -375,7 +374,7 @@ impl<
                 .await
             {
                 Ok(result) => agents.push(spawn_result_to_proto(issue, &result)),
-                Err(e) => errors.push(format!("Issue {}: {}", issue, e)),
+                Err(e) => errors.push(format!("Issue {}: [{}] {}", issue, e.code(), e)),
             }
         }
 
@@ -399,7 +398,7 @@ impl<
             .service
             .spawn_gemini_teammate(&options, &ctx.birth_branch)
             .await
-            .effect_err_preserve("agent")?;
+            .map_err(|e| EffectError::custom(e.code(), e.to_string()))?;
 
         Ok(SpawnGeminiTeammateResponse {
             agent: Some(teammate_result_to_proto(&req.name, &result)),
@@ -425,7 +424,7 @@ impl<
             .service
             .spawn_worker(&options, ctx)
             .await
-            .effect_err_preserve("agent")?;
+            .map_err(|e| EffectError::custom(e.code(), e.to_string()))?;
 
         let agent_info = worker_result_to_proto(&req.name, &result);
 
@@ -526,7 +525,7 @@ impl<
             .service
             .spawn_subtree(&options, &ctx.birth_branch)
             .await
-            .effect_err_preserve("agent")?;
+            .map_err(|e| EffectError::custom(e.code(), e.to_string()))?;
 
         let agent_info = subtree_result_to_proto(&req.branch_name, &result);
 
@@ -597,7 +596,7 @@ impl<
             .service
             .spawn_leaf_subtree(&options, &ctx.birth_branch)
             .await
-            .effect_err_preserve("agent")?;
+            .map_err(|e| EffectError::custom(e.code(), e.to_string()))?;
 
         let agent_info = leaf_subtree_result_to_proto(&req.branch_name, &result);
 

--- a/rust/exomonad-core/src/services/agent_control/error.rs
+++ b/rust/exomonad-core/src/services/agent_control/error.rs
@@ -1,0 +1,51 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum SpawnError {
+    #[error("branch already exists: {0}")]
+    BranchExists(String),
+    #[error("git worktree is locked: {0}")]
+    WorktreeLocked(String),
+    #[error("git lock file conflict (another git op in progress)")]
+    LockConflict,
+    #[error("push rejected (non-fast-forward, remote diverged)")]
+    PushRejected,
+    #[error("not running inside a tmux session")]
+    TmuxNotInSession,
+    #[error("spawn timed out after {seconds}s")]
+    Timeout { seconds: u64 },
+    #[error("depth limit reached (max {max}, current {current})")]
+    DepthLimit { max: u32, current: u32 },
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
+
+impl From<std::io::Error> for SpawnError {
+    fn from(err: std::io::Error) -> Self {
+        Self::Other(anyhow::Error::from(err))
+    }
+}
+
+impl From<serde_json::Error> for SpawnError {
+    fn from(err: serde_json::Error) -> Self {
+        Self::Other(anyhow::Error::from(err))
+    }
+}
+
+impl SpawnError {
+    /// Stable code for FFI cross-language matching.
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::BranchExists(_) => "worktree.branch_exists",
+            Self::WorktreeLocked(_) => "worktree.locked",
+            Self::LockConflict => "worktree.lock_conflict",
+            Self::PushRejected => "worktree.push_rejected",
+            Self::TmuxNotInSession => "tmux.not_in_session",
+            Self::Timeout { .. } => "spawn.timeout",
+            Self::DepthLimit { .. } => "spawn.depth_limit",
+            Self::Other(_) => "spawn.other",
+        }
+    }
+}
+
+pub type SpawnResult2<T> = std::result::Result<T, SpawnError>;

--- a/rust/exomonad-core/src/services/agent_control/internal.rs
+++ b/rust/exomonad-core/src/services/agent_control/internal.rs
@@ -107,6 +107,8 @@ impl Drop for SpawnRollback {
     }
 }
 
+use super::error::SpawnError;
+
 impl<
         C: super::super::HasGitHubClient
             + super::super::HasAcpRegistry
@@ -118,24 +120,24 @@ impl<
             + 'static,
     > AgentControlService<C>
 {
-    pub(crate) fn resolve_tmux_session(&self) -> Result<String> {
+    pub(crate) fn resolve_tmux_session(&self) -> Result<String, SpawnError> {
         self.tmux_session
             .clone()
-            .ok_or_else(|| anyhow!("No tmux session configured (call with_tmux_session)"))
+            .ok_or(SpawnError::TmuxNotInSession)
     }
 
     /// Get the direct tmux IPC client from context.
-    pub(crate) fn tmux(&self) -> Result<super::tmux_ipc::TmuxIpc> {
+    pub(crate) fn tmux(&self) -> Result<super::tmux_ipc::TmuxIpc, SpawnError> {
         let tmux = self.ctx.tmux_ipc().clone();
         let configured_session = self.resolve_tmux_session()?;
         let ctx_session = tmux.session_name();
 
         if configured_session != ctx_session {
-            anyhow::bail!(
+            return Err(anyhow!(
                 "Configured tmux session '{}' does not match context tmux session '{}'",
                 configured_session,
                 ctx_session
-            );
+            ).into());
         }
 
         Ok(tmux)
@@ -150,7 +152,7 @@ impl<
         worktree_path: &Path,
         branch_name: &BranchName,
         base_branch: &BranchName,
-    ) -> Result<()> {
+    ) -> Result<(), SpawnError> {
         if worktree_path.exists() {
             info!(path = %worktree_path.display(), "Removing existing workspace for idempotency");
             let git_wt = self.git_wt().clone();
@@ -188,8 +190,22 @@ impl<
         match result {
             Ok(Ok(())) => {}
             Ok(Err(e)) => {
-                return Err(anyhow::Error::from(EffectError::from(e)))
-                    .context("Failed to create git worktree")
+                match e {
+                    crate::services::git_worktree::WorktreeError::BranchExists { branch } => {
+                        return Err(SpawnError::BranchExists(branch));
+                    }
+                    crate::services::git_worktree::WorktreeError::LockFileConflict { .. } => {
+                        return Err(SpawnError::LockConflict);
+                    }
+                    crate::services::git_worktree::WorktreeError::PushRejected { .. } => {
+                        return Err(SpawnError::PushRejected);
+                    }
+                    _ => {
+                        return Err(anyhow::Error::from(EffectError::from(e)))
+                            .context("Failed to create git worktree")
+                            .map_err(SpawnError::Other);
+                    }
+                }
             }
             Err(panic_val) => {
                 let msg = panic_val
@@ -197,7 +213,7 @@ impl<
                     .map(|s| s.as_str())
                     .or_else(|| panic_val.downcast_ref::<&str>().copied())
                     .unwrap_or("unknown panic");
-                return Err(anyhow!("git worktree creation panicked: {}", msg));
+                return Err(anyhow!("git worktree creation panicked: {}", msg).into());
             }
         }
 
@@ -216,7 +232,7 @@ impl<
                 "Worktree branch mismatch: expected '{}', got {:?}",
                 expected,
                 actual
-            ));
+            ).into());
         }
 
         // Set upstream tracking by pushing the child branch to origin.

--- a/rust/exomonad-core/src/services/agent_control/mod.rs
+++ b/rust/exomonad-core/src/services/agent_control/mod.rs
@@ -6,10 +6,12 @@
 //! - ListAgents: Discover from tmux windows (source of truth for running agents)
 
 mod cleanup;
+pub mod error;
 mod internal;
 mod spawn;
 
 pub use cleanup::GcStats;
+pub use error::SpawnError;
 pub(crate) use internal::SpawnRollback;
 
 pub(crate) use crate::common::TimeoutError;

--- a/rust/exomonad-core/src/services/agent_control/spawn.rs
+++ b/rust/exomonad-core/src/services/agent_control/spawn.rs
@@ -1,4 +1,5 @@
 use super::*;
+use super::error::SpawnError;
 
 impl<
         C: super::super::HasGitHubClient
@@ -24,7 +25,7 @@ impl<
         issue_number: IssueNumber,
         options: &SpawnOptions,
         caller_bb: &BirthBranch,
-    ) -> Result<SpawnResult> {
+    ) -> Result<SpawnResult, SpawnError> {
         let issue_id_log = issue_number.as_u64().to_string();
         info!(issue_id = %issue_id_log, timeout_sec = SPAWN_TIMEOUT.as_secs(), "Starting spawn_agent");
 
@@ -180,7 +181,7 @@ impl<
 
             rollback.commit();
 
-            Ok::<SpawnResult, anyhow::Error>(SpawnResult {
+            Ok::<SpawnResult, SpawnError>(SpawnResult {
                 agent_dir: Some(agent_dir.clone()),
                 agent_name,
                 issue_title: issue.title,
@@ -191,9 +192,8 @@ impl<
         })
         .await
         .map_err(|_| {
-            let msg = format!("spawn_agent timed out after {}s", SPAWN_TIMEOUT.as_secs());
-            warn!(issue_id = %issue_id_log, error = %msg, "spawn_agent timed out");
-            anyhow::Error::new(TimeoutError { message: msg })
+            warn!(issue_id = %issue_id_log, timeout_sec = SPAWN_TIMEOUT.as_secs(), "spawn_agent timed out");
+            SpawnError::Timeout { seconds: SPAWN_TIMEOUT.as_secs() }
         })??;
 
         info!(issue_id = %issue_id_log, "spawn_agent completed successfully");
@@ -246,7 +246,7 @@ impl<
         &self,
         options: &SpawnGeminiTeammateOptions,
         caller_bb: &BirthBranch,
-    ) -> Result<SpawnResult> {
+    ) -> Result<SpawnResult, SpawnError> {
         info!(name = %options.name, timeout_sec = SPAWN_TIMEOUT.as_secs(), "Starting spawn_gemini_teammate");
 
         let result = timeout(SPAWN_TIMEOUT, async {
@@ -374,7 +374,7 @@ impl<
 
             rollback.commit();
 
-            Ok::<SpawnResult, anyhow::Error>(SpawnResult {
+            Ok::<SpawnResult, SpawnError>(SpawnResult {
                 agent_dir: None,
                 agent_name,
                 issue_title: options.name.to_string(),
@@ -385,12 +385,8 @@ impl<
         })
         .await
         .map_err(|_| {
-            let msg = format!(
-                "spawn_gemini_teammate timed out after {}s",
-                SPAWN_TIMEOUT.as_secs()
-            );
-            warn!(name = %options.name, error = %msg, "spawn_gemini_teammate timed out");
-            anyhow::Error::new(TimeoutError { message: msg })
+            warn!(name = %options.name, timeout_sec = SPAWN_TIMEOUT.as_secs(), "spawn_gemini_teammate timed out");
+            SpawnError::Timeout { seconds: SPAWN_TIMEOUT.as_secs() }
         })??;
 
         info!(name = %options.name, "spawn_gemini_teammate completed successfully");
@@ -489,7 +485,7 @@ impl<
         &self,
         options: &SpawnWorkerOptions,
         ctx: &crate::effects::EffectContext,
-    ) -> Result<SpawnResult> {
+    ) -> Result<SpawnResult, SpawnError> {
         info!(name = %options.name, timeout_sec = SPAWN_TIMEOUT.as_secs(), "Starting spawn_worker");
 
         let result = timeout(SPAWN_TIMEOUT, async {
@@ -615,7 +611,7 @@ impl<
 
             rollback.commit();
 
-            Ok::<SpawnResult, anyhow::Error>(SpawnResult {
+            Ok::<SpawnResult, SpawnError>(SpawnResult {
                 agent_dir: None,
                 agent_name,
                 issue_title: options.name.to_string(),
@@ -626,9 +622,8 @@ impl<
         })
         .await
         .map_err(|_| {
-            let msg = format!("spawn_worker timed out after {}s", SPAWN_TIMEOUT.as_secs());
-            warn!(name = %options.name, error = %msg, "spawn_worker timed out");
-            anyhow::Error::new(TimeoutError { message: msg })
+            warn!(name = %options.name, timeout_sec = SPAWN_TIMEOUT.as_secs(), "spawn_worker timed out");
+            SpawnError::Timeout { seconds: SPAWN_TIMEOUT.as_secs() }
         })??;
 
         info!(name = %options.name, "spawn_worker completed successfully");
@@ -641,7 +636,7 @@ impl<
         &self,
         options: &SpawnSubtreeOptions,
         caller_bb: &BirthBranch,
-    ) -> Result<SpawnResult> {
+    ) -> Result<SpawnResult, SpawnError> {
         info!(branch_name = %options.branch_name, timeout_sec = SPAWN_TIMEOUT.as_secs(), "Starting spawn_subtree");
 
         let result = timeout(SPAWN_TIMEOUT, async {
@@ -655,7 +650,7 @@ impl<
             let depth = effective_birth.depth();
 
             if depth >= 3 {
-                return Err(anyhow!("Subtree depth limit reached (max 3). Current birth-branch: {}, depth: {}", effective_birth, depth));
+                return Err(SpawnError::DepthLimit { max: 3, current: depth as u32 });
             }
 
             let effective_project_dir = self.project_dir();
@@ -829,7 +824,7 @@ impl<
 
             rollback.commit();
 
-            Ok::<SpawnResult, anyhow::Error>(SpawnResult {
+            Ok::<SpawnResult, SpawnError>(SpawnResult {
                 agent_dir: Some(worktree_path.clone()),
                 agent_name,
                 issue_title: options.branch_name.clone(),
@@ -840,9 +835,8 @@ impl<
         })
         .await
         .map_err(|_| {
-            let msg = format!("spawn_subtree timed out after {}s", SPAWN_TIMEOUT.as_secs());
-            warn!(branch_name = %options.branch_name, error = %msg, "spawn_subtree timed out");
-            anyhow::Error::new(TimeoutError { message: msg })
+            warn!(branch_name = %options.branch_name, timeout_sec = SPAWN_TIMEOUT.as_secs(), "spawn_subtree timed out");
+            SpawnError::Timeout { seconds: SPAWN_TIMEOUT.as_secs() }
         })??;
 
         info!(branch_name = %options.branch_name, "spawn_subtree completed successfully");
@@ -855,7 +849,7 @@ impl<
         &self,
         options: &SpawnLeafOptions,
         caller_bb: &BirthBranch,
-    ) -> Result<SpawnResult> {
+    ) -> Result<SpawnResult, SpawnError> {
         info!(branch_name = %options.branch_name, timeout_sec = SPAWN_TIMEOUT.as_secs(), "Starting spawn_leaf_subtree");
 
         let result = timeout(SPAWN_TIMEOUT, async {
@@ -966,7 +960,7 @@ impl<
 
             rollback.commit();
 
-            Ok::<SpawnResult, anyhow::Error>(SpawnResult {
+            Ok::<SpawnResult, SpawnError>(SpawnResult {
                 agent_dir: Some(worktree_path.clone()),
                 agent_name,
                 issue_title: options.branch_name.clone(),
@@ -977,9 +971,8 @@ impl<
         })
         .await
         .map_err(|_| {
-            let msg = format!("spawn_leaf_subtree timed out after {}s", SPAWN_TIMEOUT.as_secs());
-            warn!(branch_name = %options.branch_name, error = %msg, "spawn_leaf_subtree timed out");
-            anyhow::Error::new(TimeoutError { message: msg })
+            warn!(branch_name = %options.branch_name, timeout_sec = SPAWN_TIMEOUT.as_secs(), "spawn_leaf_subtree timed out");
+            SpawnError::Timeout { seconds: SPAWN_TIMEOUT.as_secs() }
         })??;
 
         info!(branch_name = %options.branch_name, "spawn_leaf_subtree completed successfully");


### PR DESCRIPTION
This PR replaces the generic `anyhow::Error` returns from the 5 core agent spawn functions with a structured `SpawnError` enum.

Key changes:
- Created `rust/exomonad-core/src/services/agent_control/error.rs` defining `SpawnError` with variants for branch exists, lock conflicts, push rejected, etc.
- Updated `spawn_agent`, `spawn_gemini_teammate`, `spawn_worker`, `spawn_subtree`, and `spawn_leaf_subtree` in `spawn.rs` to return `Result<_, SpawnError>`.
- Updated internal methods in `internal.rs` and `mod.rs` to propagate structured errors.
- Updated `handlers/agent.rs` to use `SpawnError::code()` when converting to `EffectError`, eliminating magic string matching.
- Added a documentation comment in `Spawn.hs` referencing the Rust-defined codes.

Verified with:
- `cargo build --workspace`
- `cargo test -p exomonad-core --no-run`
- `cargo clippy --workspace -- -D warnings`