### PR TITLE
feat: haskell-side slug validation for spawn tools

### DIFF
--- a/haskell/wasm-guest/src/ExoMonad/Guest/Tools/Spawn.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Guest/Tools/Spawn.hs
@@ -75,6 +75,7 @@ import ExoMonad.Guest.Tool.Class (MCPCallOutput (..), errorResult, successResult
 import ExoMonad.Guest.Tool.Schema (JsonSchema (..), genericToolSchemaWith)
 import ExoMonad.Guest.Tool.SuspendEffect (suspendEffect, suspendEffect_)
 import ExoMonad.Guest.Types (Effects)
+import ExoMonad.Guest.Types.Slug (Slug, mkSlug, unSlug)
 import GHC.Generics (Generic)
 
 -- ============================================================================
@@ -109,7 +110,7 @@ hasCustomCode _ _ = False
 data ForkWave
 
 data ForkWaveChild = ForkWaveChild
-  { fwcSlug :: Text,
+  { fwcSlug :: Slug,
     fwcTask :: Text,
     fwcForkSession :: Maybe Bool
   }
@@ -185,7 +186,7 @@ forkWaveCore args = do
             let cfg =
                   AC.SpawnSubtreeConfig
                     { AC.stcTask = fwcTask child,
-                      AC.stcBranchName = fwcSlug child,
+                      AC.stcBranchName = unSlug (fwcSlug child),
                       AC.stcForkSession = fromMaybe True (fwcForkSession child),
                       AC.stcRole = Nothing,
                       AC.stcAgentType = AC.Claude,
@@ -198,18 +199,21 @@ forkWaveCore args = do
             result <- AC.spawnSubtree cfg
             case result of
               Left err | hasCustomCode "worktree.branch_exists" err -> do
-                let retrySlug = fwcSlug child <> "-2"
-                let cfg' = cfg {AC.stcBranchName = retrySlug}
-                result' <- AC.spawnSubtree cfg'
-                case result' of
-                  Left err' -> pure (Left (spawnErrorMessage err'))
-                  Right spawnResult -> do
-                    emitSpawnEvent retrySlug "claude" (fwcTask child)
-                    pure (Right (retrySlug, spawnResult))
+                let retrySlugText = unSlug (fwcSlug child) <> "-2"
+                case mkSlug retrySlugText of
+                  Right retrySlug -> do
+                    let cfg' = cfg {AC.stcBranchName = unSlug retrySlug}
+                    result' <- AC.spawnSubtree cfg'
+                    case result' of
+                      Left err' -> pure (Left (spawnErrorMessage err'))
+                      Right spawnResult -> do
+                        emitSpawnEvent (unSlug retrySlug) "claude" (fwcTask child)
+                        pure (Right (unSlug retrySlug, spawnResult))
+                  Left errSlug -> pure (Left ("Invalid retry slug: " <> errSlug))
               Left err -> pure (Left (spawnErrorMessage err))
               Right spawnResult -> do
-                emitSpawnEvent (fwcSlug child) "claude" (fwcTask child)
-                pure (Right (fwcSlug child, spawnResult))
+                emitSpawnEvent (unSlug (fwcSlug child)) "claude" (fwcTask child)
+                pure (Right (unSlug (fwcSlug child), spawnResult))
 
           let (errs, successes) = partitionEithers results
           pure $
@@ -236,7 +240,7 @@ data SpawnLeafSubtree
 
 data SpawnLeafSubtreeArgs = SpawnLeafSubtreeArgs
   { slsTask :: Text,
-    slsBranchName :: Text,
+    slsBranchName :: Slug,
     slsPermissionMode :: Maybe Text,
     slsAllowedTools :: Maybe [Text],
     slsDisallowedTools :: Maybe [Text],
@@ -288,7 +292,7 @@ spawnLeafSubtreeCore args = do
       cfg =
         AC.SpawnLeafSubtreeConfig
           { AC.slcTask = renderedTask,
-            AC.slcBranchName = slsBranchName args,
+            AC.slcBranchName = unSlug (slsBranchName args),
             AC.slcRole = Nothing,
             AC.slcAgentType = AC.Gemini,
             AC.slcPerms = perms,
@@ -298,18 +302,21 @@ spawnLeafSubtreeCore args = do
   result <- AC.spawnLeafSubtree cfg
   case result of
     Left err | hasCustomCode "worktree.branch_exists" err -> do
-      let retrySlug = slsBranchName args <> "-2"
-      let cfg' = cfg {AC.slcBranchName = retrySlug}
-      result' <- AC.spawnLeafSubtree cfg'
-      case result' of
-        Left err' -> pure $ Left (spawnErrorMessage err')
-        Right spawnResult -> do
-          emitSpawnEvent retrySlug "gemini" (slsTask args)
-          pure $ Right (retrySlug, spawnResult)
+      let retrySlugText = unSlug (slsBranchName args) <> "-2"
+      case mkSlug retrySlugText of
+        Right retrySlug -> do
+          let cfg' = cfg {AC.slcBranchName = unSlug retrySlug}
+          result' <- AC.spawnLeafSubtree cfg'
+          case result' of
+            Left err' -> pure $ Left (spawnErrorMessage err')
+            Right spawnResult -> do
+              emitSpawnEvent (unSlug retrySlug) "gemini" (slsTask args)
+              pure $ Right (unSlug retrySlug, spawnResult)
+        Left errSlug -> pure $ Left ("Invalid retry slug: " <> errSlug)
     Left err -> pure $ Left (spawnErrorMessage err)
     Right spawnResult -> do
-      emitSpawnEvent (slsBranchName args) "gemini" (slsTask args)
-      pure $ Right (slsBranchName args, spawnResult)
+      emitSpawnEvent (unSlug (slsBranchName args)) "gemini" (slsTask args)
+      pure $ Right (unSlug (slsBranchName args), spawnResult)
 
 -- | Render a spawn leaf result to MCPCallOutput.
 spawnLeafRender :: Either Text (Text, AC.SpawnResult) -> MCPCallOutput
@@ -335,7 +342,7 @@ instance FromJSON WorkerType where
     t -> fail $ "Unknown worker type: " <> T.unpack t
 
 data WorkerSpec = WorkerSpec
-  { wsName :: Text,
+  { wsName :: Slug,
     wsTask :: Text,
     wsReadFirst :: Maybe [Text],
     wsSteps :: Maybe [Text],
@@ -434,13 +441,13 @@ spawnWorkersCore args = do
             }
         cfg =
           AC.SpawnWorkerConfig
-            { AC.swcName = wsName spec,
+            { AC.swcName = unSlug (wsName spec),
               AC.swcPrompt = prompt,
               AC.swcPerms = perms
             }
     r <- AC.spawnWorker cfg
     case r of
-      Right _ -> emitSpawnEvent (wsName spec) "gemini-worker" (wsTask spec)
+      Right _ -> emitSpawnEvent (unSlug (wsName spec)) "gemini-worker" (wsTask spec)
       Left _ -> pure ()
     pure r
   let (errs, successes) = partitionEithers results
@@ -458,7 +465,7 @@ spawnWorkersCore args = do
 data SpawnGemini
 
 data SpawnGeminiArgs = SpawnGeminiArgs
-  { sgName :: Text,
+  { sgName :: Slug,
     sgTask :: Text,
     sgReadFirst :: Maybe [Text],
     sgSteps :: Maybe [Text],
@@ -538,7 +545,7 @@ buildGeminiTask args =
 data SpawnWorkerTool
 
 data SpawnWorkerToolArgs = SpawnWorkerToolArgs
-  { swtName :: Text,
+  { swtName :: Slug,
     swtTask :: Text
   }
   deriving (Show, Eq, Generic)
@@ -589,7 +596,7 @@ spawnWorkerToolCore args = do
 data SpawnAcp
 
 data SpawnAcpArgs = SpawnAcpArgs
-  { saName :: Text,
+  { saName :: Slug,
     saPrompt :: Text,
     saPermissionMode :: Maybe Text,
     saAllowedTools :: Maybe [Text],
@@ -618,7 +625,7 @@ spawnAcpCore args = do
           }
       cfg =
         AC.SpawnAcpConfig
-          { AC.sacName = saName args,
+          { AC.sacName = unSlug (saName args),
             AC.sacPrompt = renderedPrompt,
             AC.sacPerms = perms
           }
@@ -626,7 +633,7 @@ spawnAcpCore args = do
   case result of
     Left err -> pure $ errorResult (spawnErrorMessage err)
     Right spawnResult -> do
-      emitSpawnEvent (saName args) "gemini-acp" (saName args)
+      emitSpawnEvent (unSlug (saName args)) "gemini-acp" (unSlug (saName args))
       pure $ successResult $ Aeson.toJSON spawnResult
 
 -- | Helper to emit 'agent.spawned' event to the host.

--- a/haskell/wasm-guest/src/ExoMonad/Guest/Types/Slug.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Guest/Types/Slug.hs
@@ -1,0 +1,32 @@
+module ExoMonad.Guest.Types.Slug (Slug, mkSlug, unSlug) where
+
+import Data.Aeson (FromJSON (..), ToJSON (..), object, withText, (.=))
+import Data.Char (isAsciiLower, isDigit)
+import Data.Text (Text)
+import qualified Data.Text as T
+import ExoMonad.Guest.Tool.Schema (JsonSchema (..))
+
+newtype Slug = Slug { unSlug :: Text }
+  deriving (Show, Eq)
+
+instance JsonSchema Slug where
+  toSchema = object ["type" .= ("string" :: Text)]
+
+-- | Smart constructor. Slugs are `[a-z0-9-]+` with no leading/trailing/double hyphens.
+mkSlug :: Text -> Either Text Slug
+mkSlug t
+  | T.null t = Left "slug cannot be empty"
+  | T.any (not . validChar) t = Left "slug must contain only [a-z0-9-]"
+  | T.head t == '-' = Left "slug cannot start with hyphen"
+  | T.last t == '-' = Left "slug cannot end with hyphen"
+  | T.isInfixOf "--" t = Left "slug cannot contain consecutive hyphens"
+  | otherwise = Right (Slug t)
+  where validChar c = isAsciiLower c || isDigit c || c == '-'
+
+instance FromJSON Slug where
+  parseJSON = withText "Slug" $ \t -> case mkSlug t of
+    Right s -> pure s
+    Left err -> fail (T.unpack err)
+
+instance ToJSON Slug where
+  toJSON = toJSON . unSlug

--- a/haskell/wasm-guest/wasm-guest.cabal
+++ b/haskell/wasm-guest/wasm-guest.cabal
@@ -109,6 +109,7 @@ library wasm-guest-internal
         -- Types
         ExoMonad.Guest.Types
         ExoMonad.Guest.Types.Permissions
+        ExoMonad.Guest.Types.Slug
         ExoMonad.Types
         -- Permissions
         ExoMonad.Permissions


### PR DESCRIPTION
This PR pushes slug validation to the Haskell WASM boundary. It introduces a `Slug` newtype in Haskell with a smart constructor that enforces `[a-z0-9-]+` constraints.

### Key Changes:
- New `ExoMonad.Guest.Types.Slug` module with validation logic.
- Updated `ForkWaveChild`, `SpawnLeafSubtreeArgs`, `WorkerSpec`, `SpawnGeminiArgs`, `SpawnWorkerToolArgs`, and `SpawnAcpArgs` to use `Slug` instead of `Text`.
- Updated retry logic in `forkWaveCore` and `spawnLeafSubtreeCore` to use `mkSlug`.
- Haskell now rejects malformed slugs at the JSON parsing boundary, allowing the Rust host to trust the inputs it receives.

Verified with `just wasm-all`.