### PR TITLE
feat: introduce SpawnableAgentType to eliminate unreachable panic paths in spawn.rs

### DIFF
--- a/rust/exomonad-core/src/handlers/agent.rs
+++ b/rust/exomonad-core/src/handlers/agent.rs
@@ -11,7 +11,7 @@ use super::non_empty;
 use crate::services::agent_control::{
     AgentControlService, AgentInfo, AgentType as ServiceAgentType, ClaudeSpawnFlags,
     SpawnGeminiTeammateOptions, SpawnLeafOptions, SpawnOptions, SpawnSubtreeOptions,
-    SpawnWorkerOptions, TmuxTarget,
+    SpawnableAgentType, SpawnWorkerOptions, TmuxTarget,
 };
 use crate::services::supervisor_registry::SupervisorEntry;
 use crate::{GithubOwner, GithubRepo, IssueNumber};
@@ -287,6 +287,16 @@ fn convert_agent_type(t: AgentType) -> EffectResult<ServiceAgentType> {
     }
 }
 
+fn convert_spawnable_agent_type(t: AgentType) -> EffectResult<SpawnableAgentType> {
+    let agent_type = convert_agent_type(t)?;
+    SpawnableAgentType::try_from(agent_type).map_err(|_| {
+        EffectError::custom(
+            "agent.not_spawnable",
+            "Process agents cannot be spawned via effects",
+        )
+    })
+}
+
 fn parse_issue_number(issue: &str) -> EffectResult<IssueNumber> {
     let n: u64 = issue
         .parse()
@@ -327,7 +337,7 @@ impl<
         let options = SpawnOptions {
             owner: parse_owner(&req.owner)?,
             repo: parse_repo(&req.repo)?,
-            agent_type: convert_agent_type(req.agent_type())?,
+            agent_type: convert_spawnable_agent_type(req.agent_type())?,
             subrepo: non_empty(req.subrepo).map(PathBuf::from),
             base_branch: non_empty(req.base_branch).map(|s| BirthBranch::from(s.as_str())),
         };
@@ -348,7 +358,7 @@ impl<
         req: SpawnBatchRequest,
         ctx: &crate::effects::EffectContext,
     ) -> EffectResult<SpawnBatchResponse> {
-        let agent_type = convert_agent_type(req.agent_type())?;
+        let agent_type = convert_spawnable_agent_type(req.agent_type())?;
         let mut agents = Vec::new();
         let mut errors = Vec::new();
 
@@ -389,7 +399,7 @@ impl<
         let options = SpawnGeminiTeammateOptions {
             name: AgentName::from(req.name.as_str()),
             prompt: req.prompt.clone(),
-            agent_type: convert_agent_type(req.agent_type())?,
+            agent_type: convert_spawnable_agent_type(req.agent_type())?,
             subrepo: non_empty(req.subrepo).map(PathBuf::from),
             base_branch: non_empty(req.base_branch).map(|s| BirthBranch::from(s.as_str())),
         };
@@ -505,7 +515,7 @@ impl<
             branch_name: req.branch_name.clone(),
             parent_session_id,
             role: non_empty(req.role.clone()).map(crate::domain::Role::new),
-            agent_type: convert_agent_type(req.agent_type())?,
+            agent_type: convert_spawnable_agent_type(req.agent_type())?,
             claude_flags: claude_spawn_flags(
                 req.permission_mode.clone(),
                 req.allowed_tools.clone(),
@@ -582,7 +592,7 @@ impl<
             task: req.task.clone(),
             branch_name: req.branch_name.clone(),
             role: non_empty(req.role.clone()).map(crate::domain::Role::new),
-            agent_type: convert_agent_type(req.agent_type())?,
+            agent_type: convert_spawnable_agent_type(req.agent_type())?,
             claude_flags: claude_spawn_flags(
                 req.permission_mode.clone(),
                 req.allowed_tools.clone(),

--- a/rust/exomonad-core/src/services/agent_control/mod.rs
+++ b/rust/exomonad-core/src/services/agent_control/mod.rs
@@ -134,6 +134,36 @@ impl AgentIdentity {
     }
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum SpawnableAgentType {
+    Claude,
+    Gemini,
+    Shoal,
+}
+
+impl TryFrom<AgentType> for SpawnableAgentType {
+    type Error = AgentType;
+    fn try_from(t: AgentType) -> Result<Self, AgentType> {
+        match t {
+            AgentType::Claude => Ok(Self::Claude),
+            AgentType::Gemini => Ok(Self::Gemini),
+            AgentType::Shoal => Ok(Self::Shoal),
+            AgentType::Process => Err(t),
+        }
+    }
+}
+
+impl From<SpawnableAgentType> for AgentType {
+    fn from(t: SpawnableAgentType) -> Self {
+        match t {
+            SpawnableAgentType::Claude => Self::Claude,
+            SpawnableAgentType::Gemini => Self::Gemini,
+            SpawnableAgentType::Shoal => Self::Shoal,
+        }
+    }
+}
+
 /// Agent type for spawned agents.
 ///
 /// Determines which CLI tool to use when spawning an agent in a tmux window.
@@ -322,13 +352,17 @@ pub struct SpawnOptions {
     /// GitHub repository name
     pub repo: GithubRepo,
     /// Agent type (Claude or Gemini)
-    #[serde(default)]
-    pub agent_type: AgentType,
+    #[serde(default = "default_spawnable_agent_type")]
+    pub agent_type: SpawnableAgentType,
     /// Sub-repository path relative to project_dir (e.g., "urchin/").
     /// When set, the agent's project context targets this directory instead of project_dir.
     pub subrepo: Option<PathBuf>,
     /// Base branch to branch off of (default: "main").
     pub base_branch: Option<BirthBranch>,
+}
+
+fn default_spawnable_agent_type() -> SpawnableAgentType {
+    SpawnableAgentType::Gemini
 }
 
 /// Options for spawning a named teammate (no GitHub issue required).
@@ -339,8 +373,8 @@ pub struct SpawnGeminiTeammateOptions {
     /// Initial prompt/instructions
     pub prompt: String,
     /// Agent type (Claude or Gemini)
-    #[serde(default)]
-    pub agent_type: AgentType,
+    #[serde(default = "default_spawnable_agent_type")]
+    pub agent_type: SpawnableAgentType,
     /// Sub-repository path relative to project_dir
     pub subrepo: Option<PathBuf>,
     /// Base branch to branch off of (defaults to current branch).
@@ -382,7 +416,7 @@ pub struct SpawnSubtreeOptions {
     /// Optional role override.
     pub role: Option<crate::domain::Role>,
     /// Agent type (claude or gemini). Required — no default.
-    pub agent_type: AgentType,
+    pub agent_type: SpawnableAgentType,
     /// Claude-specific permission flags (ignored for Gemini).
     #[serde(default)]
     pub claude_flags: ClaudeSpawnFlags,
@@ -406,7 +440,7 @@ pub struct SpawnLeafOptions {
     /// Optional role override.
     pub role: Option<crate::domain::Role>,
     /// Agent type (claude or gemini). Required — no default.
-    pub agent_type: AgentType,
+    pub agent_type: SpawnableAgentType,
     /// Claude-specific permission flags (ignored for Gemini).
     #[serde(default)]
     pub claude_flags: ClaudeSpawnFlags,

--- a/rust/exomonad-core/src/services/agent_control/spawn.rs
+++ b/rust/exomonad-core/src/services/agent_control/spawn.rs
@@ -56,9 +56,9 @@ impl<
             // Generate slug and agent identity
             let slug = slugify(&issue.title);
             let identity =
-                AgentIdentity::new(format!("gh-{}-{}", issue_id, slug), options.agent_type);
+                AgentIdentity::new(format!("gh-{}-{}", issue_id, slug), options.agent_type.into());
             let agent_name = identity.internal_name();
-            let display_name = options.agent_type.display_name(&issue_id, &slug);
+            let display_name = AgentType::from(options.agent_type).display_name(&issue_id, &slug);
 
             // Idempotency check: if tmux window is alive, return existing info
             if self.is_tmux_window_alive(&display_name).await {
@@ -67,7 +67,7 @@ impl<
                     agent_dir: Some(self.worktree_base.join(agent_name.as_str())),
                     agent_name,
                     issue_title: issue.title,
-                    agent_type: options.agent_type,
+                    agent_type: options.agent_type.into(),
                     branch_name: None,
                     tmux_target: None,
                 });
@@ -80,7 +80,7 @@ impl<
                 .as_ref()
                 .map(|b| b.as_str().to_string())
                 .unwrap_or(default_base);
-            let agent_suffix = options.agent_type.suffix();
+            let agent_suffix = AgentType::from(options.agent_type).suffix();
             let branch_name = BranchName::from(
                 if self.birth_branch.depth() == 0 {
                     format!("gh-{}/{}-{}", issue_id, slug, agent_suffix)
@@ -103,15 +103,14 @@ impl<
 
             // Write .mcp.json for the agent
             let role = match options.agent_type {
-                AgentType::Claude => crate::domain::Role::tl(),
-                AgentType::Gemini => crate::domain::Role::dev(),
-                AgentType::Shoal => crate::domain::Role::shoal(),
-                AgentType::Process => unreachable!("Process agents are not spawned via effects"),
+                SpawnableAgentType::Claude => crate::domain::Role::tl(),
+                SpawnableAgentType::Gemini => crate::domain::Role::dev(),
+                SpawnableAgentType::Shoal => crate::domain::Role::shoal(),
             };
             self.write_agent_mcp_config(
                 &effective_project_dir,
                 &agent_dir,
-                options.agent_type,
+                options.agent_type.into(),
                 &role,
             )
             .await?;
@@ -150,7 +149,7 @@ impl<
                 .new_tmux_window(
                     &display_name,
                     &agent_dir,
-                    options.agent_type,
+                    options.agent_type.into(),
                     Some(prompt_path),
                     env_vars,
                 )
@@ -163,7 +162,7 @@ impl<
             let identity_record = AgentIdentityRecord {
                 agent_name: agent_name.clone(),
                 slug: Slug::from(identity.slug()),
-                agent_type: options.agent_type,
+                agent_type: options.agent_type.into(),
                 birth_branch: BirthBranch::from(branch_name.as_str()),
                 parent_branch: effective_birth,
                 working_dir: agent_dir.clone(),
@@ -185,7 +184,7 @@ impl<
                 agent_dir: Some(agent_dir.clone()),
                 agent_name,
                 issue_title: issue.title,
-                agent_type: options.agent_type,
+                agent_type: options.agent_type.into(),
                 branch_name: Some(branch_name),
                 tmux_target: Some(TmuxTarget::Window(window_id.clone())),
             })
@@ -257,7 +256,7 @@ impl<
             let effective_project_dir = self.effective_project_dir(options.subrepo.as_deref())?;
 
             // Sanitize name and construct typed identity
-            let identity = AgentIdentity::new(slugify(options.name.as_str()), options.agent_type);
+            let identity = AgentIdentity::new(slugify(options.name.as_str()), options.agent_type.into());
             let agent_name = identity.internal_name();
             let display_name = identity.display_name();
 
@@ -277,7 +276,7 @@ impl<
                     agent_dir: None,
                     agent_name,
                     issue_title: options.name.to_string(),
-                    agent_type: options.agent_type,
+                    agent_type: options.agent_type.into(),
                     branch_name: None,
                     tmux_target: None,
                 });
@@ -317,13 +316,13 @@ impl<
             self.write_agent_mcp_config(
                 &effective_project_dir,
                 &worktree_path,
-                options.agent_type,
+                options.agent_type.into(),
                 &role,
             )
             .await?;
 
             // For Gemini agents, point at worktree settings via env var and pre-trust folder
-            if options.agent_type == AgentType::Gemini {
+            if options.agent_type == SpawnableAgentType::Gemini {
                 let settings_path = worktree_path.join(".gemini").join("settings.json");
                 env_vars.insert(
                     "GEMINI_CLI_SYSTEM_SETTINGS_PATH".to_string(),
@@ -342,7 +341,7 @@ impl<
                 .new_tmux_window(
                     &display_name,
                     &worktree_path,
-                    options.agent_type,
+                    options.agent_type.into(),
                     Some(prompt_path),
                     env_vars,
                 )
@@ -356,7 +355,7 @@ impl<
             let identity_record = AgentIdentityRecord {
                 agent_name: agent_name.clone(),
                 slug: Slug::from(identity.slug()),
-                agent_type: options.agent_type,
+                agent_type: options.agent_type.into(),
                 birth_branch: child_birth,
                 parent_branch: effective_birth,
                 working_dir: worktree_path.clone(),
@@ -378,7 +377,7 @@ impl<
                 agent_dir: None,
                 agent_name,
                 issue_title: options.name.to_string(),
-                agent_type: options.agent_type,
+                agent_type: options.agent_type.into(),
                 branch_name: Some(branch_name),
                 tmux_target: Some(TmuxTarget::Window(window_id.clone())),
             })
@@ -657,7 +656,7 @@ impl<
 
             // Sanitize branch name and construct typed identity
             let agent_type = options.agent_type;
-            let identity = AgentIdentity::new(slugify(&options.branch_name), agent_type);
+            let identity = AgentIdentity::new(slugify(&options.branch_name), agent_type.into());
             let agent_name = identity.internal_name();
             let display_name = identity.display_name();
 
@@ -669,7 +668,7 @@ impl<
                     agent_dir: Some(self.worktree_base.join(agent_name.as_str())),
                     agent_name,
                     issue_title: options.branch_name.clone(),
-                    agent_type,
+                    agent_type: agent_type.into(),
                     branch_name: None,
                     tmux_target: None,
                 });
@@ -734,8 +733,13 @@ impl<
                 "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS".to_string(),
                 "1".to_string(),
             );
-            self.write_agent_mcp_config(effective_project_dir, &worktree_path, agent_type, role)
-                .await?;
+            self.write_agent_mcp_config(
+                effective_project_dir,
+                &worktree_path,
+                agent_type.into(),
+                role,
+            )
+            .await?;
 
 
             // Write .claude/settings.local.json with hooks (SessionStart registers UUID for --fork-session)
@@ -795,7 +799,7 @@ impl<
             let window_id = self.new_tmux_window_inner(
                 &display_name,
                 &worktree_path,
-                agent_type,
+                agent_type.into(),
                 Some(prompt_path),
                 env_vars,
                 fork_id,
@@ -809,7 +813,7 @@ impl<
             let identity_record = AgentIdentityRecord {
                 agent_name: agent_name.clone(),
                 slug: Slug::from(identity.slug()),
-                agent_type,
+                agent_type: agent_type.into(),
                 birth_branch: child_birth,
                 parent_branch: effective_birth,
                 working_dir: worktree_path.clone(),
@@ -828,7 +832,7 @@ impl<
                 agent_dir: Some(worktree_path.clone()),
                 agent_name,
                 issue_title: options.branch_name.clone(),
-                agent_type,
+                agent_type: agent_type.into(),
                 branch_name: Some(full_branch),
                 tmux_target: Some(TmuxTarget::Window(window_id.clone())),
             })
@@ -867,7 +871,7 @@ impl<
 
             // Sanitize branch name and construct typed identity
             let agent_type = options.agent_type;
-            let identity = AgentIdentity::new(slugify(&options.branch_name), agent_type);
+            let identity = AgentIdentity::new(slugify(&options.branch_name), agent_type.into());
             let agent_name = identity.internal_name();
             let display_name = identity.display_name();
 
@@ -879,7 +883,7 @@ impl<
                     agent_dir: Some(self.worktree_base.join(agent_name.as_str())),
                     agent_name,
                     issue_title: options.branch_name.clone(),
-                    agent_type,
+                    agent_type: agent_type.into(),
                     branch_name: None,
                     tmux_target: None,
                 });
@@ -908,8 +912,13 @@ impl<
             let default_dev = crate::domain::Role::dev();
             let role = options.role.as_ref().unwrap_or(&default_dev);
             let mut env_vars = self.common_spawn_env(&agent_name, &branch_name, role);
-            self.write_agent_mcp_config(effective_project_dir, &worktree_path, agent_type, role)
-                .await?;
+            self.write_agent_mcp_config(
+                effective_project_dir,
+                &worktree_path,
+                agent_type.into(),
+                role,
+            )
+            .await?;
 
             // Set GEMINI_CLI_SYSTEM_SETTINGS_PATH and pre-trust folder
             let settings_path = worktree_path.join(".gemini").join("settings.json");
@@ -933,7 +942,7 @@ impl<
             let window_id = self.new_tmux_window(
                 &display_name,
                 &worktree_path,
-                agent_type,
+                agent_type.into(),
                 Some(prompt_path),
                 env_vars,
             )
@@ -945,7 +954,7 @@ impl<
             let identity_record = AgentIdentityRecord {
                 agent_name: agent_name.clone(),
                 slug: Slug::from(identity.slug()),
-                agent_type,
+                agent_type: agent_type.into(),
                 birth_branch: child_birth,
                 parent_branch: effective_birth,
                 working_dir: worktree_path.clone(),
@@ -964,7 +973,7 @@ impl<
                 agent_dir: Some(worktree_path.clone()),
                 agent_name,
                 issue_title: options.branch_name.clone(),
-                agent_type,
+                agent_type: agent_type.into(),
                 branch_name: Some(branch_name),
                 tmux_target: Some(TmuxTarget::Window(window_id.clone())),
             })
@@ -985,23 +994,23 @@ impl<
     /// and cause Claude Code to discover parent context files.
     async fn copy_role_context_into_worktree(
         &self,
-        agent_type: AgentType,
+        agent_type: SpawnableAgentType,
         role: &crate::domain::Role,
         worktree_path: &Path,
         src: &Path,
         wasm_name: &str,
     ) -> Result<(), std::io::Error> {
         let (dest_dir, dest_file) = match agent_type {
-            AgentType::Claude => (
+            SpawnableAgentType::Claude => (
                 worktree_path.join(".claude/rules"),
                 worktree_path.join(".claude/rules/exomonad_role.md"),
             ),
-            AgentType::Gemini => {
+            SpawnableAgentType::Gemini => {
                 let d = worktree_path.join(format!(".exo/roles/{}/context", wasm_name));
                 let f = d.join(format!("{}.md", role));
                 (d, f)
             }
-            AgentType::Shoal | AgentType::Process => return Ok(()),
+            SpawnableAgentType::Shoal => return Ok(()),
         };
 
         fs::create_dir_all(&dest_dir).await?;


### PR DESCRIPTION
Introduces a `SpawnableAgentType` boundary enum to eliminate `unreachable!` panics in `rust/exomonad-core/src/services/agent_control/spawn.rs` related to `AgentType::Process`.

Changes:
- Defined `SpawnableAgentType` in `services/agent_control/mod.rs` with `Claude`, `Gemini`, and `Shoal` variants.
- Implemented `TryFrom<AgentType>` and `From<SpawnableAgentType> for AgentType` for safe conversions.
- Updated `SpawnOptions`, `SpawnSubtreeOptions`, `SpawnLeafOptions`, and `SpawnGeminiTeammateOptions` to use `SpawnableAgentType`.
- Modified `handlers/agent.rs` to convert proto `AgentType` to `SpawnableAgentType` at the handler boundary, returning a custom `EffectError` for `Process` type.
- Updated `spawn.rs` to handle `SpawnableAgentType`, removing `unreachable!` match arms and using `.into()` to widen back to `AgentType` when needed.
- Updated `copy_role_context_into_worktree` to take `SpawnableAgentType` for exhaustive matching.

Verification:
- `cargo build --workspace` clean.
- `cargo test -p exomonad-core --lib` passed (585 tests).
- `cargo clippy --workspace -- -D warnings` clean.
- Grep verified no `unreachable!` or `AgentType::Process` remain in `spawn.rs`.