### PR TITLE
feat: delete dead SpawnAcp layer from Haskell WASM

### DIFF
--- a/.exo/roles/devswarm/TLRole.hs
+++ b/.exo/roles/devswarm/TLRole.hs
@@ -23,8 +23,7 @@ import ExoMonad.Guest.Tools.Spawn
   ( forkWaveCore, forkWaveDescription, forkWaveSchema, forkWaveRender, ForkWaveArgs (..), ForkWaveResult (..),
     spawnGeminiCore, spawnGeminiDescription, spawnGeminiSchema, SpawnGeminiArgs,
     spawnLeafRender,
-    spawnWorkerToolCore, spawnWorkerToolDescription, spawnWorkerToolSchema, SpawnWorkerToolArgs,
-    spawnAcpCore, SpawnAcpArgs
+    spawnWorkerToolCore, spawnWorkerToolDescription, spawnWorkerToolSchema, SpawnWorkerToolArgs
   )
 import ExoMonad.Guest.Effects.AgentControl (SpawnResult (..))
 import ExoMonad.Guest.Types (StopDecision(..), StopHookOutput(..), blockStopResponse, allowStopResponse, allowResponse, BeforeModelOutput (..), AfterModelOutput (..))

--- a/haskell/wasm-guest/src/ExoMonad/Effects/Agent.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Effects/Agent.hs
@@ -13,7 +13,6 @@ module ExoMonad.Effects.Agent
     AgentSpawnWorker,
     AgentSpawnSubtree,
     AgentSpawnLeafSubtree,
-    AgentSpawnAcp,
     AgentCleanup,
     AgentCleanupBatch,
     AgentCleanupMerged,
@@ -75,13 +74,6 @@ instance Effect AgentSpawnLeafSubtree where
   type Input AgentSpawnLeafSubtree = SpawnLeafSubtreeRequest
   type Output AgentSpawnLeafSubtree = SpawnLeafSubtreeResponse
   effectId = "agent.spawn_leaf_subtree"
-
-data AgentSpawnAcp
-
-instance Effect AgentSpawnAcp where
-  type Input AgentSpawnAcp = SpawnAcpRequest
-  type Output AgentSpawnAcp = SpawnAcpResponse
-  effectId = "agent.spawn_acp"
 
 data AgentCleanup
 

--- a/haskell/wasm-guest/src/ExoMonad/Guest/Effects/AgentControl.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Guest/Effects/AgentControl.hs
@@ -19,7 +19,6 @@ module ExoMonad.Guest.Effects.AgentControl
     spawnSubtree,
     spawnLeafSubtree,
     spawnWorker,
-    spawnAcp,
 
     -- * Interpreters
     runAgentControlSuspend,
@@ -32,7 +31,6 @@ module ExoMonad.Guest.Effects.AgentControl
     SpawnSubtreeConfig (..),
     SpawnLeafSubtreeConfig (..),
     SpawnWorkerConfig (..),
-    SpawnAcpConfig (..),
   )
 where
 
@@ -158,14 +156,6 @@ data SpawnWorkerConfig = SpawnWorkerConfig
   }
   deriving (Show, Eq, Generic)
 
--- | Configuration for spawning an ACP agent.
-data SpawnAcpConfig = SpawnAcpConfig
-  { sacName :: Text,
-    sacPrompt :: Text,
-    sacPerms :: PermissionFlags
-  }
-  deriving (Show, Eq, Generic)
-
 -- | Configuration for shutting down an agent by branch.
 data ShutdownByBranchConfig = ShutdownByBranchConfig
   { sbcBranchName :: Text,
@@ -184,7 +174,6 @@ data AgentControl a where
   SpawnSubtreeC :: SpawnSubtreeConfig -> AgentControl (Either EffectError SpawnResult)
   SpawnLeafSubtreeC :: SpawnLeafSubtreeConfig -> AgentControl (Either EffectError SpawnResult)
   SpawnWorkerC :: SpawnWorkerConfig -> AgentControl (Either EffectError SpawnResult)
-  SpawnAcpC :: SpawnAcpConfig -> AgentControl (Either EffectError SpawnResult)
   ShutdownByBranchC :: ShutdownByBranchConfig -> AgentControl (Either EffectError ShutdownByBranchResult)
 
 -- Smart constructors (manually written - makeSem doesn't work with WASM cross-compilation)
@@ -196,9 +185,6 @@ spawnLeafSubtree cfg = send (SpawnLeafSubtreeC cfg)
 
 spawnWorker :: (Member AgentControl r) => SpawnWorkerConfig -> Eff r (Either EffectError SpawnResult)
 spawnWorker cfg = send (SpawnWorkerC cfg)
-
-spawnAcp :: (Member AgentControl r) => SpawnAcpConfig -> Eff r (Either EffectError SpawnResult)
-spawnAcp cfg = send (SpawnAcpC cfg)
 
 shutdownByBranch :: (Member AgentControl r) => ShutdownByBranchConfig -> Eff r (Either EffectError ShutdownByBranchResult)
 shutdownByBranch cfg = send (ShutdownByBranchC cfg)
@@ -267,21 +253,6 @@ runAgentControlSuspend = interpret $ \case
       Left err -> Left err
       Right resp -> case PA.spawnWorkerResponseAgent resp of
         Nothing -> Left (EffectError (Just (EffectErrorKindInvalidInput (InvalidInput "SpawnWorker succeeded but no agent info returned"))))
-        Just info -> Right (protoAgentInfoToSpawnResult info)
-  SpawnAcpC cfg -> do
-    let req =
-          PA.SpawnAcpRequest
-            { PA.spawnAcpRequestName = fromText (sacName cfg),
-              PA.spawnAcpRequestPrompt = fromText (sacPrompt cfg),
-              PA.spawnAcpRequestPermissionMode = fromText (fromMaybe "" (permMode (sacPerms cfg))),
-              PA.spawnAcpRequestAllowedTools = V.fromList (map fromText (allowedTools (sacPerms cfg))),
-              PA.spawnAcpRequestDisallowedTools = V.fromList (map fromText (disallowedTools (sacPerms cfg)))
-            }
-    result <- suspendEffect @Agent.AgentSpawnAcp req
-    pure $ case result of
-      Left err -> Left err
-      Right resp -> case PA.spawnAcpResponseAgent resp of
-        Nothing -> Left (EffectError (Just (EffectErrorKindInvalidInput (InvalidInput "SpawnAcp succeeded but no agent info returned"))))
         Just info -> Right (protoAgentInfoToSpawnResult info)
   ShutdownByBranchC cfg -> do
     let req =

--- a/haskell/wasm-guest/src/ExoMonad/Guest/Records/Spawn.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Guest/Records/Spawn.hs
@@ -23,10 +23,6 @@ module ExoMonad.Guest.Records.Spawn
     spawnWorkersCore,
     spawnWorkersDescription,
     spawnWorkersSchema,
-
-    -- * SpawnAcp
-    SpawnAcpArgs (..),
-    spawnAcpCore,
   )
 where
 

--- a/haskell/wasm-guest/src/ExoMonad/Guest/Tools/Spawn.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Guest/Tools/Spawn.hs
@@ -9,7 +9,6 @@ module ExoMonad.Guest.Tools.Spawn
     SpawnWorkers,
     SpawnGemini,
     SpawnWorkerTool,
-    SpawnAcp,
 
     -- * Args types
     ForkWaveArgs (..),
@@ -20,7 +19,6 @@ module ExoMonad.Guest.Tools.Spawn
     SpawnWorkerToolArgs (..),
     WorkerSpec (..),
     WorkerType (..),
-    SpawnAcpArgs (..),
 
     -- * Core functions (role wrappers call these)
     forkWaveCore,
@@ -28,7 +26,6 @@ module ExoMonad.Guest.Tools.Spawn
     spawnWorkersCore,
     spawnGeminiCore,
     spawnWorkerToolCore,
-    spawnAcpCore,
 
     -- * Result types
     ForkWaveResult (..),
@@ -588,53 +585,6 @@ spawnWorkerToolCore args = do
             wsDisallowedTools = Nothing
           }
   spawnWorkersCore (SpawnWorkersArgs [spec])
-
--- ============================================================================
--- SpawnAcp (single ACP agent)
--- ============================================================================
-
-data SpawnAcp
-
-data SpawnAcpArgs = SpawnAcpArgs
-  { saName :: Slug,
-    saPrompt :: Text,
-    saPermissionMode :: Maybe Text,
-    saAllowedTools :: Maybe [Text],
-    saDisallowedTools :: Maybe [Text]
-  }
-  deriving (Show, Eq, Generic)
-
-instance FromJSON SpawnAcpArgs where
-  parseJSON = withObject "SpawnAcpArgs" $ \v ->
-    SpawnAcpArgs
-      <$> v .: "name"
-      <*> v .: "prompt"
-      <*> v .:? "permission_mode"
-      <*> v .:? "allowed_tools"
-      <*> v .:? "disallowed_tools"
-
--- | Core spawn_acp I/O.
-spawnAcpCore :: SpawnAcpArgs -> Eff Effects MCPCallOutput
-spawnAcpCore args = do
-  let renderedPrompt = saPrompt args <> "\n\n" <> workerProfileText
-      perms =
-        AC.PermissionFlags
-          { AC.permMode = saPermissionMode args,
-            AC.allowedTools = fromMaybe [] (saAllowedTools args),
-            AC.disallowedTools = fromMaybe [] (saDisallowedTools args)
-          }
-      cfg =
-        AC.SpawnAcpConfig
-          { AC.sacName = unSlug (saName args),
-            AC.sacPrompt = renderedPrompt,
-            AC.sacPerms = perms
-          }
-  result <- AC.spawnAcp cfg
-  case result of
-    Left err -> pure $ errorResult (spawnErrorMessage err)
-    Right spawnResult -> do
-      emitSpawnEvent (unSlug (saName args)) "gemini-acp" (unSlug (saName args))
-      pure $ successResult $ Aeson.toJSON spawnResult
 
 -- | Helper to emit 'agent.spawned' event to the host.
 emitSpawnEvent :: Text -> Text -> Text -> Eff Effects ()


### PR DESCRIPTION
This PR removes the dead `SpawnAcp` layer from the Haskell WASM codebase. 

`SpawnAcp` was unreachable as it was not registered in any role's tool record. 

Changes:
- Removed unused imports in `.exo/roles/devswarm/TLRole.hs`.
- Deleted `SpawnAcp`, `SpawnAcpArgs`, and `spawnAcpCore` from `haskell/wasm-guest/src/ExoMonad/Guest/Tools/Spawn.hs`.
- Deleted `AgentSpawnAcp` effect from `haskell/wasm-guest/src/ExoMonad/Effects/Agent.hs`.
- Deleted `spawnAcp` and `SpawnAcpConfig` from `haskell/wasm-guest/src/ExoMonad/Guest/Effects/AgentControl.hs`.
- Removed re-exports from `haskell/wasm-guest/src/ExoMonad/Guest/Records/Spawn.hs`.

Verified that:
- `cabal build all` and `just wasm-all` pass.
- No references to `SpawnAcp` or `spawnacp` remain in `haskell/wasm-guest`, `.exo/roles`, or `.exo/lib`.
- LANGUAGE pragmas remain intact.
- No trailing whitespace was added.