### PR TITLE
refactor(agent_control): consolidate teardown mechanics and fix shutdown leak

### DIFF
--- a/rust/exomonad-core/src/handlers/agent.rs
+++ b/rust/exomonad-core/src/handlers/agent.rs
@@ -843,6 +843,16 @@ impl<
         let record = if let Some(r) = resolver.find_by_birth_branch(&branch).await {
             r
         } else {
+            // Fallback for resolver miss: derive agent name from branch and attempt best-effort cleanup.
+            // Branch naming: {parent}.{slug}-{type} -> last segment is internal_name.
+            let agent_name = req.branch_name.split('.').last().unwrap_or(&req.branch_name);
+            info!(branch = %req.branch_name, derived_name = %agent_name, "Agent not found in resolver — falling back to name-derived cleanup");
+            
+            self.service
+                .cleanup_agent(agent_name, req.remove_worktree)
+                .await
+                .effect_err("agent")?;
+
             return Ok(ShutdownByBranchResponse { agent_found: false });
         };
 
@@ -1186,5 +1196,35 @@ mod tests {
 
         // Verify it was deregistered from resolver
         assert!(resolver.get(&agent_name).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_shutdown_by_branch_fallback_cleanup() {
+        let handler = test_handler();
+        let project_dir = handler.ctx.project_dir();
+
+        // Setup an agent directory that isn't in the resolver
+        let branch_name = "main.orphan-gemini";
+        let agent_name = "orphan-gemini";
+        let agent_dir = project_dir.join(".exo/agents").join(agent_name);
+        tokio::fs::create_dir_all(&agent_dir).await.unwrap();
+        assert!(agent_dir.exists());
+
+        let ctx = crate::effects::EffectContext {
+            agent_name: AgentName::from("test-agent"),
+            birth_branch: crate::domain::BirthBranch::from("main"),
+            working_dir: std::path::PathBuf::from("."),
+        };
+
+        let req = ShutdownByBranchRequest {
+            branch_name: branch_name.to_string(),
+            remove_worktree: false,
+        };
+
+        let resp = handler.shutdown_by_branch(req, &ctx).await.unwrap();
+        assert!(!resp.agent_found);
+
+        // Verify the directory was removed by the fallback cleanup
+        assert!(!agent_dir.exists());
     }
 }

--- a/rust/exomonad-core/src/services/agent_control/cleanup.rs
+++ b/rust/exomonad-core/src/services/agent_control/cleanup.rs
@@ -1,5 +1,8 @@
 use super::*;
 
+/// Orphan agent dirs with no routing.json older than this are pruned.
+const ORPHAN_GC_THRESHOLD: Duration = Duration::from_secs(3600);
+
 /// Statistics for stale agent garbage collection.
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct GcStats {
@@ -109,7 +112,7 @@ impl<
                             match meta.modified() {
                                 Ok(mtime) => {
                                     let elapsed = mtime.elapsed().unwrap_or(Duration::ZERO);
-                                    if elapsed >= Duration::from_secs(3600) {
+                                    if elapsed >= ORPHAN_GC_THRESHOLD {
                                         info!(path = %path.display(), age = ?elapsed, reason = "orphan (no routing.json) and old", "Pruning orphan agent directory");
                                         if let Err(e) = fs::remove_dir_all(&path).await {
                                             warn!(path = %path.display(), error = %e, "Failed to prune orphan agent directory");
@@ -228,26 +231,11 @@ impl<
         let mut target_closed = false;
         if let Ok(routing) = RoutingInfo::read_from_dir(&agent_config_dir).await {
             let tmux = self.tmux()?;
-            if let Some(wid) = routing.window_id {
-                match tmux.kill_window(&wid).await {
-                    Ok(()) => {
-                        info!(identifier, "Closed tmux window via stored window_id");
-                        target_closed = true;
-                    }
-                    Err(e) => {
-                        warn!(identifier, error = %e, "kill_window by stored ID failed, falling back to name match");
-                    }
-                }
-            } else if let Some(pid) = routing.pane_id {
-                match tmux.kill_pane(&pid).await {
-                    Ok(()) => {
-                        info!(identifier, "Closed tmux pane via stored pane_id");
-                        target_closed = true;
-                    }
-                    Err(e) => {
-                        warn!(identifier, error = %e, "kill_pane by stored ID failed");
-                    }
-                }
+            target_closed =
+                internal::kill_tmux_target(&tmux, routing.window_id.as_ref(), routing.pane_id.as_ref())
+                    .await;
+            if target_closed {
+                info!(identifier, "Closed tmux target via stored ID");
             }
         }
 
@@ -292,28 +280,7 @@ impl<
             };
             if worktree_path.exists() {
                 let git_wt = self.git_wt().clone();
-                let path = worktree_path.clone();
-                let join_result =
-                    tokio::task::spawn_blocking(move || git_wt.remove_workspace(&path)).await;
-                match join_result {
-                    Ok(Ok(())) => {
-                        // Successfully removed workspace
-                    }
-                    Ok(Err(e)) => {
-                        warn!(
-                            path = %worktree_path.display(),
-                            error = %e,
-                            "Failed to remove git worktree (non-fatal)"
-                        );
-                    }
-                    Err(join_err) => {
-                        warn!(
-                            path = %worktree_path.display(),
-                            error = %join_err,
-                            "Blocking task for git worktree removal panicked or was cancelled (non-fatal)"
-                        );
-                    }
-                }
+                internal::remove_worktree_best_effort(&git_wt, &worktree_path).await;
             }
         }
 

--- a/rust/exomonad-core/src/services/agent_control/internal.rs
+++ b/rust/exomonad-core/src/services/agent_control/internal.rs
@@ -83,15 +83,10 @@ impl Drop for SpawnRollback {
 
         if let Ok(handle) = tokio::runtime::Handle::try_current() {
             handle.spawn(async move {
-                if let Some(id) = window_id {
-                    let _ = tmux.kill_window(&id).await;
-                }
-                if let Some(id) = pane_id {
-                    let _ = tmux.kill_pane(&id).await;
-                }
+                kill_tmux_target(&tmux, window_id.as_ref(), pane_id.as_ref()).await;
+
                 if let Some(path) = wt_path {
-                    let _ =
-                        tokio::task::spawn_blocking(move || git_wt.remove_workspace(&path)).await;
+                    remove_worktree_best_effort(&git_wt, &path).await;
                 }
                 if let Some(p) = prompt {
                     let _ = tokio::fs::remove_file(p).await;
@@ -103,6 +98,64 @@ impl Drop for SpawnRollback {
             });
         } else {
             tracing::error!("SpawnRollback: no tokio runtime available for cleanup");
+        }
+    }
+}
+
+/// Kill a tmux window or pane by ID.
+pub(crate) async fn kill_tmux_target(
+    tmux: &super::tmux_ipc::TmuxIpc,
+    window_id: Option<&super::tmux_ipc::WindowId>,
+    pane_id: Option<&super::tmux_ipc::PaneId>,
+) -> bool {
+    if let Some(wid) = window_id {
+        match tmux.kill_window(wid).await {
+            Ok(()) => true,
+            Err(e) => {
+                warn!(error = %e, "kill_window by stored ID failed");
+                false
+            }
+        }
+    } else if let Some(pid) = pane_id {
+        match tmux.kill_pane(pid).await {
+            Ok(()) => true,
+            Err(e) => {
+                warn!(error = %e, "kill_pane by stored ID failed");
+                false
+            }
+        }
+    } else {
+        false
+    }
+}
+
+/// Remove a git worktree, logging any errors but continuing (best effort).
+pub(crate) async fn remove_worktree_best_effort(
+    git_wt: &std::sync::Arc<GitWorktreeService>,
+    path: &std::path::Path,
+) {
+    let path_buf = path.to_path_buf();
+    let git_wt = git_wt.clone();
+    let path_for_blocking = path_buf.clone();
+    let join_result =
+        tokio::task::spawn_blocking(move || git_wt.remove_workspace(&path_for_blocking)).await;
+    match join_result {
+        Ok(Ok(())) => {
+            // Successfully removed workspace
+        }
+        Ok(Err(e)) => {
+            warn!(
+                path = %path_buf.display(),
+                error = %e,
+                "Failed to remove git worktree (non-fatal)"
+            );
+        }
+        Err(join_err) => {
+            warn!(
+                path = %path_buf.display(),
+                error = %join_err,
+                "Blocking task for git worktree removal panicked or was cancelled (non-fatal)"
+            );
         }
     }
 }
@@ -155,16 +208,7 @@ impl<
         if worktree_path.exists() {
             info!(path = %worktree_path.display(), "Removing existing workspace for idempotency");
             let git_wt = self.git_wt().clone();
-            let path = worktree_path.to_path_buf();
-            match tokio::task::spawn_blocking(move || git_wt.remove_workspace(&path)).await {
-                Err(join_err) => {
-                    warn!(error = %join_err, "Join error while removing existing workspace (non-fatal)");
-                }
-                Ok(Err(e)) => {
-                    warn!(error = %e, "Failed to remove existing workspace (non-fatal)");
-                }
-                Ok(Ok(_)) => {}
-            }
+            remove_worktree_best_effort(&git_wt, worktree_path).await;
         }
 
         info!(


### PR DESCRIPTION
Consolidated teardown mechanics in `agent_control` and fixed a worktree/registry leak in `shutdown_by_branch`.

### Changes
1. **Bug Fix**: In `shutdown_by_branch`, if the agent is not found in the resolver, we now derive the agent's internal name from the branch name and call `cleanup_agent` to ensure any remaining resources (worktree, tmux, config dir) are cleaned up.
2. **Refactor**: Extracted two free-function helpers in `internal.rs`:
   - `kill_tmux_target`: Consolidates tmux window/pane killing logic with shared logging.
   - `remove_worktree_best_effort`: Consolidates `spawn_blocking` worktree removal with shared error handling.
3. **Rewiring**: Updated `SpawnRollback`, `cleanup_agent`, and `create_worktree_checked` to use these helpers, ensuring consistent teardown mechanics across the codebase.
4. **Threshold Constant**: Added `ORPHAN_GC_THRESHOLD` in `cleanup.rs` for orphan agent GC.

### Verification
- `cargo build --workspace` successful.
- `cargo test --workspace` successful (unit tests).
- Added `test_shutdown_by_branch_fallback_cleanup` in `handlers/agent.rs` to verify the fix.
- Verified no clippy warnings in `agent_control`.