### PR TITLE
chore: remove unused dependencies and dead tracked_retry method

### DIFF
--- a/rust/exomonad-core/Cargo.toml
+++ b/rust/exomonad-core/Cargo.toml
@@ -14,7 +14,6 @@ default = ["runtime"]
 runtime = [
     "dep:async-trait",
     "dep:anyhow",
-    "dep:libc",
     "dep:clap",
     "dep:duct",
     "dep:prost",
@@ -56,7 +55,6 @@ tempfile = { workspace = true }
 # Runtime feature: workspace deps
 async-trait = { workspace = true, optional = true }
 anyhow = { workspace = true, optional = true }
-libc = { version = "0.2", optional = true }
 clap = { workspace = true, optional = true }
 duct = { workspace = true, optional = true }
 futures-util = { workspace = true, optional = true }

--- a/rust/exomonad-core/src/services/github.rs
+++ b/rust/exomonad-core/src/services/github.rs
@@ -480,8 +480,6 @@ impl GitHubService {
     }
 
     /// Execute a GitHub API call with automatic success/failure tracking.
-    ///
-    /// For retried calls, use `tracked_retry` instead.
     async fn tracked<T, F, Fut>(&self, f: F) -> Result<T>
     where
         F: FnOnce(Octocrab) -> Fut,
@@ -489,26 +487,6 @@ impl GitHubService {
     {
         let client = self.github.get().await?;
         let result = f(client).await;
-        match &result {
-            Ok(_) => self.github.report_success(),
-            Err(_) => self.github.report_failure().await,
-        }
-        result
-    }
-
-    /// Execute a GitHub API call with retry and automatic success/failure tracking.
-    #[allow(dead_code)]
-    async fn tracked_retry<T, F, Fut>(
-        &self,
-        policy: &super::resilience::RetryPolicy,
-        f: F,
-    ) -> Result<T>
-    where
-        F: Fn(Octocrab) -> Fut,
-        Fut: std::future::Future<Output = Result<T>>,
-    {
-        let client = self.github.get().await?;
-        let result = super::resilience::retry(policy, || f(client.clone())).await;
         match &result {
             Ok(_) => self.github.report_success(),
             Err(_) => self.github.report_failure().await,

--- a/rust/exomonad/Cargo.toml
+++ b/rust/exomonad/Cargo.toml
@@ -26,9 +26,7 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 tracing-appender = { workspace = true }
-chrono = { workspace = true }
 anyhow = { workspace = true }
-thiserror = { workspace = true }
 toml = "0.8"
 uuid = { workspace = true }
 urlencoding = "2"
@@ -45,7 +43,6 @@ tracing-opentelemetry = { workspace = true }
 hyper = { workspace = true }
 hyper-util = { workspace = true }
 http-body-util = { workspace = true }
-futures-util = { workspace = true }
 nix = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
This PR performs a minor cleanup of the Rust codebase:
- Removes unused dependencies from `rust/exomonad/Cargo.toml`: `chrono`, `thiserror`, and `futures-util`.
- Removes unused dependency `libc` and its `runtime` feature entry from `rust/exomonad-core/Cargo.toml`.
- Deletes the dead `tracked_retry` method from `rust/exomonad-core/src/services/github.rs` and updates the doc comment for the `tracked` method.

Verified with `cargo build --workspace` and `cargo test --workspace`. `tracked_retry` is no longer present in `rust/exomonad-core/src`.