### PR TITLE
fix(merge_pr): make COMMENTED review state non-blocking

### DIFF
--- a/haskell/wasm-guest/src/ExoMonad/Guest/Tools/MergePR.hs
+++ b/haskell/wasm-guest/src/ExoMonad/Guest/Tools/MergePR.hs
@@ -229,13 +229,7 @@ checkCopilotReadinessFromPR prNum resp =
                           <> T.pack (show prNum)
                           <> ". Wait for the agent to push fixes ([FIXES PUSHED]) or use force=true."
                 Protobuf.Enumerated (Right GH.ReviewStateREVIEW_STATE_COMMENTED) ->
-                  if headSha /= reviewSha && not (T.null headSha) && not (T.null reviewSha)
-                    then Ready
-                    else
-                      NotReady $
-                        "Copilot commented on PR #"
-                          <> T.pack (show prNum)
-                          <> ". Wait for the agent to address comments ([FIXES PUSHED]) or use force=true."
+                  Ready
                 _ -> Ready
 
 -- | Check if a review is from Copilot (author login contains "copilot").


### PR DESCRIPTION
Currently, `merge_pr` blocks merges if Copilot has left a `COMMENTED` review unless a new commit was pushed. In GitHub's review model, `COMMENTED` reviews are non-blocking (unlike `CHANGES_REQUESTED`). Since Copilot often posts a summary comment on every PR, this check incorrectly blocks the normal workflow.

This PR changes the `COMMENTED` review state handling in `checkCopilotReadinessFromPR` to always return `Ready`, allowing merges to proceed when Copilot has only left comments.

Verified with `cabal build all` and `just wasm-all`.