### PR TITLE
feat: unify companion-worktree creation using GitWorktreeService

### DIFF
--- a/rust/exomonad-core/src/services/git_worktree.rs
+++ b/rust/exomonad-core/src/services/git_worktree.rs
@@ -99,6 +99,39 @@ impl GitWorktreeService {
         Ok(())
     }
 
+    /// Create a worktree, or attach to the branch if it already exists (idempotent reuse).
+    /// Used by `init` where companion branches persist across --recreate.
+    pub fn reuse_or_create_workspace(
+        &self,
+        path: &Path,
+        branch: &BranchName,
+        base: &BranchName,
+    ) -> Result<(), WorktreeError> {
+        match self.create_workspace(path, branch, base) {
+            Ok(()) => Ok(()),
+            Err(WorktreeError::BranchExists { .. }) => {
+                info!(path = %path.display(), branch = %branch, "Branch exists, attaching existing branch to worktree");
+                let output = std::process::Command::new("git")
+                    .args(["worktree", "add", &path.to_string_lossy(), branch.as_str()])
+                    .current_dir(&self.project_dir)
+                    .output()
+                    .map_err(|e| WorktreeError::GitError {
+                        message: format!("Failed to run git worktree add (reuse): {}", e),
+                    })?;
+
+                if !output.status.success() {
+                    let stderr = String::from_utf8_lossy(&output.stderr);
+                    error!(stderr = %stderr, "git worktree add (reuse) failed");
+                    return Err(self.parse_git_stderr(&stderr));
+                }
+
+                info!(path = %path.display(), branch = %branch, "Worktree attached successfully");
+                Ok(())
+            }
+            Err(e) => Err(e),
+        }
+    }
+
     /// Remove a git worktree.
     ///
     /// Equivalent to: `git worktree remove --force {path}`
@@ -593,6 +626,39 @@ mod tests {
 
         let actual = service.get_workspace_bookmark(&worktree_path).unwrap();
         assert_eq!(actual, Some(branch_name));
+    }
+
+    #[test]
+    fn test_reuse_or_create_workspace_idempotency() {
+        let (temp, service) = init_test_repo();
+        let default_branch = get_default_branch(temp.path());
+        let worktree_path = temp.path().join("wt-reuse");
+        let branch = BranchName::from("reuse-branch");
+        let base = BranchName::from(default_branch.as_str());
+
+        // First call creates it
+        service
+            .reuse_or_create_workspace(&worktree_path, &branch, &base)
+            .unwrap();
+        assert!(worktree_path.exists());
+        assert_eq!(
+            service.get_workspace_bookmark(&worktree_path).unwrap(),
+            Some("reuse-branch".to_string())
+        );
+
+        // Remove worktree but keep branch
+        service.remove_workspace(&worktree_path).unwrap();
+        assert!(!worktree_path.exists());
+
+        // Second call should reuse existing branch
+        service
+            .reuse_or_create_workspace(&worktree_path, &branch, &base)
+            .unwrap();
+        assert!(worktree_path.exists());
+        assert_eq!(
+            service.get_workspace_bookmark(&worktree_path).unwrap(),
+            Some("reuse-branch".to_string())
+        );
     }
 
     /// Resolution chain with agent-suffixed branch.

--- a/rust/exomonad-core/src/services/git_worktree.rs
+++ b/rust/exomonad-core/src/services/git_worktree.rs
@@ -101,12 +101,28 @@ impl GitWorktreeService {
 
     /// Create a worktree, or attach to the branch if it already exists (idempotent reuse).
     /// Used by `init` where companion branches persist across --recreate.
+    ///
+    /// If the path already exists, this method returns `Ok(())` if it is already
+    /// attached to the requested branch, otherwise it returns `WorktreeError::PathExists`.
     pub fn reuse_or_create_workspace(
         &self,
         path: &Path,
         branch: &BranchName,
         base: &BranchName,
     ) -> Result<(), WorktreeError> {
+        // If path exists, check if it's already the correct branch
+        if path.exists() {
+            if let Ok(Some(current)) = self.get_workspace_bookmark(path) {
+                if current == branch.as_str() {
+                    info!(path = %path.display(), branch = %branch, "Worktree path already exists and is on the correct branch");
+                    return Ok(());
+                }
+            }
+            return Err(WorktreeError::PathExists {
+                path: path.to_string_lossy().to_string(),
+            });
+        }
+
         match self.create_workspace(path, branch, base) {
             Ok(()) => Ok(()),
             Err(WorktreeError::BranchExists { .. }) => {
@@ -308,20 +324,35 @@ impl GitWorktreeService {
     fn parse_git_stderr(&self, stderr: &str) -> WorktreeError {
         if stderr.contains("already exists") {
             if stderr.contains("branch named") {
-                let branch = stderr.split('\'').nth(1).unwrap_or("unknown").to_string();
+                let branch = stderr
+                    .split('\'')
+                    .nth(1)
+                    .map(|s| s.to_string())
+                    .unwrap_or_else(|| "unknown".to_string());
                 WorktreeError::BranchExists { branch }
             } else {
-                let path = stderr
-                    .trim_start_matches("fatal: ")
-                    .trim_end_matches(" already exists")
-                    .to_string();
+                // Extracts '/path' from "... fatal: '/path' already exists"
+                let path = if let Some(pos) = stderr.rfind("fatal: '") {
+                    let start = pos + 8;
+                    if let Some(end) = stderr[start..].find('\'') {
+                        stderr[start..start + end].to_string()
+                    } else {
+                        stderr.trim().to_string()
+                    }
+                } else {
+                    stderr.trim().to_string()
+                };
                 WorktreeError::PathExists { path }
             }
         } else if stderr.contains("not a valid object")
             || stderr.contains("not a commit")
             || stderr.contains("invalid reference")
         {
-            let branch = stderr.split('\'').nth(1).unwrap_or("unknown").to_string();
+            let branch = stderr
+                .split('\'')
+                .nth(1)
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| "unknown".to_string());
             WorktreeError::BaseBranchNotFound { branch }
         } else if stderr.contains(".lock") {
             WorktreeError::LockFileConflict {
@@ -659,6 +690,30 @@ mod tests {
             service.get_workspace_bookmark(&worktree_path).unwrap(),
             Some("reuse-branch".to_string())
         );
+    }
+
+    #[test]
+    fn test_reuse_or_create_workspace_path_exists_idempotency() {
+        let (temp, service) = init_test_repo();
+        let default_branch = get_default_branch(temp.path());
+        let worktree_path = temp.path().join("wt-path-exists");
+        let branch = BranchName::from("reuse-branch");
+        let base = BranchName::from(default_branch.as_str());
+
+        // First call creates it
+        service
+            .reuse_or_create_workspace(&worktree_path, &branch, &base)
+            .unwrap();
+
+        // Second call with same path should succeed (idempotent)
+        service
+            .reuse_or_create_workspace(&worktree_path, &branch, &base)
+            .unwrap();
+
+        // Third call with different branch should fail with PathExists
+        let other_branch = BranchName::from("other-branch");
+        let result = service.reuse_or_create_workspace(&worktree_path, &other_branch, &base);
+        assert!(matches!(result, Err(WorktreeError::PathExists { .. })));
     }
 
     /// Resolution chain with agent-suffixed branch.

--- a/rust/exomonad/src/init.rs
+++ b/rust/exomonad/src/init.rs
@@ -145,17 +145,18 @@ pub async fn run(session_override: Option<String>, recreate: bool) -> Result<()>
     // Write root agent birth branch so fork_wave resolves the correct parent prefix.
     // Without this, BirthBranch::root() falls back to `git branch --show-current` in the
     // server process CWD, which may differ from the TL's actual branch.
+    let current_branch = std::process::Command::new("git")
+        .args(["branch", "--show-current"])
+        .current_dir(&cwd)
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_else(|| "main".to_string());
+
     {
         let root_agent_dir = cwd.join(".exo/agents/root");
         std::fs::create_dir_all(&root_agent_dir)?;
-        let current_branch = std::process::Command::new("git")
-            .args(["branch", "--show-current"])
-            .current_dir(&cwd)
-            .output()
-            .ok()
-            .filter(|o| o.status.success())
-            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
-            .unwrap_or_else(|| "main".to_string());
         std::fs::write(root_agent_dir.join(".birth_branch"), &current_branch)?;
         info!(branch = %current_branch, "Wrote root agent birth branch");
     }
@@ -254,6 +255,7 @@ pub async fn run(session_override: Option<String>, recreate: bool) -> Result<()>
     }
 
     // Validate tmux is available
+    // Pre-flight: validate tmux is installed.
     let tmux_check = std::process::Command::new("tmux").arg("-V").output();
     match tmux_check {
         Ok(output) if output.status.success() => {
@@ -365,6 +367,7 @@ pub async fn run(session_override: Option<String>, recreate: bool) -> Result<()>
     }
 
     // Set EXOMONAD_TMUX_SESSION
+    // One-time session bootstrap: set-environment/set-option/send-keys are not wrapped by TmuxIpc by design.
     let env_output = std::process::Command::new("tmux")
         .args([
             "set-environment",
@@ -483,16 +486,16 @@ pub async fn run(session_override: Option<String>, recreate: bool) -> Result<()>
     wait_for_server_socket(&cwd).await?;
 
     // GC stale agents before spawning companions
+    let git_wt = std::sync::Arc::new(exomonad_core::services::GitWorktreeService::new(cwd.clone()));
     {
         use exomonad_core::services::agent_control::AgentControlService;
-        use exomonad_core::services::{GitWorktreeService, ServicesBuilder};
+        use exomonad_core::services::ServicesBuilder;
         use std::sync::Arc;
 
-        let git_wt = Arc::new(GitWorktreeService::new(cwd.clone()));
         let services = ServicesBuilder::new(
             cwd.clone(),
             cwd.join(".exo/tasks"),
-            git_wt,
+            git_wt.clone(),
             Arc::new(ipc.clone()),
         )
         .build();
@@ -566,6 +569,7 @@ pub async fn run(session_override: Option<String>, recreate: bool) -> Result<()>
                     .unwrap_or(false);
 
                 if !head_valid {
+                    // Bootstrap: ensure HEAD exists so worktree creation has a base commit.
                     info!("No commits in repo, creating initial commit for worktree support");
                     let _ = std::process::Command::new("git")
                         .args(["commit", "--allow-empty", "-m", "initial commit"])
@@ -573,56 +577,18 @@ pub async fn run(session_override: Option<String>, recreate: bool) -> Result<()>
                         .output();
                 }
 
-                // Create worktree (reuse branch if it already exists)
-                let branch_exists = std::process::Command::new("git")
-                    .args(["rev-parse", "--verify", &branch_name])
-                    .current_dir(&cwd)
-                    .output()
-                    .map(|o| o.status.success())
-                    .unwrap_or(false);
-
                 std::fs::create_dir_all(cwd.join(".exo/companions"))?;
 
-                let worktree_result = if branch_exists {
-                    std::process::Command::new("git")
-                        .args(["worktree", "add"])
-                        .arg(&worktree_path)
-                        .arg(&branch_name)
-                        .current_dir(&cwd)
-                        .output()
-                } else {
-                    std::process::Command::new("git")
-                        .args(["worktree", "add", "-b", &branch_name])
-                        .arg(&worktree_path)
-                        .arg("HEAD")
-                        .current_dir(&cwd)
-                        .output()
-                };
-
-                match worktree_result {
-                    Ok(output) if output.status.success() => {
-                        info!(
-                            name = %companion.name,
-                            path = %worktree_path.display(),
-                            branch = %branch_name,
-                            "Created companion worktree"
-                        );
-                    }
-                    Ok(output) => {
-                        anyhow::bail!(
-                            "Failed to create worktree for companion '{}': {}",
-                            companion.name,
-                            String::from_utf8_lossy(&output.stderr)
-                        );
-                    }
-                    Err(e) => {
-                        anyhow::bail!(
-                            "Failed to run git worktree add for companion '{}': {}",
-                            companion.name,
-                            e
-                        );
-                    }
-                }
+                git_wt
+                    .reuse_or_create_workspace(
+                        &worktree_path,
+                        &exomonad_core::domain::BranchName::from(branch_name.as_str()),
+                        &exomonad_core::domain::BranchName::from(current_branch.as_str()),
+                    )
+                    .context(format!(
+                        "Failed to create worktree for companion '{}'",
+                        companion.name
+                    ))?;
             } else {
                 info!(
                     name = %companion.name,

--- a/rust/exomonad/src/init.rs
+++ b/rust/exomonad/src/init.rs
@@ -152,6 +152,7 @@ pub async fn run(session_override: Option<String>, recreate: bool) -> Result<()>
         .ok()
         .filter(|o| o.status.success())
         .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .filter(|s| !s.is_empty())
         .unwrap_or_else(|| "main".to_string());
 
     {


### PR DESCRIPTION
Unify companion-worktree creation in `exomonad init` to reuse `GitWorktreeService::reuse_or_create_workspace` instead of raw shell-outs. 

Updates based on Copilot review:
- Ensured `current_branch` is non-empty to avoid panic in `BranchName::from`.
- Made `reuse_or_create_workspace` fully idempotent by checking if an existing path is already attached to the correct branch.
- Improved `parse_git_stderr` robustness.
- Added test case for path-exists idempotency.
- Clarified docstrings.