### PR TITLE
feat: structured SpawnError variants for agent spawn path

### DIFF
--- a/rust/exomonad-core/src/services/agent_control/error.rs
+++ b/rust/exomonad-core/src/services/agent_control/error.rs
@@ -16,6 +16,18 @@ pub enum SpawnError {
     Timeout { seconds: u64 },
     #[error("depth limit reached (max {max}, current {current})")]
     DepthLimit { max: u32, current: u32 },
+    #[error("GitHub service not available (GITHUB_TOKEN not set)")]
+    GitHubUnavailable,
+    #[error("failed to write hook config in worktree: {reason}")]
+    HookConfigFailed { reason: String },
+    #[error("$HOME not set — cannot resolve Claude project dir for --fork-session")]
+    HomeDirNotSet,
+    #[error("git init failed at {path}: {stderr}")]
+    GitInitFailed { path: String, stderr: String },
+    #[error("invalid subrepo path: {reason}")]
+    InvalidSubrepoPath { reason: String },
+    #[error("path traversal detected in subrepo path: {path}")]
+    PathTraversal { path: String },
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }
@@ -43,6 +55,12 @@ impl SpawnError {
             Self::TmuxNotInSession => "tmux.not_in_session",
             Self::Timeout { .. } => "spawn.timeout",
             Self::DepthLimit { .. } => "spawn.depth_limit",
+            Self::GitHubUnavailable => "github_unavailable",
+            Self::HookConfigFailed { .. } => "hook_config_failed",
+            Self::HomeDirNotSet => "home_dir_not_set",
+            Self::GitInitFailed { .. } => "git_init_failed",
+            Self::InvalidSubrepoPath { .. } => "invalid_subrepo_path",
+            Self::PathTraversal { .. } => "path_traversal",
             Self::Other(_) => "spawn.other",
         }
     }

--- a/rust/exomonad-core/src/services/agent_control/error.rs
+++ b/rust/exomonad-core/src/services/agent_control/error.rs
@@ -55,12 +55,12 @@ impl SpawnError {
             Self::TmuxNotInSession => "tmux.not_in_session",
             Self::Timeout { .. } => "spawn.timeout",
             Self::DepthLimit { .. } => "spawn.depth_limit",
-            Self::GitHubUnavailable => "github_unavailable",
-            Self::HookConfigFailed { .. } => "hook_config_failed",
-            Self::HomeDirNotSet => "home_dir_not_set",
-            Self::GitInitFailed { .. } => "git_init_failed",
-            Self::InvalidSubrepoPath { .. } => "invalid_subrepo_path",
-            Self::PathTraversal { .. } => "path_traversal",
+            Self::GitHubUnavailable => "github.unavailable",
+            Self::HookConfigFailed { .. } => "spawn.hook_config_failed",
+            Self::HomeDirNotSet => "spawn.home_dir_not_set",
+            Self::GitInitFailed { .. } => "spawn.git_init_failed",
+            Self::InvalidSubrepoPath { .. } => "spawn.invalid_subrepo_path",
+            Self::PathTraversal { .. } => "spawn.path_traversal",
             Self::Other(_) => "spawn.other",
         }
     }

--- a/rust/exomonad-core/src/services/agent_control/mod.rs
+++ b/rust/exomonad-core/src/services/agent_control/mod.rs
@@ -727,7 +727,7 @@ impl<
     /// Initialize a standalone git repo at the given path.
     /// Creates the directory and runs `git init`, providing a .git boundary
     /// that prevents Claude's project discovery from traversing into the parent.
-    pub(crate) async fn init_standalone_repo(&self, path: &Path) -> Result<()> {
+    pub(crate) async fn init_standalone_repo(&self, path: &Path) -> Result<(), SpawnError> {
         tokio::fs::create_dir_all(path).await?;
         let output = tokio::process::Command::new("git")
             .args(["init"])
@@ -735,11 +735,10 @@ impl<
             .output()
             .await?;
         if !output.status.success() {
-            return Err(anyhow!(
-                "git init failed at {}: {}",
-                path.display(),
-                String::from_utf8_lossy(&output.stderr)
-            ));
+            return Err(SpawnError::GitInitFailed {
+                path: path.display().to_string(),
+                stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+            });
         }
         tracing::info!("Initialized standalone repo at {}", path.display());
         Ok(())
@@ -748,21 +747,19 @@ impl<
     /// Resolve effective project dir for git operations.
     /// When subrepo is set, git operations target project_dir/subrepo instead.
     /// Validates that subrepo is relative and does not escape project_dir.
-    pub(crate) fn effective_project_dir(&self, subrepo: Option<&Path>) -> Result<PathBuf> {
+    pub(crate) fn effective_project_dir(&self, subrepo: Option<&Path>) -> Result<PathBuf, SpawnError> {
         match subrepo {
             Some(sub_path) => {
                 if sub_path.is_absolute() {
-                    return Err(anyhow!(
-                        "subrepo path must be relative: {}",
-                        sub_path.display()
-                    ));
+                    return Err(SpawnError::InvalidSubrepoPath {
+                        reason: format!("subrepo path must be relative: {}", sub_path.display()),
+                    });
                 }
                 for component in sub_path.components() {
                     if matches!(component, std::path::Component::ParentDir) {
-                        return Err(anyhow!(
-                            "subrepo path cannot contain '..': {}",
-                            sub_path.display()
-                        ));
+                        return Err(SpawnError::PathTraversal {
+                            path: sub_path.display().to_string(),
+                        });
                     }
                 }
                 let dir = self.project_dir().join(sub_path);

--- a/rust/exomonad-core/src/services/agent_control/spawn.rs
+++ b/rust/exomonad-core/src/services/agent_control/spawn.rs
@@ -69,7 +69,7 @@ impl<
             // Get GitHub client
             let github_client = self
                 .github()
-                .ok_or_else(|| anyhow!("GitHub service not available (GITHUB_TOKEN not set)"))?;
+                .ok_or(SpawnError::GitHubUnavailable)?;
             let github = GitHubService::new(github_client.clone());
 
             // Fetch issue from GitHub
@@ -749,7 +749,7 @@ impl<
             // Write .claude/settings.local.json with hooks (SessionStart registers UUID for --fork-session)
             let binary_path = crate::util::find_exomonad_binary();
             crate::hooks::HookConfig::write_persistent(&worktree_path, &binary_path, options.permissions.as_ref(), Some(self.project_dir()))
-                .map_err(|e| anyhow!("Failed to write hook config in worktree: {}", e))?;
+                .map_err(|e| SpawnError::HookConfigFailed { reason: e.to_string() })?;
             info!(worktree = %worktree_path.display(), "Wrote hook configuration for spawned Claude agent");
 
             // Symlink Claude project dir so child can discover parent's sessions for --fork-session.
@@ -757,7 +757,7 @@ impl<
             // Without this symlink, --resume --fork-session fails with "no conversation ID found".
             {
                 let claude_projects_dir = dirs::home_dir()
-                    .ok_or_else(|| anyhow!("$HOME not set — cannot resolve Claude project dir for --fork-session"))?
+                    .ok_or(SpawnError::HomeDirNotSet)?
                     .join(".claude")
                     .join("projects");
                 let canonical_project_dir = self.project_dir().canonicalize().unwrap_or_else(|_| self.project_dir().to_path_buf());


### PR DESCRIPTION
This PR replaces generic `anyhow!` error escape-hatches in the agent spawn path with dedicated structured `SpawnError` variants. 

**Update (v2):** Added namespaces to new error codes (`github.`, `spawn.`) for consistency with existing `worktree.` and `tmux.` codes as requested in review.

The following variants were added to `SpawnError`:
- `GitHubUnavailable` (code: `github.unavailable`)
- `HookConfigFailed { reason: String }` (code: `spawn.hook_config_failed`)
- `HomeDirNotSet` (code: `spawn.home_dir_not_set`)
- `GitInitFailed { path: String, stderr: String }` (code: `spawn.git_init_failed`)
- `InvalidSubrepoPath { reason: String }` (code: `spawn.invalid_subrepo_path`)
- `PathTraversal { path: String }` (code: `spawn.path_traversal`)

These variants are now used in `agent_control/spawn.rs` and `agent_control/mod.rs` to provide more precise error information at the WASM FFI boundary.