### PR TITLE
feat: implement Fs, Process, Log, and Kv capabilities in exo-runtime

### DIFF
--- a/rust/exo-runtime/src/fs.rs
+++ b/rust/exo-runtime/src/fs.rs
@@ -11,11 +11,36 @@ use std::path::Path;
 
 #[async_trait]
 impl Fs for Runtime {
-    async fn read(&self, _path: &Path) -> Result<Vec<u8>, FsError> {
-        todo!("R3: tokio::fs::read(path), map io error to FsError::At with op=read")
+    async fn read(&self, path: &Path) -> Result<Vec<u8>, FsError> {
+        tokio::fs::read(path).await.map_err(|e| FsError::At {
+            op: "read",
+            path: path.display().to_string(),
+            source: e,
+        })
     }
 
-    async fn write_atomic(&self, _path: &Path, _bytes: &[u8]) -> Result<(), FsError> {
-        todo!("R3: write sibling temp then tokio::fs::rename over path (atomic replace)")
+    async fn write_atomic(&self, path: &Path, bytes: &[u8]) -> Result<(), FsError> {
+        let parent = path.parent().ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::InvalidInput, "path has no parent")
+        })?;
+        let file_name = path
+            .file_name()
+            .ok_or_else(|| {
+                std::io::Error::new(std::io::ErrorKind::InvalidInput, "path has no file name")
+            })?
+            .to_string_lossy();
+        let tmp_path = parent.join(format!("{}.tmp", file_name));
+
+        tokio::fs::write(&tmp_path, bytes).await.map_err(|e| FsError::At {
+            op: "write_atomic (write tmp)",
+            path: tmp_path.display().to_string(),
+            source: e,
+        })?;
+
+        tokio::fs::rename(&tmp_path, path).await.map_err(|e| FsError::At {
+            op: "write_atomic (rename)",
+            path: path.display().to_string(),
+            source: e,
+        })
     }
 }

--- a/rust/exo-runtime/src/kv.rs
+++ b/rust/exo-runtime/src/kv.rs
@@ -10,11 +10,55 @@ use exo_caps::{Kv, KvError};
 
 #[async_trait]
 impl Kv for Runtime {
-    async fn get(&self, _key: &str) -> Result<Option<String>, KvError> {
-        todo!("R3: read kv/<key> under self.working_dir; missing file => Ok(None)")
+    async fn get(&self, key: &str) -> Result<Option<String>, KvError> {
+        let sanitized = sanitize_key(key);
+        let path = self.working_dir().join("kv").join(sanitized);
+
+        match tokio::fs::read_to_string(&path).await {
+            Ok(content) => Ok(Some(content)),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(KvError::Failed {
+                op: "get",
+                key: key.to_string(),
+                detail: e.to_string(),
+            }),
+        }
     }
 
-    async fn set(&self, _key: &str, _value: &str) -> Result<(), KvError> {
-        todo!("R3: temp+rename write of kv/<key> under self.working_dir")
+    async fn set(&self, key: &str, value: &str) -> Result<(), KvError> {
+        let kv_dir = self.working_dir().join("kv");
+        tokio::fs::create_dir_all(&kv_dir).await.map_err(|e| KvError::Failed {
+            op: "set (create_dir_all)",
+            key: key.to_string(),
+            detail: e.to_string(),
+        })?;
+
+        let sanitized = sanitize_key(key);
+        let path = kv_dir.join(&sanitized);
+        let tmp_path = kv_dir.join(format!("{}.tmp", sanitized));
+
+        tokio::fs::write(&tmp_path, value).await.map_err(|e| KvError::Failed {
+            op: "set (write tmp)",
+            key: key.to_string(),
+            detail: e.to_string(),
+        })?;
+
+        tokio::fs::rename(&tmp_path, path).await.map_err(|e| KvError::Failed {
+            op: "set (rename)",
+            key: key.to_string(),
+            detail: e.to_string(),
+        })
     }
+}
+
+fn sanitize_key(key: &str) -> String {
+    key.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '.' || c == '_' || c == '-' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
 }

--- a/rust/exo-runtime/src/log.rs
+++ b/rust/exo-runtime/src/log.rs
@@ -8,12 +8,29 @@
 use crate::runtime::Runtime;
 use exo_caps::Log;
 
+use std::fs::OpenOptions;
+use std::io::Write;
+
 impl Log for Runtime {
-    fn info(&self, _msg: &str) {
-        todo!("R3: append an info line to the worktree-root log file under self.working_dir")
+    fn info(&self, msg: &str) {
+        let path = self.working_dir().join("exo-runtime.log");
+        let _ = (|| -> std::io::Result<()> {
+            let mut file = OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(path)?;
+            writeln!(file, "[INFO] {}", msg)
+        })();
     }
 
-    fn error(&self, _msg: &str) {
-        todo!("R3: append an error line to the worktree-root log file under self.working_dir")
+    fn error(&self, msg: &str) {
+        let path = self.working_dir().join("exo-runtime.log");
+        let _ = (|| -> std::io::Result<()> {
+            let mut file = OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(path)?;
+            writeln!(file, "[ERROR] {}", msg)
+        })();
     }
 }

--- a/rust/exo-runtime/src/process.rs
+++ b/rust/exo-runtime/src/process.rs
@@ -12,9 +12,16 @@ use exo_caps::{Process, ProcessError};
 impl Process for Runtime {
     async fn run(
         &self,
-        _program: &str,
-        _args: &[String],
+        program: &str,
+        args: &[String],
     ) -> Result<std::process::Output, ProcessError> {
-        todo!("R3: tokio::process::Command output().await; map spawn err to ProcessError::Spawn")
+        tokio::process::Command::new(program)
+            .args(args)
+            .output()
+            .await
+            .map_err(|e| ProcessError::Spawn {
+                program: program.to_string(),
+                source: e,
+            })
     }
 }


### PR DESCRIPTION
Implement four trivial capability traits for the `Runtime` struct in `exo-runtime`:

- **Fs**: Implemented `read` and `write_atomic` using `tokio::fs`. `write_atomic` uses a sibling `.tmp` file and `rename` for atomicity.
- **Process**: Implemented `run` using `tokio::process::Command`.
- **Log**: Implemented `info` and `error` (sync) appending to `exo-runtime.log` in the working directory.
- **Kv**: Implemented `get` and `set` using a `kv/` subdirectory. `set` uses the same atomic write pattern as `Fs`.

Verified with `cargo build -p exo-runtime`. Clippy is clean for the modified files (pre-existing warnings in other files in the crate persist as they are out of scope).
Checked that no other files were modified.