### PR TITLE
feat: implement Tmux capability for exo-runtime

### DIFF
--- a/rust/exo-runtime/src/tmux.rs
+++ b/rust/exo-runtime/src/tmux.rs
@@ -17,15 +17,111 @@ use std::path::Path;
 
 #[async_trait]
 impl Tmux for Runtime {
-    async fn new_pane(&self, _cwd: &Path, _cmd: &str) -> Result<PaneId, TmuxError> {
-        todo!("R2: tmux split/new-window in self.tmux_session at cwd running cmd; parse %N")
+    async fn new_pane(&self, cwd: &Path, cmd: &str) -> Result<PaneId, TmuxError> {
+        let output = self
+            .tmux(
+                "new_pane",
+                &[
+                    "split-window",
+                    "-t",
+                    &self.tmux_session,
+                    "-c",
+                    &cwd.to_string_lossy(),
+                    "-P",
+                    "-F",
+                    "#{pane_id}",
+                    cmd,
+                ],
+            )
+            .await?;
+
+        let s = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        PaneId::new(s).map_err(|e| TmuxError::Failed {
+            op: "new_pane",
+            detail: e.to_string(),
+        })
     }
 
-    async fn paste(&self, _pane: &PaneId, _text: &str) -> Result<(), TmuxError> {
-        todo!("R2: buffer-paste pattern (load-buffer temp + paste-buffer + send-keys Enter)")
+    async fn paste(&self, pane: &PaneId, text: &str) -> Result<(), TmuxError> {
+        let target = pane.as_str();
+
+        // 1. Exit copy/scroll mode if active — copy mode intercepts input (matches TmuxIpc)
+        let mode_output = tokio::process::Command::new("tmux")
+            .args(["display-message", "-p", "-t", target, "#{pane_in_mode}"])
+            .output()
+            .await;
+
+        if let Ok(output) = mode_output {
+            if output.status.success() && String::from_utf8_lossy(&output.stdout).trim() == "1" {
+                let _ = tokio::process::Command::new("tmux")
+                    .args(["send-keys", "-t", target, "-X", "cancel"])
+                    .output()
+                    .await;
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            }
+        }
+
+        // 2. Buffer paste pattern — load-buffer temp + paste-buffer + send-keys Enter
+        let payload = text.trim_end_matches('\n').trim_end_matches('\r');
+        let tmp = tempfile::NamedTempFile::new().map_err(TmuxError::Io)?;
+        let tmp_path = tmp.path();
+        tokio::fs::write(tmp_path, payload)
+            .await
+            .map_err(TmuxError::Io)?;
+
+        // Use temp file name as a unique buffer name
+        let buf_name = format!(
+            "exo_{}",
+            tmp_path
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+        );
+
+        self.tmux(
+            "paste",
+            &["load-buffer", "-b", &buf_name, &tmp_path.to_string_lossy()],
+        )
+        .await?;
+
+        self.tmux(
+            "paste",
+            &["paste-buffer", "-t", target, "-b", &buf_name, "-d"],
+        )
+        .await?;
+
+        // Debounce: allow TUI (Claude Code Ink, Gemini CLI readline) to process pasted text
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+
+        self.tmux("paste", &["send-keys", "-t", target, "Enter"])
+            .await?;
+
+        Ok(())
     }
 
-    async fn kill_pane(&self, _pane: &PaneId) -> Result<(), TmuxError> {
-        todo!("R2: tmux kill-pane -t <pane>")
+    async fn kill_pane(&self, pane: &PaneId) -> Result<(), TmuxError> {
+        self.tmux("kill_pane", &["kill-pane", "-t", pane.as_str()])
+            .await?;
+        Ok(())
+    }
+}
+
+impl Runtime {
+    /// Private async helper for tmux CLI calls.
+    /// Maps non-success exits to TmuxError::Failed { op, detail }.
+    async fn tmux(&self, op: &'static str, args: &[&str]) -> Result<std::process::Output, TmuxError> {
+        let output = tokio::process::Command::new("tmux")
+            .args(args)
+            .output()
+            .await
+            .map_err(TmuxError::Io)?;
+
+        if !output.status.success() {
+            return Err(TmuxError::Failed {
+                op,
+                detail: String::from_utf8_lossy(&output.stderr).to_string(),
+            });
+        }
+        Ok(output)
     }
 }


### PR DESCRIPTION
Implement the Tmux capability trait for the Runtime struct in crate exo-runtime.

Changes:
- Implemented `new_pane` using `tmux split-window`.
- Implemented `paste` using the `load-buffer` + `paste-buffer` + `send-keys Enter` pattern, including copy-mode cancellation and debounce sleep.
- Implemented `kill_pane` using `tmux kill-pane`.
- Added a private `tmux` async helper for CLI calls.

Verification:
- `cargo build -p exo-runtime` succeeded.
- `cargo clippy -p exo-runtime` succeeded.
- Verified ownership boundary (only `tmux.rs` was modified).
- Striped trailing whitespace.