### PR TITLE
feat(policy): implement messaging tools

### DIFF
--- a/rust/exo-policy/src/tools/messaging.rs
+++ b/rust/exo-policy/src/tools/messaging.rs
@@ -3,9 +3,180 @@
 //! JsonSchema`), a generic-over-caps `run<C: Bus>(ctx, args) -> CapResult<ToolOutput>`, and a
 //! hand-written `Tool<R>` adapter. Ships mock-cap unit tests (assert `Bus::deliver` recorded
 //! with the right `Addressee`/`Message`) in this file. See `docs/design/swarm/04-policy.md`.
-//!
-//! Empty until the P1 leaf lands.
 
-#![allow(unused_imports)]
 use crate::tool::{ok_json, parse, schema_json, Tool, ToolOutput};
-use exo_caps::Bus;
+use exo_caps::{Addressee, AgentName, Bus, CapResult, Message, MessageBody, MessageKind, Summary};
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+/// A tool to notify the parent agent.
+pub struct NotifyParent;
+
+#[derive(Deserialize, JsonSchema)]
+pub struct NotifyParentArgs {
+    /// The message body.
+    pub text: String,
+    /// A short one-line preview/summary.
+    pub summary: String,
+}
+
+impl NotifyParent {
+    /// The typed logic: builds a [`Message`] and delivers it to [`Addressee::Parent`].
+    pub async fn run<C: Bus>(ctx: &C, args: NotifyParentArgs) -> CapResult<ToolOutput> {
+        let msg = Message {
+            text: MessageBody::new(args.text)?,
+            summary: Summary::new(args.summary)?,
+            kind: MessageKind::Chat,
+        };
+        ctx.deliver(Addressee::Parent, msg).await?;
+        Ok(ToolOutput::text("delivered"))
+    }
+}
+
+#[async_trait::async_trait]
+impl<R: Bus + Send + Sync> Tool<R> for NotifyParent {
+    fn name(&self) -> &str {
+        "notify_parent"
+    }
+    fn schema(&self) -> serde_json::Value {
+        schema_json(schemars::schema_for!(NotifyParentArgs))
+    }
+    async fn call(&self, ctx: &R, j: serde_json::Value) -> CapResult<serde_json::Value> {
+        ok_json(Self::run(ctx, parse(j)?).await?)
+    }
+}
+
+/// A tool to send a message to a child agent.
+pub struct SendMessage;
+
+#[derive(Deserialize, JsonSchema)]
+pub struct SendMessageArgs {
+    /// The recipient child and its kind (inline or worktree).
+    pub to: ChildTarget,
+    /// The message body.
+    pub text: String,
+    /// A short one-line preview/summary.
+    pub summary: String,
+}
+
+/// Selects an [`Addressee`] child variant.
+#[derive(Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ChildTarget {
+    /// A worker spawned in the parent's worktree.
+    Inline(String),
+    /// A child spawned in its own worktree.
+    Worktree(String),
+}
+
+impl SendMessage {
+    /// The typed logic: builds a [`Message`] and delivers it to the specified child.
+    pub async fn run<C: Bus>(ctx: &C, args: SendMessageArgs) -> CapResult<ToolOutput> {
+        let to = match args.to {
+            ChildTarget::Inline(name) => Addressee::InlineChild(AgentName::new(name)?),
+            ChildTarget::Worktree(name) => Addressee::WorktreeChild(AgentName::new(name)?),
+        };
+        let msg = Message {
+            text: MessageBody::new(args.text)?,
+            summary: Summary::new(args.summary)?,
+            kind: MessageKind::Chat,
+        };
+        ctx.deliver(to, msg).await?;
+        Ok(ToolOutput::text("delivered"))
+    }
+}
+
+#[async_trait::async_trait]
+impl<R: Bus + Send + Sync> Tool<R> for SendMessage {
+    fn name(&self) -> &str {
+        "send_message"
+    }
+    fn schema(&self) -> serde_json::Value {
+        schema_json(schemars::schema_for!(SendMessageArgs))
+    }
+    async fn call(&self, ctx: &R, j: serde_json::Value) -> CapResult<serde_json::Value> {
+        ok_json(Self::run(ctx, parse(j)?).await?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testing::{Call, MockRuntime};
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn test_notify_parent() {
+        let mock = MockRuntime::default();
+        let tool = NotifyParent;
+        let args = json!({
+            "text": "Hello parent",
+            "summary": "Greeting"
+        });
+
+        let res = tool.call(&mock, args).await.expect("tool call failed");
+        assert_eq!(res, json!({ "text": "delivered" }));
+
+        let calls = mock.calls_made();
+        assert_eq!(calls.len(), 1);
+        if let Call::BusDeliver { to, msg } = &calls[0] {
+            assert_eq!(to, &Addressee::Parent);
+            assert_eq!(msg.text.as_str(), "Hello parent");
+            assert_eq!(msg.summary.as_str(), "Greeting");
+        } else {
+            panic!("expected BusDeliver call, got {:?}", calls[0]);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_send_message_inline() {
+        let mock = MockRuntime::default();
+        let tool = SendMessage;
+        let args = json!({
+            "to": { "inline": "worker-1" },
+            "text": "Hello worker",
+            "summary": "Greeting"
+        });
+
+        tool.call(&mock, args).await.expect("tool call failed");
+
+        let calls = mock.calls_made();
+        assert_eq!(calls.len(), 1);
+        if let Call::BusDeliver { to, msg } = &calls[0] {
+            assert_eq!(
+                to,
+                &Addressee::InlineChild(AgentName::new("worker-1".into()).unwrap())
+            );
+            assert_eq!(msg.text.as_str(), "Hello worker");
+            assert_eq!(msg.summary.as_str(), "Greeting");
+        } else {
+            panic!("expected BusDeliver call, got {:?}", calls[0]);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_send_message_worktree() {
+        let mock = MockRuntime::default();
+        let tool = SendMessage;
+        let args = json!({
+            "to": { "worktree": "child-1" },
+            "text": "Hello child",
+            "summary": "Greeting"
+        });
+
+        tool.call(&mock, args).await.expect("tool call failed");
+
+        let calls = mock.calls_made();
+        assert_eq!(calls.len(), 1);
+        if let Call::BusDeliver { to, msg } = &calls[0] {
+            assert_eq!(
+                to,
+                &Addressee::WorktreeChild(AgentName::new("child-1".into()).unwrap())
+            );
+            assert_eq!(msg.text.as_str(), "Hello child");
+            assert_eq!(msg.summary.as_str(), "Greeting");
+        } else {
+            panic!("expected BusDeliver call, got {:?}", calls[0]);
+        }
+    }
+}

--- a/rust/exo-policy/src/tools/messaging.rs
+++ b/rust/exo-policy/src/tools/messaging.rs
@@ -5,7 +5,9 @@
 //! with the right `Addressee`/`Message`) in this file. See `docs/design/swarm/04-policy.md`.
 
 use crate::tool::{ok_json, parse, schema_json, Tool, ToolOutput};
-use exo_caps::{Addressee, AgentName, Bus, CapResult, Message, MessageBody, MessageKind, Summary};
+use exo_caps::{
+    Addressee, AgentName, Bus, CapResult, ControlKind, Message, MessageBody, MessageKind, Summary,
+};
 use schemars::JsonSchema;
 use serde::Deserialize;
 
@@ -18,6 +20,9 @@ pub struct NotifyParentArgs {
     pub text: String,
     /// A short one-line preview/summary.
     pub summary: String,
+    /// The kind of message (defaults to chat).
+    #[serde(default)]
+    pub kind: ToolMessageKind,
 }
 
 impl NotifyParent {
@@ -26,7 +31,7 @@ impl NotifyParent {
         let msg = Message {
             text: MessageBody::new(args.text)?,
             summary: Summary::new(args.summary)?,
-            kind: MessageKind::Chat,
+            kind: args.kind.into(),
         };
         ctx.deliver(Addressee::Parent, msg).await?;
         Ok(ToolOutput::text("delivered"))
@@ -57,6 +62,9 @@ pub struct SendMessageArgs {
     pub text: String,
     /// A short one-line preview/summary.
     pub summary: String,
+    /// The kind of message (defaults to chat).
+    #[serde(default)]
+    pub kind: ToolMessageKind,
 }
 
 /// Selects an [`Addressee`] child variant.
@@ -69,6 +77,30 @@ pub enum ChildTarget {
     Worktree(String),
 }
 
+/// The kind of message to send, porting the [`MessageKind`] vocabulary to a
+/// schema-friendly form.
+#[derive(Deserialize, JsonSchema, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolMessageKind {
+    /// A standard peer-to-peer chat message.
+    #[default]
+    Chat,
+    /// A world event notification.
+    Event,
+    /// A lifecycle control message (e.g. shutdown).
+    Shutdown { grace_ms: u32 },
+}
+
+impl From<ToolMessageKind> for MessageKind {
+    fn from(k: ToolMessageKind) -> Self {
+        match k {
+            ToolMessageKind::Chat => MessageKind::Chat,
+            ToolMessageKind::Event => MessageKind::Event,
+            ToolMessageKind::Shutdown { grace_ms } => MessageKind::Control(ControlKind::Shutdown { grace_ms }),
+        }
+    }
+}
+
 impl SendMessage {
     /// The typed logic: builds a [`Message`] and delivers it to the specified child.
     pub async fn run<C: Bus>(ctx: &C, args: SendMessageArgs) -> CapResult<ToolOutput> {
@@ -79,7 +111,7 @@ impl SendMessage {
         let msg = Message {
             text: MessageBody::new(args.text)?,
             summary: Summary::new(args.summary)?,
-            kind: MessageKind::Chat,
+            kind: args.kind.into(),
         };
         ctx.deliver(to, msg).await?;
         Ok(ToolOutput::text("delivered"))
@@ -123,6 +155,7 @@ mod tests {
             assert_eq!(to, &Addressee::Parent);
             assert_eq!(msg.text.as_str(), "Hello parent");
             assert_eq!(msg.summary.as_str(), "Greeting");
+            assert_eq!(msg.kind, MessageKind::Chat);
         } else {
             panic!("expected BusDeliver call, got {:?}", calls[0]);
         }
@@ -149,19 +182,21 @@ mod tests {
             );
             assert_eq!(msg.text.as_str(), "Hello worker");
             assert_eq!(msg.summary.as_str(), "Greeting");
+            assert_eq!(msg.kind, MessageKind::Chat);
         } else {
             panic!("expected BusDeliver call, got {:?}", calls[0]);
         }
     }
 
     #[tokio::test]
-    async fn test_send_message_worktree() {
+    async fn test_send_message_shutdown() {
         let mock = MockRuntime::default();
         let tool = SendMessage;
         let args = json!({
             "to": { "worktree": "child-1" },
-            "text": "Hello child",
-            "summary": "Greeting"
+            "text": "finish and exit",
+            "summary": "shutdown",
+            "kind": { "shutdown": { "grace_ms": 5000 } }
         });
 
         tool.call(&mock, args).await.expect("tool call failed");
@@ -173,10 +208,10 @@ mod tests {
                 to,
                 &Addressee::WorktreeChild(AgentName::new("child-1".into()).unwrap())
             );
-            assert_eq!(msg.text.as_str(), "Hello child");
-            assert_eq!(msg.summary.as_str(), "Greeting");
+            assert_eq!(msg.kind, MessageKind::Control(ControlKind::Shutdown { grace_ms: 5000 }));
         } else {
             panic!("expected BusDeliver call, got {:?}", calls[0]);
         }
     }
 }
+


### PR DESCRIPTION
Implement `notify_parent` and `send_message` tools in the `exo-policy` crate.
- Defined `NotifyParent` and `SendMessage` tool types.
- Implemented `run` methods with `Bus` capability bound.
- Hand-wrote `Tool` adapter implementations.
- Added support for `Chat`, `Event`, and `Control(Shutdown)` message kinds as requested in review.
- Added comprehensive unit tests using `MockRuntime`.
- Verified with `cargo test` and `cargo clippy`.