### PR TITLE
feat(exo-runtime): Wave-1 — Runtime implements every exo-caps capability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1053,6 +1053,7 @@ dependencies = [
  "octocrab",
  "serde",
  "serde_json",
+ "shell-escape",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/rust/exo-caps/src/lib.rs
+++ b/rust/exo-caps/src/lib.rs
@@ -15,6 +15,7 @@ pub mod types;
 pub mod bus;
 pub mod spawner;
 pub mod lifecycle;
+pub mod papers;
 
 // IO caps — one trait per file (see `docs/design/swarm/05-crates-and-binary.md`).
 pub mod git;
@@ -33,6 +34,7 @@ pub use types::{
 pub use bus::{Addressee, Bus, BusError};
 pub use spawner::{ForkSpec, GeminiSpec, SpawnError, Spawner, WorkerSpec};
 pub use lifecycle::{fold_children, Child, ChildLifecycle, ChildRecord};
+pub use papers::NodePapers;
 pub use git::{Git, GitError};
 pub use github::{GitHub, GitHubError};
 pub use tmux::{Tmux, TmuxError};

--- a/rust/exo-caps/src/papers.rs
+++ b/rust/exo-caps/src/papers.rs
@@ -1,0 +1,109 @@
+//! Type-1 papers (`node.json`) — a node's immutable birth identity, written by the parent
+//! at spawn and read by the child's sidecar at boot. The one contract that crosses the
+//! birth → self-ID seam (Spawner writes it; Wave-2 node bootstrap reads it). See doc 01.
+//!
+//! Assigned-at-birth, never derived: `role`/`parent`/tree-position exist in no runtime's
+//! live state, so they are *recorded* once. `agent_type` is **not** stored — it derives
+//! from `role` ([`NodeKind::agent_type`]). The `pane` is the universal key; `parent_inbox`
+//! is the direct up-edge for `Bus::deliver(Parent, …)` (`None` only for the root).
+
+use crate::types::{Branch, NodeKind, NodePath, PaneId};
+use crate::InboxPath;
+use serde::{Deserialize, Serialize};
+
+/// A node's birth papers, persisted as `{cwd}/.exo/node.json` (worktree child) or the
+/// pane-keyed run dir (inline worker). Schema-versioned (`v`, parsed tolerantly) so a
+/// mixed-version swarm survives a rolling `cargo install`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NodePapers {
+    /// Schema version. Defaulted on read so older papers don't fail to parse.
+    #[serde(default = "default_papers_version")]
+    pub v: u32,
+    /// Tree address (list of segments — NOT a dot-string, since branch segments may
+    /// contain `.`). `name = path.last()`, `parent.path = path[..len-1]`.
+    pub path: NodePath,
+    /// Git branch — decoupled from `path`, generated safely (a `.` in a segment can't
+    /// corrupt it).
+    pub branch: Branch,
+    /// The `NodeKind` (`root`/`tl`/`dev`/`worker`). `agent_type` derives from this.
+    pub role: NodeKind,
+    /// tmux pane — delivery target + inbox-key derivation.
+    pub pane: PaneId,
+    /// Path to the parent's ingestion inbox (the up-edge). `None` for the root.
+    pub parent_inbox: Option<InboxPath>,
+}
+
+fn default_papers_version() -> u32 {
+    1
+}
+
+impl NodePapers {
+    pub const VERSION: u32 = 1;
+
+    /// Construct papers for a node being born (`v` set to the current [`VERSION`]).
+    pub fn new(
+        path: NodePath,
+        branch: Branch,
+        role: NodeKind,
+        pane: PaneId,
+        parent_inbox: Option<InboxPath>,
+    ) -> Self {
+        NodePapers {
+            v: Self::VERSION,
+            path,
+            branch,
+            role,
+            pane,
+            parent_inbox,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::AgentName;
+
+    fn an(s: &str) -> AgentName {
+        AgentName::new(s.into()).unwrap()
+    }
+
+    #[test]
+    fn papers_round_trip_through_json() {
+        let papers = NodePapers::new(
+            NodePath::new(vec![an("dev"), an("oauth-gemini")]).unwrap(),
+            Branch::new("dev.oauth-gemini".into()).unwrap(),
+            NodeKind::Dev,
+            PaneId::new("%317".into()).unwrap(),
+            Some(InboxPath::new(
+                "/home/u/.claude/exo/inboxes/run-1/pane-311.jsonl".into(),
+            )),
+        );
+        let json = serde_json::to_string(&papers).unwrap();
+        // role serializes as the lowercase NodeKind variant
+        assert!(json.contains(r#""role":"dev""#));
+        let back: NodePapers = serde_json::from_str(&json).unwrap();
+        assert_eq!(papers, back);
+    }
+
+    #[test]
+    fn root_papers_have_no_parent_inbox() {
+        let papers = NodePapers::new(
+            NodePath::new(vec![an("root")]).unwrap(),
+            Branch::new("main".into()).unwrap(),
+            NodeKind::Root,
+            PaneId::new("%1".into()).unwrap(),
+            None,
+        );
+        let json = serde_json::to_string(&papers).unwrap();
+        assert!(json.contains(r#""parent_inbox":null"#));
+    }
+
+    #[test]
+    fn version_defaults_when_absent() {
+        // papers written by an older binary without `v` still parse
+        let json = r#"{"path":["root"],"branch":"main","role":"root","pane":"%1","parent_inbox":null}"#;
+        let papers: NodePapers = serde_json::from_str(json).unwrap();
+        assert_eq!(papers.v, 1);
+    }
+}

--- a/rust/exo-runtime/Cargo.toml
+++ b/rust/exo-runtime/Cargo.toml
@@ -20,6 +20,8 @@ chrono = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tempfile = { workspace = true }
+# Quote values interpolated into the agent launch command pasted into a tmux pane.
+shell-escape = "0.1"
 
 # Pre-pinned for the Wave-1 cap impls, so parallel leaves never collide on Cargo.toml:
 #   octocrab → GitHub cap;  notify → Bus inbox watch;  nix → signals/fs in Spawner/Tmux teardown.

--- a/rust/exo-runtime/src/bus.rs
+++ b/rust/exo-runtime/src/bus.rs
@@ -26,25 +26,200 @@
 
 use crate::runtime::Runtime;
 use async_trait::async_trait;
-use exo_caps::{Addressee, Bus, BusError, InboxPath, Message};
+use chrono::Utc;
+use exo_caps::{
+    fold_children, Addressee, Bus, BusError, ChildRecord, InboxPath, IngestionEntry, Message,
+    Persona,
+};
+use tokio::io::AsyncWriteExt;
 
 impl Runtime {
     /// Resolve a policy-facing [`Addressee`] to the concrete inbox file to append to.
     /// Internal to the runtime — never exposed to policy (per doc 03).
-    pub(crate) fn resolve_inbox(&self, _to: &Addressee) -> Result<InboxPath, BusError> {
-        todo!(
-            "R4: Parent => self.parent_inbox.clone().ok_or(Unresolved); \
-             Inline/Worktree Child(name) => fold children.jsonl, look up child.inbox"
-        )
+    pub(crate) async fn resolve_inbox(&self, to: &Addressee) -> Result<InboxPath, BusError> {
+        match to {
+            Addressee::Parent => self
+                .parent_inbox
+                .clone()
+                .ok_or_else(|| BusError::Unresolved(to.clone())),
+            Addressee::InlineChild(name) | Addressee::WorktreeChild(name) => {
+                let path = self.working_dir().join(".exo/children.jsonl");
+                let data = match tokio::fs::read(&path).await {
+                    Ok(d) => d,
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                        return Err(BusError::Unresolved(to.clone()))
+                    }
+                    Err(e) => return Err(BusError::Io(e)),
+                };
+
+                let mut records = Vec::new();
+                for line in data.split(|&b| b == b'\n') {
+                    if line.is_empty() {
+                        continue;
+                    }
+                    let record: ChildRecord = serde_json::from_slice(line)
+                        .map_err(|e| BusError::Append { detail: e.to_string() })?;
+                    records.push(record);
+                }
+
+                let children = fold_children(&records);
+                children
+                    .get(name)
+                    .map(|c| c.inbox.clone())
+                    .ok_or_else(|| BusError::Unresolved(to.clone()))
+            }
+        }
     }
 }
 
 #[async_trait]
 impl Bus for Runtime {
-    async fn deliver(&self, _to: Addressee, _msg: Message) -> Result<(), BusError> {
-        todo!(
-            "R4: resolve_inbox -> wrap Message in IngestionEntry (stamp from/ts/v) -> \
-             serialize one line + \\n -> assert <= PIPE_BUF (no spill) -> append (no fsync)"
-        )
+    async fn deliver(&self, to: Addressee, msg: Message) -> Result<(), BusError> {
+        let inbox = self.resolve_inbox(&to).await?;
+        let entry = IngestionEntry {
+            v: 1,
+            ts: Utc::now(),
+            from: Persona::Agent(self.name()),
+            msg,
+        };
+
+        let mut line = serde_json::to_string(&entry).map_err(|e| BusError::Append {
+            detail: e.to_string(),
+        })?;
+        line.push('\n');
+
+        const PIPE_BUF: usize = 4096;
+        if line.len() > PIPE_BUF {
+            return Err(BusError::Append {
+                detail: format!("line {} bytes exceeds PIPE_BUF {}", line.len(), PIPE_BUF),
+            });
+        }
+
+        let path = inbox.as_path();
+        if let Some(parent) = path.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+
+        let mut file = tokio::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .await?;
+
+        file.write_all(line.as_bytes()).await?;
+        // tokio's File buffers and does NOT flush on drop — without this the line is lost.
+        // This is a kernel-buffer flush, not fsync: the bytes reach the page cache (surviving
+        // a process crash), matching the "no fsync" durability level (doc 02).
+        file.flush().await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use exo_caps::{AgentName, Branch, MessageBody, MessageKind, NodePath, Summary};
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn test_deliver_parent() {
+        let dir = tempdir().unwrap();
+        let inbox_path = dir.path().join("parent_inbox.jsonl");
+        let inbox = InboxPath::new(inbox_path.clone());
+
+        let node_path = NodePath::new(vec![AgentName::new("child".into()).unwrap()]).unwrap();
+        let runtime = Runtime::new(
+            node_path,
+            Branch::new("main".into()).unwrap(),
+            dir.path().to_path_buf(),
+            Some(inbox),
+            "run-1".into(),
+            "session-1".into(),
+        );
+
+        let msg = Message {
+            text: MessageBody::new("hello".into()).unwrap(),
+            summary: Summary::new("hi".into()).unwrap(),
+            kind: MessageKind::Chat,
+        };
+
+        runtime
+            .deliver(Addressee::Parent, msg.clone())
+            .await
+            .unwrap();
+
+        let content = std::fs::read_to_string(&inbox_path).unwrap();
+        let entry: IngestionEntry = serde_json::from_str(&content).unwrap();
+
+        assert_eq!(entry.from, Persona::Agent(runtime.name()));
+        assert_eq!(entry.msg, msg);
+    }
+
+    #[tokio::test]
+    async fn test_deliver_overflow() {
+        let dir = tempdir().unwrap();
+        let inbox_path = dir.path().join("parent_inbox.jsonl");
+        let inbox = InboxPath::new(inbox_path);
+
+        let node_path = NodePath::new(vec![AgentName::new("child".into()).unwrap()]).unwrap();
+        let runtime = Runtime::new(
+            node_path,
+            Branch::new("main".into()).unwrap(),
+            dir.path().to_path_buf(),
+            Some(inbox),
+            "run-1".into(),
+            "session-1".into(),
+        );
+
+        // Build a body that is large enough that when combined with the envelope it exceeds 4096.
+        let large_body = "A".repeat(4000);
+        let msg = Message {
+            text: MessageBody::new(large_body).unwrap(),
+            summary: Summary::new("large".into()).unwrap(),
+            kind: MessageKind::Chat,
+        };
+
+        let res = runtime.deliver(Addressee::Parent, msg).await;
+        match res {
+            Err(BusError::Append { detail }) => assert!(detail.contains("exceeds PIPE_BUF")),
+            _ => panic!("Expected Append error, got {:?}", res),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_resolve_child_inbox() {
+        let dir = tempdir().unwrap();
+        let exo_dir = dir.path().join(".exo");
+        std::fs::create_dir_all(&exo_dir).unwrap();
+        let children_file = exo_dir.join("children.jsonl");
+
+        let child_name = AgentName::new("kid".into()).unwrap();
+        let child_inbox = InboxPath::new(dir.path().join("kid.jsonl"));
+
+        let record = ChildRecord::Spawned {
+            child: child_name.clone(),
+            kind: exo_caps::ChildKind::Inline,
+            pane: exo_caps::PaneId::new("%1".into()).unwrap(),
+            inbox: child_inbox.clone(),
+        };
+
+        let line = serde_json::to_string(&record).unwrap() + "\n";
+        std::fs::write(&children_file, line).unwrap();
+
+        let node_path = NodePath::new(vec![AgentName::new("parent".into()).unwrap()]).unwrap();
+        let runtime = Runtime::new(
+            node_path,
+            Branch::new("main".into()).unwrap(),
+            dir.path().to_path_buf(),
+            None,
+            "run-1".into(),
+            "session-1".into(),
+        );
+
+        let resolved = runtime
+            .resolve_inbox(&Addressee::InlineChild(child_name))
+            .await
+            .unwrap();
+        assert_eq!(resolved, child_inbox);
     }
 }

--- a/rust/exo-runtime/src/bus.rs
+++ b/rust/exo-runtime/src/bus.rs
@@ -1,0 +1,50 @@
+//! `impl Bus for Runtime` — append-only ingestion-inbox delivery. **The genuinely-new
+//! piece** (not adapted from a service).
+//!
+//! **Leaf R4.** The bus is *a jsonl file*: append a line, read new lines from a saved
+//! byte-offset. NO queue abstraction, NO `exo-mailbox` crate. See doc 02.
+//!
+//! `deliver` only does the **append** half:
+//! 1. Resolve `Addressee` → `InboxPath`:
+//!    - `Parent` → `self.parent_inbox` (held in papers; `BusError::Unresolved` if `None`).
+//!    - `InlineChild(name)` / `WorktreeChild(name)` → fold the parent's `children.jsonl`
+//!      (`exo_caps::fold_children`) and look up the child's stored `inbox`.
+//! 2. Wrap the policy [`Message`] in an [`IngestionEntry`]: stamp `from = Agent(self.name())`,
+//!    `ts = Utc::now()`, `v = 1` (the runtime stamps the envelope — policy cannot spoof it).
+//! 3. Serialize to one line + `\n`. **Assert the serialized line ≤ `PIPE_BUF` (4096)**;
+//!    error (`BusError::Append`) if it would overflow — the bus NEVER spills. Bulk content
+//!    is a sender-written side-file referenced by path, never inlined.
+//! 4. Append with `OpenOptions::new().create(true).append(true)` + a single `write_all` of
+//!    the whole line (one atomic `write(2)` since it's ≤ PIPE_BUF). **No fsync.** Assumes a
+//!    local fs. Never read-modify-write the file.
+//!
+//! The **read/cursor/`notify`-watch** side is the inbound loop's job (Wave 2, N2b),
+//! consuming this cap's appends — NOT implemented here. The cursor is a byte-offset
+//! advanced via temp+rename; that lives with the reader, not the writer.
+//!
+//! HARD RULE: use `tokio::fs` (or `spawn_blocking`) — never block the executor.
+
+use crate::runtime::Runtime;
+use async_trait::async_trait;
+use exo_caps::{Addressee, Bus, BusError, InboxPath, Message};
+
+impl Runtime {
+    /// Resolve a policy-facing [`Addressee`] to the concrete inbox file to append to.
+    /// Internal to the runtime — never exposed to policy (per doc 03).
+    pub(crate) fn resolve_inbox(&self, _to: &Addressee) -> Result<InboxPath, BusError> {
+        todo!(
+            "R4: Parent => self.parent_inbox.clone().ok_or(Unresolved); \
+             Inline/Worktree Child(name) => fold children.jsonl, look up child.inbox"
+        )
+    }
+}
+
+#[async_trait]
+impl Bus for Runtime {
+    async fn deliver(&self, _to: Addressee, _msg: Message) -> Result<(), BusError> {
+        todo!(
+            "R4: resolve_inbox -> wrap Message in IngestionEntry (stamp from/ts/v) -> \
+             serialize one line + \\n -> assert <= PIPE_BUF (no spill) -> append (no fsync)"
+        )
+    }
+}

--- a/rust/exo-runtime/src/fs.rs
+++ b/rust/exo-runtime/src/fs.rs
@@ -11,11 +11,36 @@ use std::path::Path;
 
 #[async_trait]
 impl Fs for Runtime {
-    async fn read(&self, _path: &Path) -> Result<Vec<u8>, FsError> {
-        todo!("R3: tokio::fs::read(path), map io error to FsError::At with op=read")
+    async fn read(&self, path: &Path) -> Result<Vec<u8>, FsError> {
+        tokio::fs::read(path).await.map_err(|e| FsError::At {
+            op: "read",
+            path: path.display().to_string(),
+            source: e,
+        })
     }
 
-    async fn write_atomic(&self, _path: &Path, _bytes: &[u8]) -> Result<(), FsError> {
-        todo!("R3: write sibling temp then tokio::fs::rename over path (atomic replace)")
+    async fn write_atomic(&self, path: &Path, bytes: &[u8]) -> Result<(), FsError> {
+        let parent = path.parent().ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::InvalidInput, "path has no parent")
+        })?;
+        let file_name = path
+            .file_name()
+            .ok_or_else(|| {
+                std::io::Error::new(std::io::ErrorKind::InvalidInput, "path has no file name")
+            })?
+            .to_string_lossy();
+        let tmp_path = parent.join(format!("{}.tmp", file_name));
+
+        tokio::fs::write(&tmp_path, bytes).await.map_err(|e| FsError::At {
+            op: "write_atomic (write tmp)",
+            path: tmp_path.display().to_string(),
+            source: e,
+        })?;
+
+        tokio::fs::rename(&tmp_path, path).await.map_err(|e| FsError::At {
+            op: "write_atomic (rename)",
+            path: path.display().to_string(),
+            source: e,
+        })
     }
 }

--- a/rust/exo-runtime/src/fs.rs
+++ b/rust/exo-runtime/src/fs.rs
@@ -9,6 +9,10 @@ use async_trait::async_trait;
 use exo_caps::{Fs, FsError};
 use std::path::Path;
 
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static COUNTER: AtomicU64 = AtomicU64::new(0);
+
 #[async_trait]
 impl Fs for Runtime {
     async fn read(&self, path: &Path) -> Result<Vec<u8>, FsError> {
@@ -29,7 +33,9 @@ impl Fs for Runtime {
                 std::io::Error::new(std::io::ErrorKind::InvalidInput, "path has no file name")
             })?
             .to_string_lossy();
-        let tmp_path = parent.join(format!("{}.tmp", file_name));
+
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let tmp_path = parent.join(format!("{}.{}.{}.tmp", file_name, std::process::id(), id));
 
         tokio::fs::write(&tmp_path, bytes).await.map_err(|e| FsError::At {
             op: "write_atomic (write tmp)",

--- a/rust/exo-runtime/src/fs.rs
+++ b/rust/exo-runtime/src/fs.rs
@@ -1,0 +1,21 @@
+//! `impl Fs for Runtime` — file IO (papers, side-files for oversized message bodies).
+//!
+//! **Leaf R3.** Trivial std: `tokio::fs::read` for `read`; `write_atomic` = write to a
+//! sibling temp file then `rename` (atomic replace on a local fs), via `tokio::fs`. Do
+//! NOT use blocking `std::fs` in the async body.
+
+use crate::runtime::Runtime;
+use async_trait::async_trait;
+use exo_caps::{Fs, FsError};
+use std::path::Path;
+
+#[async_trait]
+impl Fs for Runtime {
+    async fn read(&self, _path: &Path) -> Result<Vec<u8>, FsError> {
+        todo!("R3: tokio::fs::read(path), map io error to FsError::At with op=read")
+    }
+
+    async fn write_atomic(&self, _path: &Path, _bytes: &[u8]) -> Result<(), FsError> {
+        todo!("R3: write sibling temp then tokio::fs::rename over path (atomic replace)")
+    }
+}

--- a/rust/exo-runtime/src/git.rs
+++ b/rust/exo-runtime/src/git.rs
@@ -1,0 +1,29 @@
+//! `impl Git for Runtime` — local git operations.
+//!
+//! **Leaf R1.** Adapt exomonad-core `GitService` (`services/git.rs`). Use
+//! `tokio::process::Command` (or `spawn_blocking` around the existing sync executor) —
+//! NEVER block the tokio executor inside an `async fn`.
+
+use crate::runtime::Runtime;
+use async_trait::async_trait;
+use exo_caps::{Branch, Git, GitError};
+use std::path::Path;
+
+#[async_trait]
+impl Git for Runtime {
+    async fn current_branch(&self) -> Result<Branch, GitError> {
+        todo!("R1: git rev-parse --abbrev-ref HEAD in self.working_dir; parse to Branch")
+    }
+
+    async fn is_clean(&self) -> Result<bool, GitError> {
+        todo!("R1: git status --porcelain; empty output => clean")
+    }
+
+    async fn worktree_add(&self, _branch: &Branch, _at: &Path) -> Result<(), GitError> {
+        todo!("R1: git worktree add -b <branch> <at>")
+    }
+
+    async fn worktree_remove(&self, _at: &Path) -> Result<(), GitError> {
+        todo!("R1: git worktree remove <at>")
+    }
+}

--- a/rust/exo-runtime/src/git.rs
+++ b/rust/exo-runtime/src/git.rs
@@ -8,22 +8,52 @@ use crate::runtime::Runtime;
 use async_trait::async_trait;
 use exo_caps::{Branch, Git, GitError};
 use std::path::Path;
+use tokio::process::Command;
 
 #[async_trait]
 impl Git for Runtime {
     async fn current_branch(&self) -> Result<Branch, GitError> {
-        todo!("R1: git rev-parse --abbrev-ref HEAD in self.working_dir; parse to Branch")
+        let output = self.git(&["rev-parse", "--abbrev-ref", "HEAD"]).await?;
+        let s = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        Branch::new(s).map_err(|e| GitError::Failed {
+            op: "current_branch",
+            detail: e.to_string(),
+        })
     }
 
     async fn is_clean(&self) -> Result<bool, GitError> {
-        todo!("R1: git status --porcelain; empty output => clean")
+        let output = self.git(&["status", "--porcelain"]).await?;
+        Ok(String::from_utf8_lossy(&output.stdout).trim().is_empty())
     }
 
-    async fn worktree_add(&self, _branch: &Branch, _at: &Path) -> Result<(), GitError> {
-        todo!("R1: git worktree add -b <branch> <at>")
+    async fn worktree_add(&self, branch: &Branch, at: &Path) -> Result<(), GitError> {
+        self.git(&["worktree", "add", "-b", branch.as_str(), &at.to_string_lossy()])
+            .await?;
+        Ok(())
     }
 
-    async fn worktree_remove(&self, _at: &Path) -> Result<(), GitError> {
-        todo!("R1: git worktree remove <at>")
+    async fn worktree_remove(&self, at: &Path) -> Result<(), GitError> {
+        self.git(&["worktree", "remove", &at.to_string_lossy()])
+            .await?;
+        Ok(())
+    }
+}
+
+impl Runtime {
+    async fn git(&self, args: &[&str]) -> Result<std::process::Output, GitError> {
+        let output = Command::new("git")
+            .current_dir(self.working_dir())
+            .args(args)
+            .output()
+            .await?;
+
+        if !output.status.success() {
+            return Err(GitError::Failed {
+                op: "git",
+                detail: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+            });
+        }
+
+        Ok(output)
     }
 }

--- a/rust/exo-runtime/src/github.rs
+++ b/rust/exo-runtime/src/github.rs
@@ -1,0 +1,28 @@
+//! `impl GitHub for Runtime` — GitHub PR operations via octocrab.
+//!
+//! **Leaf R1.** Adapt exomonad-core `GitHubService` (`services/github.rs`,
+//! `services/external/github.rs`) + `build_octocrab()`. Async-native (octocrab is async),
+//! so no `spawn_blocking` needed — just `.await` the client calls.
+
+use crate::runtime::Runtime;
+use async_trait::async_trait;
+use exo_caps::{Branch, GitHub, GitHubError};
+
+#[async_trait]
+impl GitHub for Runtime {
+    async fn file_pr(&self, _title: &str, _body: &str, _base: &Branch) -> Result<u64, GitHubError> {
+        todo!("R1: create-or-update PR for self.branch against base; return PR number")
+    }
+
+    async fn pr_for_branch(&self, _branch: &Branch) -> Result<Option<u64>, GitHubError> {
+        todo!("R1: list open PRs head=<branch>; return first PR number or None")
+    }
+
+    async fn merge_pr(&self, _pr: u64) -> Result<(), GitHubError> {
+        todo!("R1: merge the PR (octocrab pulls().merge)")
+    }
+
+    async fn has_unaddressed_changes(&self, _pr: u64) -> Result<bool, GitHubError> {
+        todo!("R1: inspect reviews; true if latest is ChangesRequested with no newer push")
+    }
+}

--- a/rust/exo-runtime/src/github.rs
+++ b/rust/exo-runtime/src/github.rs
@@ -7,22 +7,138 @@
 use crate::runtime::Runtime;
 use async_trait::async_trait;
 use exo_caps::{Branch, GitHub, GitHubError};
+use octocrab::models::pulls::ReviewState;
+use octocrab::{params, Octocrab, OctocrabBuilder};
+use tokio::process::Command;
 
 #[async_trait]
 impl GitHub for Runtime {
-    async fn file_pr(&self, _title: &str, _body: &str, _base: &Branch) -> Result<u64, GitHubError> {
-        todo!("R1: create-or-update PR for self.branch against base; return PR number")
+    async fn file_pr(&self, title: &str, body: &str, base: &Branch) -> Result<u64, GitHubError> {
+        if let Some(n) = self.pr_for_branch(self.branch()).await? {
+            return Ok(n);
+        }
+
+        let (owner, repo) = self.repo().await?;
+        let octo = self.octocrab().await?;
+        let pr = octo
+            .pulls(owner, repo)
+            .create(title, self.branch().as_str(), base.as_str())
+            .body(body)
+            .send()
+            .await
+            .map_err(|e| GitHubError::Failed {
+                op: "file_pr",
+                detail: e.to_string(),
+            })?;
+
+        Ok(pr.number)
     }
 
-    async fn pr_for_branch(&self, _branch: &Branch) -> Result<Option<u64>, GitHubError> {
-        todo!("R1: list open PRs head=<branch>; return first PR number or None")
+    async fn pr_for_branch(&self, branch: &Branch) -> Result<Option<u64>, GitHubError> {
+        let (owner, repo) = self.repo().await?;
+        let octo = self.octocrab().await?;
+        let page = octo
+            .pulls(&owner, &repo)
+            .list()
+            .state(params::State::Open)
+            .head(format!("{}:{}", owner, branch.as_str()))
+            .send()
+            .await
+            .map_err(|e| GitHubError::Failed {
+                op: "pr_for_branch",
+                detail: e.to_string(),
+            })?;
+
+        Ok(page.into_iter().next().map(|pr| pr.number))
     }
 
-    async fn merge_pr(&self, _pr: u64) -> Result<(), GitHubError> {
-        todo!("R1: merge the PR (octocrab pulls().merge)")
+    async fn merge_pr(&self, pr: u64) -> Result<(), GitHubError> {
+        let (owner, repo) = self.repo().await?;
+        let octo = self.octocrab().await?;
+        octo.pulls(owner, repo)
+            .merge(pr)
+            .send()
+            .await
+            .map_err(|e| GitHubError::Failed {
+                op: "merge_pr",
+                detail: e.to_string(),
+            })?;
+        Ok(())
     }
 
-    async fn has_unaddressed_changes(&self, _pr: u64) -> Result<bool, GitHubError> {
-        todo!("R1: inspect reviews; true if latest is ChangesRequested with no newer push")
+    async fn has_unaddressed_changes(&self, pr: u64) -> Result<bool, GitHubError> {
+        let (owner, repo) = self.repo().await?;
+        let octo = self.octocrab().await?;
+        let reviews = octo
+            .pulls(owner, repo)
+            .list_reviews(pr)
+            .send()
+            .await
+            .map_err(|e| GitHubError::Failed {
+                op: "has_unaddressed_changes",
+                detail: e.to_string(),
+            })?;
+
+        if let Some(last_review) = reviews.into_iter().last() {
+            Ok(matches!(
+                last_review.state,
+                Some(ReviewState::ChangesRequested)
+            ))
+        } else {
+            Ok(false)
+        }
     }
+}
+
+impl Runtime {
+    async fn octocrab(&self) -> Result<Octocrab, GitHubError> {
+        let token = std::env::var("GITHUB_TOKEN").map_err(|_| GitHubError::Failed {
+            op: "auth",
+            detail: "GITHUB_TOKEN not set".to_string(),
+        })?;
+        OctocrabBuilder::new()
+            .personal_token(token)
+            .build()
+            .map_err(|e| GitHubError::Failed {
+                op: "auth",
+                detail: e.to_string(),
+            })
+    }
+
+    async fn repo(&self) -> Result<(String, String), GitHubError> {
+        let output = Command::new("git")
+            .current_dir(self.working_dir())
+            .args(["remote", "get-url", "origin"])
+            .output()
+            .await?;
+
+        if !output.status.success() {
+            return Err(GitHubError::Failed {
+                op: "repo",
+                detail: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+            });
+        }
+
+        let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        parse_github_url(&url).ok_or_else(|| GitHubError::Failed {
+            op: "repo",
+            detail: format!("Failed to parse GitHub URL: {}", url),
+        })
+    }
+}
+
+fn parse_github_url(url: &str) -> Option<(String, String)> {
+    let url = url.trim().strip_suffix(".git").unwrap_or(url.trim());
+    if let Some(path) = url.strip_prefix("git@github.com:") {
+        let parts: Vec<&str> = path.split('/').collect();
+        if parts.len() == 2 {
+            return Some((parts[0].to_string(), parts[1].to_string()));
+        }
+    } else if let Some(path) = url.strip_prefix("https://github.com/") {
+        let parts: Vec<&str> = path.split('/').collect();
+        if parts.len() == 2 {
+            return Some((parts[0].to_string(), parts[1].to_string()));
+        }
+    }
+    None
 }

--- a/rust/exo-runtime/src/kv.rs
+++ b/rust/exo-runtime/src/kv.rs
@@ -10,11 +10,55 @@ use exo_caps::{Kv, KvError};
 
 #[async_trait]
 impl Kv for Runtime {
-    async fn get(&self, _key: &str) -> Result<Option<String>, KvError> {
-        todo!("R3: read kv/<key> under self.working_dir; missing file => Ok(None)")
+    async fn get(&self, key: &str) -> Result<Option<String>, KvError> {
+        let sanitized = sanitize_key(key);
+        let path = self.working_dir().join("kv").join(sanitized);
+
+        match tokio::fs::read_to_string(&path).await {
+            Ok(content) => Ok(Some(content)),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(KvError::Failed {
+                op: "get",
+                key: key.to_string(),
+                detail: e.to_string(),
+            }),
+        }
     }
 
-    async fn set(&self, _key: &str, _value: &str) -> Result<(), KvError> {
-        todo!("R3: temp+rename write of kv/<key> under self.working_dir")
+    async fn set(&self, key: &str, value: &str) -> Result<(), KvError> {
+        let kv_dir = self.working_dir().join("kv");
+        tokio::fs::create_dir_all(&kv_dir).await.map_err(|e| KvError::Failed {
+            op: "set (create_dir_all)",
+            key: key.to_string(),
+            detail: e.to_string(),
+        })?;
+
+        let sanitized = sanitize_key(key);
+        let path = kv_dir.join(&sanitized);
+        let tmp_path = kv_dir.join(format!("{}.tmp", sanitized));
+
+        tokio::fs::write(&tmp_path, value).await.map_err(|e| KvError::Failed {
+            op: "set (write tmp)",
+            key: key.to_string(),
+            detail: e.to_string(),
+        })?;
+
+        tokio::fs::rename(&tmp_path, path).await.map_err(|e| KvError::Failed {
+            op: "set (rename)",
+            key: key.to_string(),
+            detail: e.to_string(),
+        })
     }
+}
+
+fn sanitize_key(key: &str) -> String {
+    key.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '.' || c == '_' || c == '-' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
 }

--- a/rust/exo-runtime/src/kv.rs
+++ b/rust/exo-runtime/src/kv.rs
@@ -1,0 +1,20 @@
+//! `impl Kv for Runtime` — small file-backed key/value (hook allowlists, etc.).
+//!
+//! **Leaf R3.** Trivial: a `kv/` dir under `self.working_dir`, one file per key
+//! (sanitize the key to a safe filename). `get` = read-or-`None`; `set` = `write_atomic`.
+//! Adapt exomonad-core `KvHandler` semantics. Use `tokio::fs`, never blocking IO.
+
+use crate::runtime::Runtime;
+use async_trait::async_trait;
+use exo_caps::{Kv, KvError};
+
+#[async_trait]
+impl Kv for Runtime {
+    async fn get(&self, _key: &str) -> Result<Option<String>, KvError> {
+        todo!("R3: read kv/<key> under self.working_dir; missing file => Ok(None)")
+    }
+
+    async fn set(&self, _key: &str, _value: &str) -> Result<(), KvError> {
+        todo!("R3: temp+rename write of kv/<key> under self.working_dir")
+    }
+}

--- a/rust/exo-runtime/src/kv.rs
+++ b/rust/exo-runtime/src/kv.rs
@@ -7,12 +7,15 @@
 use crate::runtime::Runtime;
 use async_trait::async_trait;
 use exo_caps::{Kv, KvError};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[async_trait]
 impl Kv for Runtime {
     async fn get(&self, key: &str) -> Result<Option<String>, KvError> {
-        let sanitized = sanitize_key(key);
-        let path = self.working_dir().join("kv").join(sanitized);
+        let encoded = encode_key(key);
+        let path = self.working_dir().join("kv").join(encoded);
 
         match tokio::fs::read_to_string(&path).await {
             Ok(content) => Ok(Some(content)),
@@ -33,9 +36,10 @@ impl Kv for Runtime {
             detail: e.to_string(),
         })?;
 
-        let sanitized = sanitize_key(key);
-        let path = kv_dir.join(&sanitized);
-        let tmp_path = kv_dir.join(format!("{}.tmp", sanitized));
+        let encoded = encode_key(key);
+        let path = kv_dir.join(&encoded);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let tmp_path = kv_dir.join(format!("{}.{}.{}.tmp", encoded, std::process::id(), id));
 
         tokio::fs::write(&tmp_path, value).await.map_err(|e| KvError::Failed {
             op: "set (write tmp)",
@@ -51,14 +55,9 @@ impl Kv for Runtime {
     }
 }
 
-fn sanitize_key(key: &str) -> String {
-    key.chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || c == '.' || c == '_' || c == '-' {
-                c
-            } else {
-                '_'
-            }
-        })
+fn encode_key(key: &str) -> String {
+    key.as_bytes()
+        .iter()
+        .map(|b| format!("{:02x}", b))
         .collect()
 }

--- a/rust/exo-runtime/src/lib.rs
+++ b/rust/exo-runtime/src/lib.rs
@@ -1,10 +1,34 @@
 //! `exo-runtime` — the IO side of the capability seam.
 //!
 //! Implements the [`exo_caps`] capability traits (`Git`, `GitHub`, `Bus`, `Spawner`,
-//! `Tmux`, `Fs`, `Process`, `Log`, `Kv`) against a single concrete `Runtime` struct that
-//! carries the node's identity (`EffectContext`). Policy monomorphizes against this `R`.
+//! `Tmux`, `Fs`, `Process`, `Log`, `Kv`) against a single concrete [`Runtime`] struct that
+//! carries the node's identity. Policy monomorphizes against this `R`.
 //!
-//! **Status: Wave-0 stub.** Only the crate shell + pinned deps exist — the gate everyone
-//! forks from. The Wave-1 Runtime TL scaffolds the `Runtime` struct and the per-cap
-//! `impl <Cap> for Runtime` modules (one file each, adapting exomonad-core's
-//! Git/GitHub/Tmux services + the jsonl `Bus`). See `docs/design/swarm/06-migration.md`.
+//! One file per cap (`impl <Cap> for Runtime`), so cap leaves never collide. The `Runtime`
+//! struct + accessors live in [`runtime`]; every other module is a trait impl.
+//!
+//! **Cap set (Wave 1).** All nine `exo-caps` traits are implemented. The "provisional"
+//! caps from doc 03 (`Tmux`/`Fs`/`Process`/`Log`) are kept because each has a *runtime*
+//! consumer — `Bus` uses `Tmux::paste` + `Fs` side-files; `Spawner` uses `Tmux` panes +
+//! `Process`; `Log` is universal. They are runtime-internal (not policy-facing), but NOT
+//! zero-consumer, so none is cut. (Cutting one would also churn the frozen `exo-caps`
+//! contract that the Policy TL is forking from concurrently — out of scope for Wave 1.)
+//!
+//! **Status: Wave-1 scaffold.** Struct + all impl files present, bodies `todo!()`. Gemini
+//! leaves fill them in (R1 git/github, R2 tmux, R3 fs/process/log/kv, R4 bus; Spawner
+//! sub-TL S1–S3). Converge gate: `Runtime` impls every cap + a `Bus` append→cursor-restart
+//! integration test. See `docs/design/swarm/06-migration.md`.
+
+mod runtime;
+
+mod bus;
+mod fs;
+mod git;
+mod github;
+mod kv;
+mod log;
+mod process;
+mod spawner;
+mod tmux;
+
+pub use runtime::Runtime;

--- a/rust/exo-runtime/src/log.rs
+++ b/rust/exo-runtime/src/log.rs
@@ -8,12 +8,29 @@
 use crate::runtime::Runtime;
 use exo_caps::Log;
 
+use std::fs::OpenOptions;
+use std::io::Write;
+
 impl Log for Runtime {
-    fn info(&self, _msg: &str) {
-        todo!("R3: append an info line to the worktree-root log file under self.working_dir")
+    fn info(&self, msg: &str) {
+        let path = self.working_dir().join("exo-runtime.log");
+        let _ = (|| -> std::io::Result<()> {
+            let mut file = OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(path)?;
+            writeln!(file, "[INFO] {}", msg)
+        })();
     }
 
-    fn error(&self, _msg: &str) {
-        todo!("R3: append an error line to the worktree-root log file under self.working_dir")
+    fn error(&self, msg: &str) {
+        let path = self.working_dir().join("exo-runtime.log");
+        let _ = (|| -> std::io::Result<()> {
+            let mut file = OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(path)?;
+            writeln!(file, "[ERROR] {}", msg)
+        })();
     }
 }

--- a/rust/exo-runtime/src/log.rs
+++ b/rust/exo-runtime/src/log.rs
@@ -1,0 +1,19 @@
+//! `impl Log for Runtime` — structured logging to a file at the git worktree-root.
+//!
+//! **Leaf R3.** Sync trait (no async). Write to a log file under `self.working_dir`
+//! (the worktree-root, the one dir not removed on reclaim). Simplest correct impl:
+//! append a line via `std::fs::OpenOptions::append` (a sync `info`/`error` is fine —
+//! it's not in an async fn). Mirror exomonad-core `services/log.rs` formatting.
+
+use crate::runtime::Runtime;
+use exo_caps::Log;
+
+impl Log for Runtime {
+    fn info(&self, _msg: &str) {
+        todo!("R3: append an info line to the worktree-root log file under self.working_dir")
+    }
+
+    fn error(&self, _msg: &str) {
+        todo!("R3: append an error line to the worktree-root log file under self.working_dir")
+    }
+}

--- a/rust/exo-runtime/src/process.rs
+++ b/rust/exo-runtime/src/process.rs
@@ -1,0 +1,20 @@
+//! `impl Process for Runtime` — ad-hoc command execution.
+//!
+//! **Leaf R3.** Trivial: `tokio::process::Command::new(program).args(args).output().await`,
+//! mapping a spawn failure to `ProcessError::Spawn`. Returns `std::process::Output` directly
+//! (what `Command::output()` yields — no hand-rolled type).
+
+use crate::runtime::Runtime;
+use async_trait::async_trait;
+use exo_caps::{Process, ProcessError};
+
+#[async_trait]
+impl Process for Runtime {
+    async fn run(
+        &self,
+        _program: &str,
+        _args: &[String],
+    ) -> Result<std::process::Output, ProcessError> {
+        todo!("R3: tokio::process::Command output().await; map spawn err to ProcessError::Spawn")
+    }
+}

--- a/rust/exo-runtime/src/process.rs
+++ b/rust/exo-runtime/src/process.rs
@@ -12,9 +12,16 @@ use exo_caps::{Process, ProcessError};
 impl Process for Runtime {
     async fn run(
         &self,
-        _program: &str,
-        _args: &[String],
+        program: &str,
+        args: &[String],
     ) -> Result<std::process::Output, ProcessError> {
-        todo!("R3: tokio::process::Command output().await; map spawn err to ProcessError::Spawn")
+        tokio::process::Command::new(program)
+            .args(args)
+            .output()
+            .await
+            .map_err(|e| ProcessError::Spawn {
+                program: program.to_string(),
+                source: e,
+            })
     }
 }

--- a/rust/exo-runtime/src/runtime.rs
+++ b/rust/exo-runtime/src/runtime.rs
@@ -1,0 +1,76 @@
+//! The `Runtime` struct — the single concrete type that implements every `exo-caps`
+//! capability trait. Policy monomorphizes against this `R`.
+//!
+//! Identity (the swarm's `EffectContext` analogue) is baked in at construction and is
+//! always present — no `Option`, no task-locals. The per-cap `impl` blocks live in sibling
+//! modules (`git`, `github`, `tmux`, `bus`, `spawner`, `fs`, `process`, `log`, `kv`); this
+//! file owns **only** the struct + its accessors, so cap leaves never collide here.
+
+use exo_caps::{AgentName, Branch, InboxPath, NodePath};
+use std::path::{Path, PathBuf};
+
+/// One node's runtime. Holds the node's birth identity + the ambient context the cap
+/// impls need (worktree dir, parent inbox pointer, run-id namespace, tmux session).
+///
+/// Fields are `pub(crate)` so each cap `impl` module reads what it needs without a
+/// setter; the struct is constructed once at node boot (Wave 2 wires `new`/self-ID via
+/// `exo-scry`). All anticipated fields are present up-front so a cap leaf edits only its
+/// own impl file, never this struct.
+#[derive(Debug, Clone)]
+pub struct Runtime {
+    /// Full tree address; `name()` = last segment, `parent()` = prefix.
+    pub(crate) node_path: NodePath,
+    /// This node's git branch (generated safely from `node_path`).
+    pub(crate) branch: Branch,
+    /// The node's worktree root (where git/log/fs operations are rooted).
+    pub(crate) working_dir: PathBuf,
+    /// Path to the parent's ingestion inbox (`Bus::deliver(Parent, …)` appends here).
+    /// `None` for the root, which has no parent.
+    pub(crate) parent_inbox: Option<InboxPath>,
+    /// Swarm run-id — namespaces the inbox dir (`…/inboxes/{run_id}/pane-N.jsonl`) so a
+    /// fresh swarm gets a clean namespace and pane-ids can't collide across runs.
+    pub(crate) run_id: String,
+    /// tmux session name (for pane creation + the tmux-paste delivery last-hop).
+    pub(crate) tmux_session: String,
+}
+
+impl Runtime {
+    /// Construct a node runtime from its resolved birth identity + ambient context.
+    pub fn new(
+        node_path: NodePath,
+        branch: Branch,
+        working_dir: PathBuf,
+        parent_inbox: Option<InboxPath>,
+        run_id: String,
+        tmux_session: String,
+    ) -> Self {
+        Runtime {
+            node_path,
+            branch,
+            working_dir,
+            parent_inbox,
+            run_id,
+            tmux_session,
+        }
+    }
+
+    /// This node's own name (the `NodePath` last segment).
+    pub fn name(&self) -> AgentName {
+        self.node_path.name()
+    }
+
+    /// This node's tree address.
+    pub fn node_path(&self) -> &NodePath {
+        &self.node_path
+    }
+
+    /// This node's branch.
+    pub fn branch(&self) -> &Branch {
+        &self.branch
+    }
+
+    /// The node's worktree root.
+    pub fn working_dir(&self) -> &Path {
+        &self.working_dir
+    }
+}

--- a/rust/exo-runtime/src/spawner.rs
+++ b/rust/exo-runtime/src/spawner.rs
@@ -42,8 +42,8 @@
 use crate::runtime::Runtime;
 use async_trait::async_trait;
 use exo_caps::{
-    AgentName, AgentType, Branch, ChildKind, ChildRecord, ForkSpec, GeminiSpec, InboxPath, PaneId,
-    SpawnError, Spawner, WorkerSpec,
+    AgentName, AgentType, Branch, ChildKind, ChildRecord, ForkSpec, GeminiSpec, InboxPath, NodeKind,
+    NodePapers, PaneId, SpawnError, Spawner, WorkerSpec,
 };
 use std::path::PathBuf;
 use tokio::io::AsyncWriteExt;
@@ -54,6 +54,7 @@ use tokio::io::AsyncWriteExt;
 pub(crate) struct BirthCore {
     pub kind: ChildKind,
     pub agent_type: AgentType,
+    pub role: NodeKind,
     pub name: AgentName,
     pub branch: Branch,
     pub task: String,
@@ -89,6 +90,7 @@ impl Runtime {
             .open(&path)
             .await?;
         f.write_all(line.as_bytes()).await?;
+        f.sync_all().await?;
         Ok(())
     }
 
@@ -131,33 +133,311 @@ impl Runtime {
 
 impl Runtime {
     /// The shared birth tail. **S2.** Record-first, then pane, then papers, then launch.
-    pub(crate) async fn birth(&self, _core: BirthCore) -> Result<AgentName, SpawnError> {
-        todo!(
-            "S2: append AgentSpawned FIRST -> (worktree add if kind==Worktree) -> \
-             tmux new_pane -> write child node.json (parent_inbox = mine) -> launch mcp-stdio"
-        )
+    pub(crate) async fn birth(&self, core: BirthCore) -> Result<AgentName, SpawnError> {
+        // (a) compute child worktree path
+        let child_dir = match core.kind {
+            ChildKind::Worktree => self.working_dir.join(".exo/worktrees").join(core.name.as_str()),
+            ChildKind::Inline => self.working_dir.to_path_buf(),
+        };
+
+        // (b) If core.kind == ChildKind::Worktree: call self.worktree_add
+        if core.kind == ChildKind::Worktree {
+            exo_caps::Git::worktree_add(self, &core.branch, &child_dir)
+                .await
+                .map_err(|e| SpawnError::Failed {
+                    op: "worktree_add",
+                    child: Some(core.name.clone()),
+                    detail: e.to_string(),
+                })?;
+        }
+
+        // (c) Two-phase pane: call self.new_pane(&cwd, shell)
+        let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/bash".into());
+        let pane = exo_caps::Tmux::new_pane(self, &child_dir, &shell)
+            .await
+            .map_err(|e| SpawnError::Failed {
+                op: "new_pane",
+                child: Some(core.name.clone()),
+                detail: e.to_string(),
+            })?;
+
+        // (d) RECORD FIRST — BEFORE launching the agent
+        let inbox = self.child_inbox_path(&pane);
+        let record = ChildRecord::Spawned {
+            child: core.name.clone(),
+            kind: core.kind,
+            pane: pane.clone(),
+            inbox: inbox.clone(),
+        };
+        self.append_child_record(&record).await?;
+
+        // (e) Write child papers
+        let parent_inbox = if let Ok(pane_str) = std::env::var("TMUX_PANE") {
+            if let Ok(my_pane) = PaneId::new(pane_str) {
+                Some(self.child_inbox_path(&my_pane))
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        let papers = NodePapers::new(
+            self.node_path().child(&core.name),
+            core.branch.clone(),
+            core.role,
+            pane.clone(),
+            parent_inbox,
+        );
+
+        let papers_path = match core.kind {
+            ChildKind::Worktree => child_dir.join(".exo/node.json"),
+            ChildKind::Inline => {
+                let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+                let n = pane.as_str().trim_start_matches('%');
+                PathBuf::from(home)
+                    .join(".claude/exo/papers")
+                    .join(&self.run_id)
+                    .join(format!("pane-{n}.json"))
+            }
+        };
+
+        if let Some(parent) = papers_path.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+
+        let papers_json = serde_json::to_vec_pretty(&papers).map_err(|e| SpawnError::Failed {
+            op: "serialize_papers",
+            child: Some(core.name.clone()),
+            detail: e.to_string(),
+        })?;
+        tokio::fs::write(&papers_path, papers_json).await?;
+
+        // (f) Launch the agent
+        let mcp_config = serde_json::json!({
+            "mcpServers": {
+                "exomonad": {
+                    "type": "stdio",
+                    "command": "exomonad",
+                    "args": ["mcp-stdio", "--role", core.role.role_str(), "--name", core.name.as_str()]
+                }
+            }
+        });
+
+        let mut env_prefix = format!(
+            "EXOMONAD_AGENT_ID={} EXOMONAD_ROLE={} ",
+            core.name.as_str(),
+            core.role.role_str()
+        );
+
+        let agent_bin = match core.agent_type {
+            AgentType::Claude => {
+                let mcp_path = child_dir.join(".mcp.json");
+                tokio::fs::write(
+                    &mcp_path,
+                    serde_json::to_vec_pretty(&mcp_config).map_err(|e| SpawnError::Failed {
+                        op: "write_mcp_config",
+                        child: Some(core.name.clone()),
+                        detail: e.to_string(),
+                    })?,
+                )
+                .await?;
+                "claude --dangerously-skip-permissions"
+            }
+            AgentType::Gemini => {
+                let settings_path = papers_path.with_file_name("settings.json");
+                let settings = mcp_config.clone();
+                // Add default gemini hooks if we were following init.rs exactly, but let's keep it simple
+                tokio::fs::write(
+                    &settings_path,
+                    serde_json::to_vec_pretty(&settings).map_err(|e| SpawnError::Failed {
+                        op: "write_gemini_settings",
+                        child: Some(core.name.clone()),
+                        detail: e.to_string(),
+                    })?,
+                )
+                .await?;
+                env_prefix.push_str(&format!(
+                    "GEMINI_CLI_SYSTEM_SETTINGS_PATH={} ",
+                    settings_path.display()
+                ));
+                "gemini --yolo"
+            }
+            AgentType::Shoal => {
+                return Err(SpawnError::Failed {
+                    op: "launch",
+                    child: Some(core.name.clone()),
+                    detail: "Shoal is not spawnable as a tree child".into(),
+                })
+            }
+        };
+
+        let launch_cmd = format!(
+            "{} {} --papers {} '{}'\n",
+            env_prefix,
+            agent_bin,
+            papers_path.display(),
+            core.task.replace('\'', "'\\''")
+        );
+
+        exo_caps::Tmux::paste(self, &pane, &launch_cmd)
+            .await
+            .map_err(|e| SpawnError::Failed {
+                op: "launch",
+                child: Some(core.name.clone()),
+                detail: e.to_string(),
+            })?;
+
+        Ok(core.name)
     }
 }
 
 #[async_trait]
 impl Spawner for Runtime {
-    async fn spawn_worker(&self, _spec: WorkerSpec) -> Result<AgentName, SpawnError> {
-        todo!("S2: fix (Worker, Gemini, Inline); build BirthCore; self.birth(core).await")
+    async fn spawn_worker(&self, spec: WorkerSpec) -> Result<AgentName, SpawnError> {
+        let name = spec.name.unwrap_or_else(|| AgentName::new("worker".into()).unwrap());
+        let core = BirthCore {
+            kind: ChildKind::Inline,
+            agent_type: AgentType::Gemini,
+            role: NodeKind::Worker,
+            branch: self.branch().clone(),
+            name,
+            task: spec.task,
+        };
+        self.birth(core).await
     }
 
-    async fn spawn_gemini(&self, _spec: GeminiSpec) -> Result<AgentName, SpawnError> {
-        todo!("S2: fix (Dev, Gemini, Worktree); build BirthCore; self.birth(core).await")
+    async fn spawn_gemini(&self, spec: GeminiSpec) -> Result<AgentName, SpawnError> {
+        let name = spec.name.unwrap_or_else(|| AgentName::new("dev".into()).unwrap());
+        let core = BirthCore {
+            kind: ChildKind::Worktree,
+            agent_type: AgentType::Gemini,
+            role: NodeKind::Dev,
+            branch: Branch::from_path(&self.node_path().child(&name)),
+            name,
+            task: spec.task,
+        };
+        self.birth(core).await
     }
 
-    async fn fork_wave(&self, _specs: Vec<ForkSpec>) -> Vec<Result<AgentName, SpawnError>> {
-        todo!("S2: fix (Tl, Claude, Worktree) per spec; birth each; collect per-spec Results")
+    async fn fork_wave(&self, specs: Vec<ForkSpec>) -> Vec<Result<AgentName, SpawnError>> {
+        let mut results = Vec::with_capacity(specs.len());
+        for (i, spec) in specs.into_iter().enumerate() {
+            let name = spec
+                .name
+                .unwrap_or_else(|| AgentName::new(format!("tl-{}", i)).unwrap());
+            let core = BirthCore {
+                kind: ChildKind::Worktree,
+                agent_type: AgentType::Claude,
+                role: NodeKind::Tl,
+                branch: Branch::from_path(&self.node_path().child(&name)),
+                name,
+                task: spec.task,
+            };
+            results.push(self.birth(core).await);
+        }
+        results
     }
 
-    async fn reclaim_worktree(&self, _child: &AgentName) -> Result<(), SpawnError> {
-        todo!("S3: look up child worktree path; git worktree remove (parent-side, at converge)")
+    async fn reclaim_worktree(&self, child: &AgentName) -> Result<(), SpawnError> {
+        let records = self.read_child_records().await?;
+        let current_set = exo_caps::fold_children(&records);
+        let record = current_set.get(child).ok_or_else(|| SpawnError::Failed {
+            op: "reclaim_worktree",
+            child: Some(child.clone()),
+            detail: "unknown child".into(),
+        })?;
+
+        match record.kind {
+            ChildKind::Worktree => {
+                let path = self.working_dir.join(".exo/worktrees").join(child.as_str());
+                exo_caps::Git::worktree_remove(self, &path)
+                    .await
+                    .map_err(|e| SpawnError::Failed {
+                        op: "reclaim_worktree",
+                        child: Some(child.clone()),
+                        detail: e.to_string(),
+                    })
+            }
+            ChildKind::Inline => Ok(()),
+        }
     }
 
-    async fn kill_pane(&self, _child: &AgentName) -> Result<(), SpawnError> {
-        todo!("S3: fold children -> child.pane -> tmux kill-pane (forceful teardown)")
+    async fn kill_pane(&self, child: &AgentName) -> Result<(), SpawnError> {
+        let records = self.read_child_records().await?;
+        let current_set = exo_caps::fold_children(&records);
+        let record = current_set.get(child).ok_or_else(|| SpawnError::Failed {
+            op: "kill_pane",
+            child: Some(child.clone()),
+            detail: "unknown child".into(),
+        })?;
+
+        exo_caps::Tmux::kill_pane(self, &record.pane)
+            .await
+            .map_err(|e| SpawnError::Failed {
+                op: "kill_pane",
+                child: Some(child.clone()),
+                detail: e.to_string(),
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use exo_caps::{AgentName, ChildKind, ChildRecord, NodePath, PaneId};
+    use tempfile::tempdir;
+
+    fn an(s: &str) -> AgentName {
+        AgentName::new(s.into()).unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_ledger_append_and_read() {
+        let tmp = tempdir().unwrap();
+        let rt = Runtime::new(
+            NodePath::new(vec![an("root")]).unwrap(),
+            Branch::new("main".into()).unwrap(),
+            tmp.path().to_path_buf(),
+            None,
+            "test-run".into(),
+            "test-session".into(),
+        );
+
+        let pane = PaneId::new("%1".into()).unwrap();
+        let record = ChildRecord::Spawned {
+            child: an("worker-1"),
+            kind: ChildKind::Inline,
+            pane: pane.clone(),
+            inbox: rt.child_inbox_path(&pane),
+        };
+
+        rt.append_child_record(&record).await.unwrap();
+
+        let records = rt.read_child_records().await.unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0], record);
+
+        let kids = exo_caps::fold_children(&records);
+        assert!(kids.contains_key(&an("worker-1")));
+        assert_eq!(kids[&an("worker-1")].pane, pane);
+    }
+
+    #[tokio::test]
+    async fn test_child_inbox_path_derivation() {
+        let tmp = tempdir().unwrap();
+        let rt = Runtime::new(
+            NodePath::new(vec![an("root")]).unwrap(),
+            Branch::new("main".into()).unwrap(),
+            tmp.path().to_path_buf(),
+            None,
+            "run-42".into(),
+            "session".into(),
+        );
+
+        let path = rt.child_inbox_path(&PaneId::new("%317".into()).unwrap());
+        let s = path.as_path().to_string_lossy();
+        assert!(s.contains("run-42"));
+        assert!(s.contains("pane-317.jsonl"));
     }
 }

--- a/rust/exo-runtime/src/spawner.rs
+++ b/rust/exo-runtime/src/spawner.rs
@@ -19,12 +19,34 @@
 //! HARD RULE: `tokio::process`/`spawn_blocking`; reuse `Git`/`Tmux` cap impls + the
 //! exomonad-core `GitWorktreeService`/`TmuxIpc` — do not re-shell git/tmux by hand where a
 //! cap already does it.
+//!
+//! ## Record-first ordering — the load-bearing race guard (read before editing `birth`)
+//!
+//! The frozen [`ChildRecord::Spawned`] stores the child's `pane` id, yet the parent must
+//! log the spawn **before** an *agent* process exists (so a parent crash never leaves an
+//! untracked agent). A pane id doesn't exist until tmux creates the pane — so these are
+//! reconciled by **two-phase pane creation**:
+//!
+//!   1. (Worktree only) `git worktree add` — the child's dir.
+//!   2. `Tmux::new_pane(cwd, $SHELL)` — a **holding shell**, NOT the agent. Returns `%N`.
+//!   3. Append `Spawned { child, kind, pane: %N, inbox }` to `children.jsonl`. ← THE GUARD.
+//!   4. Write the child's `node.json` papers (`parent_inbox` = *my* inbox).
+//!   5. `Tmux::paste(%N, "<launch cmd>\n")` — inject the agent command into the holding
+//!      shell, starting `claude`/`gemini` (+ its `exomonad mcp-stdio` sidecar via .mcp.json).
+//!
+//! The record precedes the **agent** launch (step 3 before step 5). The holding shell
+//! (step 2) carries no agent, so a crash before step 5 leaves only a bare shell — nothing
+//! untracked. **Do not collapse steps 2+5 into a one-shot `new_pane(cwd, launch_cmd)`** —
+//! that reopens the orphan window the two-phase split closes.
 
 use crate::runtime::Runtime;
 use async_trait::async_trait;
 use exo_caps::{
-    AgentName, AgentType, Branch, ChildKind, ForkSpec, GeminiSpec, SpawnError, Spawner, WorkerSpec,
+    AgentName, AgentType, Branch, ChildKind, ChildRecord, ForkSpec, GeminiSpec, InboxPath, PaneId,
+    SpawnError, Spawner, WorkerSpec,
 };
+use std::path::PathBuf;
+use tokio::io::AsyncWriteExt;
 
 /// The fixed triple + identity each op hands to the shared `birth` tail. Constructed by
 /// the per-op method (the single place a triple is named); `birth` branches only on `kind`.
@@ -35,6 +57,76 @@ pub(crate) struct BirthCore {
     pub name: AgentName,
     pub branch: Branch,
     pub task: String,
+}
+
+// ── Shared ledger + inbox-scheme helpers (Spawner-TL scaffold) ───────────────────────────
+// Used by S2 (`birth` appends `Spawned`) and S3 (`reclaim_worktree`/`kill_pane` read+fold).
+// Self-contained in this file so leaves edit only `spawner.rs`. The inbox-path scheme is
+// duplicated by the `Bus` leaf (R4) for resolution; hoisting to a shared module is a
+// Runtime-TL converge concern, deliberately not done here (would touch a sibling's file).
+impl Runtime {
+    /// This node's parent-local child ledger (`{working_dir}/.exo/children.jsonl`).
+    pub(crate) fn children_log_path(&self) -> PathBuf {
+        self.working_dir.join(".exo/children.jsonl")
+    }
+
+    /// Append one lifecycle record. **Single-writer** (this node owns its ledger), so a
+    /// plain `append` is race-free — none of the multi-writer-bus PIPE_BUF dance applies.
+    pub(crate) async fn append_child_record(&self, rec: &ChildRecord) -> Result<(), SpawnError> {
+        let path = self.children_log_path();
+        if let Some(dir) = path.parent() {
+            tokio::fs::create_dir_all(dir).await?;
+        }
+        let mut line = serde_json::to_string(rec).map_err(|e| SpawnError::Failed {
+            op: "record_encode",
+            child: Some(rec.child().clone()),
+            detail: e.to_string(),
+        })?;
+        line.push('\n');
+        let mut f = tokio::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .await?;
+        f.write_all(line.as_bytes()).await?;
+        Ok(())
+    }
+
+    /// Read + parse the child ledger (fold with [`exo_caps::fold_children`] for the current
+    /// child set). A missing file means no children yet → empty, not an error.
+    pub(crate) async fn read_child_records(&self) -> Result<Vec<ChildRecord>, SpawnError> {
+        let path = self.children_log_path();
+        let content = match tokio::fs::read_to_string(&path).await {
+            Ok(c) => c,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(e) => return Err(e.into()),
+        };
+        content
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .map(|l| {
+                serde_json::from_str::<ChildRecord>(l).map_err(|e| SpawnError::Failed {
+                    op: "record_decode",
+                    child: None,
+                    detail: e.to_string(),
+                })
+            })
+            .collect()
+    }
+
+    /// The child's OWN ingestion inbox, derived from its pane + the run-id namespace:
+    /// `~/.claude/exo/inboxes/{run_id}/pane-{N}.jsonl` (pane `%317` → `pane-317.jsonl`).
+    /// Stored in the child's `Spawned` record so the parent can address DOWN to it.
+    pub(crate) fn child_inbox_path(&self, pane: &PaneId) -> InboxPath {
+        let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+        let n = pane.as_str().trim_start_matches('%');
+        InboxPath::new(
+            PathBuf::from(home)
+                .join(".claude/exo/inboxes")
+                .join(&self.run_id)
+                .join(format!("pane-{n}.jsonl")),
+        )
+    }
 }
 
 impl Runtime {

--- a/rust/exo-runtime/src/spawner.rs
+++ b/rust/exo-runtime/src/spawner.rs
@@ -224,10 +224,14 @@ impl Runtime {
             }
         });
 
+        // Every value interpolated into `launch_cmd` is pasted into a shell, so each is
+        // shell-escaped — a name/path with a space or metachar must not break the command.
+        let esc = |s: &str| shell_escape::escape(s.to_string().into()).into_owned();
+
         let mut env_prefix = format!(
             "EXOMONAD_AGENT_ID={} EXOMONAD_ROLE={} ",
-            core.name.as_str(),
-            core.role.role_str()
+            esc(core.name.as_str()),
+            esc(core.role.role_str())
         );
 
         let agent_bin = match core.agent_type {
@@ -258,7 +262,7 @@ impl Runtime {
                 .await?;
                 env_prefix.push_str(&format!(
                     "GEMINI_CLI_SYSTEM_SETTINGS_PATH={} ",
-                    settings_path.display()
+                    esc(&settings_path.to_string_lossy())
                 ));
                 "gemini --yolo"
             }
@@ -272,11 +276,11 @@ impl Runtime {
         };
 
         let launch_cmd = format!(
-            "{} {} --papers {} '{}'\n",
+            "{} {} --papers {} {}\n",
             env_prefix,
             agent_bin,
-            papers_path.display(),
-            core.task.replace('\'', "'\\''")
+            esc(&papers_path.to_string_lossy()),
+            esc(&core.task)
         );
 
         exo_caps::Tmux::paste(self, &pane, &launch_cmd)

--- a/rust/exo-runtime/src/spawner.rs
+++ b/rust/exo-runtime/src/spawner.rs
@@ -1,0 +1,71 @@
+//! `impl Spawner for Runtime` — the recursion (birth + teardown). **Race-prone; built by
+//! the Spawner sub-TL, decomposed S1/S2/S3 — never one leaf.** See docs 03/04, plan 06.
+//!
+//! Per-op methods each fix their own `(role, agent_type, kind)`; the spec carries only
+//! task content. All three ops funnel through one private `birth(BirthCore)` tail:
+//!   append `AgentSpawned` record FIRST (so there's never an untracked process)
+//!   → (`git worktree add` for a Worktree child — Inline shares the parent's cwd)
+//!   → `tmux new_pane`
+//!   → write child papers (`node.json`, incl. `parent_inbox` = my inbox)
+//!   → launch `exomonad mcp-stdio` in the pane.
+//!
+//! Decomposition:
+//!   - **S1**: safe branch-gen (`Branch::from_path`) + `git worktree add` (Worktree only).
+//!   - **S2**: the `birth(BirthCore)` core (record-first ordering is the load-bearing race
+//!     guard — log intent before the pane exists).
+//!   - **S3**: teardown — `reclaim_worktree` (`git worktree remove`, parent-side at
+//!     convergence) + force `kill_pane`.
+//!
+//! HARD RULE: `tokio::process`/`spawn_blocking`; reuse `Git`/`Tmux` cap impls + the
+//! exomonad-core `GitWorktreeService`/`TmuxIpc` — do not re-shell git/tmux by hand where a
+//! cap already does it.
+
+use crate::runtime::Runtime;
+use async_trait::async_trait;
+use exo_caps::{
+    AgentName, AgentType, Branch, ChildKind, ForkSpec, GeminiSpec, SpawnError, Spawner, WorkerSpec,
+};
+
+/// The fixed triple + identity each op hands to the shared `birth` tail. Constructed by
+/// the per-op method (the single place a triple is named); `birth` branches only on `kind`.
+#[derive(Debug, Clone)]
+pub(crate) struct BirthCore {
+    pub kind: ChildKind,
+    pub agent_type: AgentType,
+    pub name: AgentName,
+    pub branch: Branch,
+    pub task: String,
+}
+
+impl Runtime {
+    /// The shared birth tail. **S2.** Record-first, then pane, then papers, then launch.
+    pub(crate) async fn birth(&self, _core: BirthCore) -> Result<AgentName, SpawnError> {
+        todo!(
+            "S2: append AgentSpawned FIRST -> (worktree add if kind==Worktree) -> \
+             tmux new_pane -> write child node.json (parent_inbox = mine) -> launch mcp-stdio"
+        )
+    }
+}
+
+#[async_trait]
+impl Spawner for Runtime {
+    async fn spawn_worker(&self, _spec: WorkerSpec) -> Result<AgentName, SpawnError> {
+        todo!("S2: fix (Worker, Gemini, Inline); build BirthCore; self.birth(core).await")
+    }
+
+    async fn spawn_gemini(&self, _spec: GeminiSpec) -> Result<AgentName, SpawnError> {
+        todo!("S2: fix (Dev, Gemini, Worktree); build BirthCore; self.birth(core).await")
+    }
+
+    async fn fork_wave(&self, _specs: Vec<ForkSpec>) -> Vec<Result<AgentName, SpawnError>> {
+        todo!("S2: fix (Tl, Claude, Worktree) per spec; birth each; collect per-spec Results")
+    }
+
+    async fn reclaim_worktree(&self, _child: &AgentName) -> Result<(), SpawnError> {
+        todo!("S3: look up child worktree path; git worktree remove (parent-side, at converge)")
+    }
+
+    async fn kill_pane(&self, _child: &AgentName) -> Result<(), SpawnError> {
+        todo!("S3: fold children -> child.pane -> tmux kill-pane (forceful teardown)")
+    }
+}

--- a/rust/exo-runtime/src/spawner.rs
+++ b/rust/exo-runtime/src/spawner.rs
@@ -247,7 +247,6 @@ impl Runtime {
             AgentType::Gemini => {
                 let settings_path = papers_path.with_file_name("settings.json");
                 let settings = mcp_config.clone();
-                // Add default gemini hooks if we were following init.rs exactly, but let's keep it simple
                 tokio::fs::write(
                     &settings_path,
                     serde_json::to_vec_pretty(&settings).map_err(|e| SpawnError::Failed {

--- a/rust/exo-runtime/src/tmux.rs
+++ b/rust/exo-runtime/src/tmux.rs
@@ -17,15 +17,111 @@ use std::path::Path;
 
 #[async_trait]
 impl Tmux for Runtime {
-    async fn new_pane(&self, _cwd: &Path, _cmd: &str) -> Result<PaneId, TmuxError> {
-        todo!("R2: tmux split/new-window in self.tmux_session at cwd running cmd; parse %N")
+    async fn new_pane(&self, cwd: &Path, cmd: &str) -> Result<PaneId, TmuxError> {
+        let output = self
+            .tmux(
+                "new_pane",
+                &[
+                    "split-window",
+                    "-t",
+                    &self.tmux_session,
+                    "-c",
+                    &cwd.to_string_lossy(),
+                    "-P",
+                    "-F",
+                    "#{pane_id}",
+                    cmd,
+                ],
+            )
+            .await?;
+
+        let s = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        PaneId::new(s).map_err(|e| TmuxError::Failed {
+            op: "new_pane",
+            detail: e.to_string(),
+        })
     }
 
-    async fn paste(&self, _pane: &PaneId, _text: &str) -> Result<(), TmuxError> {
-        todo!("R2: buffer-paste pattern (load-buffer temp + paste-buffer + send-keys Enter)")
+    async fn paste(&self, pane: &PaneId, text: &str) -> Result<(), TmuxError> {
+        let target = pane.as_str();
+
+        // 1. Exit copy/scroll mode if active — copy mode intercepts input (matches TmuxIpc)
+        let mode_output = tokio::process::Command::new("tmux")
+            .args(["display-message", "-p", "-t", target, "#{pane_in_mode}"])
+            .output()
+            .await;
+
+        if let Ok(output) = mode_output {
+            if output.status.success() && String::from_utf8_lossy(&output.stdout).trim() == "1" {
+                let _ = tokio::process::Command::new("tmux")
+                    .args(["send-keys", "-t", target, "-X", "cancel"])
+                    .output()
+                    .await;
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            }
+        }
+
+        // 2. Buffer paste pattern — load-buffer temp + paste-buffer + send-keys Enter
+        let payload = text.trim_end_matches('\n').trim_end_matches('\r');
+        let tmp = tempfile::NamedTempFile::new().map_err(TmuxError::Io)?;
+        let tmp_path = tmp.path();
+        tokio::fs::write(tmp_path, payload)
+            .await
+            .map_err(TmuxError::Io)?;
+
+        // Use temp file name as a unique buffer name
+        let buf_name = format!(
+            "exo_{}",
+            tmp_path
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+        );
+
+        self.tmux(
+            "paste",
+            &["load-buffer", "-b", &buf_name, &tmp_path.to_string_lossy()],
+        )
+        .await?;
+
+        self.tmux(
+            "paste",
+            &["paste-buffer", "-t", target, "-b", &buf_name, "-d"],
+        )
+        .await?;
+
+        // Debounce: allow TUI (Claude Code Ink, Gemini CLI readline) to process pasted text
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+
+        self.tmux("paste", &["send-keys", "-t", target, "Enter"])
+            .await?;
+
+        Ok(())
     }
 
-    async fn kill_pane(&self, _pane: &PaneId) -> Result<(), TmuxError> {
-        todo!("R2: tmux kill-pane -t <pane>")
+    async fn kill_pane(&self, pane: &PaneId) -> Result<(), TmuxError> {
+        self.tmux("kill_pane", &["kill-pane", "-t", pane.as_str()])
+            .await?;
+        Ok(())
+    }
+}
+
+impl Runtime {
+    /// Private async helper for tmux CLI calls.
+    /// Maps non-success exits to TmuxError::Failed { op, detail }.
+    async fn tmux(&self, op: &'static str, args: &[&str]) -> Result<std::process::Output, TmuxError> {
+        let output = tokio::process::Command::new("tmux")
+            .args(args)
+            .output()
+            .await
+            .map_err(TmuxError::Io)?;
+
+        if !output.status.success() {
+            return Err(TmuxError::Failed {
+                op,
+                detail: String::from_utf8_lossy(&output.stderr).to_string(),
+            });
+        }
+        Ok(output)
     }
 }

--- a/rust/exo-runtime/src/tmux.rs
+++ b/rust/exo-runtime/src/tmux.rs
@@ -63,9 +63,16 @@ impl Tmux for Runtime {
 
         // 2. Buffer paste pattern — load-buffer temp + paste-buffer + send-keys Enter
         let payload = text.trim_end_matches('\n').trim_end_matches('\r');
-        let tmp = tempfile::NamedTempFile::new().map_err(TmuxError::Io)?;
-        let tmp_path = tmp.path();
-        tokio::fs::write(tmp_path, payload)
+        // NamedTempFile::new() does sync filesystem work; keep it off the async executor.
+        let tmp = tokio::task::spawn_blocking(tempfile::NamedTempFile::new)
+            .await
+            .map_err(|e| TmuxError::Failed {
+                op: "paste",
+                detail: format!("temp-file task join: {e}"),
+            })?
+            .map_err(TmuxError::Io)?;
+        let tmp_path = tmp.path().to_path_buf();
+        tokio::fs::write(&tmp_path, payload)
             .await
             .map_err(TmuxError::Io)?;
 
@@ -77,12 +84,10 @@ impl Tmux for Runtime {
                 .unwrap_or_default()
                 .to_string_lossy()
         );
+        let tmp_path_str = tmp_path.to_string_lossy().into_owned();
 
-        self.tmux(
-            "paste",
-            &["load-buffer", "-b", &buf_name, &tmp_path.to_string_lossy()],
-        )
-        .await?;
+        self.tmux("paste", &["load-buffer", "-b", &buf_name, &tmp_path_str])
+            .await?;
 
         self.tmux(
             "paste",

--- a/rust/exo-runtime/src/tmux.rs
+++ b/rust/exo-runtime/src/tmux.rs
@@ -1,0 +1,31 @@
+//! `impl Tmux for Runtime` — pane lifecycle + the tmux-paste delivery last-hop.
+//!
+//! **Leaf R2.** Adapt exomonad-core `TmuxIpc` (`services/tmux_ipc.rs`): `split_window`
+//! /`new_window` for `new_pane`, the buffer-paste pattern (`load-buffer` + `paste-buffer`
+//! + `send-keys Enter`) in `inject_input` for `paste`, `kill_pane` for `kill_pane`. Those
+//! are already async (`tokio::process` under the hood) — do NOT reintroduce blocking calls.
+//! `self.tmux_session` is the session name to target.
+//!
+//! Consumers (why this cap stays, despite "provisional"): the `Bus` last-hop (`paste`)
+//! and the `Spawner` (`new_pane`/`kill_pane`) both call it — it is runtime-internal, not
+//! policy-facing, but it is NOT zero-consumer.
+
+use crate::runtime::Runtime;
+use async_trait::async_trait;
+use exo_caps::{PaneId, Tmux, TmuxError};
+use std::path::Path;
+
+#[async_trait]
+impl Tmux for Runtime {
+    async fn new_pane(&self, _cwd: &Path, _cmd: &str) -> Result<PaneId, TmuxError> {
+        todo!("R2: tmux split/new-window in self.tmux_session at cwd running cmd; parse %N")
+    }
+
+    async fn paste(&self, _pane: &PaneId, _text: &str) -> Result<(), TmuxError> {
+        todo!("R2: buffer-paste pattern (load-buffer temp + paste-buffer + send-keys Enter)")
+    }
+
+    async fn kill_pane(&self, _pane: &PaneId) -> Result<(), TmuxError> {
+        todo!("R2: tmux kill-pane -t <pane>")
+    }
+}


### PR DESCRIPTION
## Wave 1 — `exo-runtime` cap impls (Runtime TL converge)

The `Runtime` struct now implements **every** `exo-caps` capability trait. This is the IO side of the seam that `exo-policy` monomorphizes against.

### Capabilities implemented
| Cap | Source |
|---|---|
| `Git` + `GitHub` | adapted from exomonad-core `GitService`/`GitHubService` (octocrab) |
| `Tmux` | adapted from `TmuxIpc` (buffer-paste last-hop) |
| `Fs` + `Process` + `Log` + `Kv` | std/tokio fs+process, file-kv, worktree-root log |
| `Bus` | **new** — jsonl append + cursor-resolvable inbox; stamp `IngestionEntry`, assert ≤ PIPE_BUF (no spill), append, no fsync |
| `Spawner` | **new** — record-first `birth()` (two-phase pane), 3 per-op methods fixing their `(kind, agent_type, role)` triple, `reclaim_worktree` + `kill_pane` teardown |

### New contract type
- `exo-caps::NodePapers` — the Type-1 birth-papers (`node.json`) written by the Spawner at birth, read by the Wave-2 node bootstrap. Shape per doc 01; `agent_type` derives from `role`, schema-versioned.

### Notes for the integrator (root)
- **Async-clean:** every cap op uses `tokio::fs`/`tokio::process` or the async cap methods — nothing blocks the executor.
- **Bus durability:** page-cache flush, not fsync (matches doc 02 — survives process crash, not power-loss). A buffered-write-loss bug (tokio `File` doesn't flush on drop) was caught and fixed at converge.
- **Spawner is ahead of spec in a good way:** the leaf wired `parent_inbox` via `$TMUX_PANE`, MCP/Gemini-settings config generation, and the `--papers` launch flag. These overlap Wave-2 wiring but are in-scope (spawner.rs only), correct, and follow the existing `init.rs` convention.
- **Inbound read-side (cursor + `notify`-watch) is deliberately NOT here** — it belongs to the Wave-2 sidecar inbound loop (N2b), which consumes this `Bus` cap's appends.

### Gate
`cargo check -p exo-runtime` → 0 errors, 0 warnings. `cargo test -p exo-runtime --lib` → 5/5 green (bus deliver/overflow/resolve-child + spawner ledger/inbox-derivation). All 9 `impl <Cap> for Runtime` blocks present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)