### PR TITLE
feat: harden spawner/inbox path layer and resolve child names

### DIFF
--- a/rust/exo-caps/src/lib.rs
+++ b/rust/exo-caps/src/lib.rs
@@ -16,6 +16,7 @@ pub mod bus;
 pub mod spawner;
 pub mod lifecycle;
 pub mod papers;
+pub mod paths;
 
 // IO caps — one trait per file (see `docs/design/swarm/05-crates-and-binary.md`).
 pub mod git;

--- a/rust/exo-caps/src/paths.rs
+++ b/rust/exo-caps/src/paths.rs
@@ -1,0 +1,58 @@
+use crate::{InboxPath, PaneId};
+use std::path::{Path, PathBuf};
+
+/// Child's OWN ingestion inbox: `{home}/.claude/exo/inboxes/{run_id}/pane-{n}.jsonl`.
+pub fn inbox_path(home: &Path, run_id: &str, pane: &PaneId) -> InboxPath {
+    let n = pane.as_str().trim_start_matches('%');
+    InboxPath::new(
+        home.join(".claude/exo/inboxes")
+            .join(run_id)
+            .join(format!("pane-{n}.jsonl")),
+    )
+}
+
+/// Child's NodePapers path: `{home}/.claude/exo/papers/{run_id}/pane-{n}.json`.
+pub fn papers_path(home: &Path, run_id: &str, pane: &PaneId) -> PathBuf {
+    let n = pane.as_str().trim_start_matches('%');
+    home.join(".claude/exo/papers")
+        .join(run_id)
+        .join(format!("pane-{n}.json"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::PaneId;
+
+    #[test]
+    fn test_paths_strip_percent() {
+        let home = Path::new("/home/user");
+        let run_id = "run-42";
+        let pane = PaneId::new("%317".into()).unwrap();
+
+        let inbox = inbox_path(home, run_id, &pane);
+        assert_eq!(
+            inbox.as_path(),
+            Path::new("/home/user/.claude/exo/inboxes/run-42/pane-317.jsonl")
+        );
+
+        let papers = papers_path(home, run_id, &pane);
+        assert_eq!(
+            papers,
+            Path::new("/home/user/.claude/exo/papers/run-42/pane-317.json")
+        );
+    }
+
+    #[test]
+    fn test_paths_no_percent_defensive() {
+        // PaneId::new would actually reject this, but the helper should be robust
+        // if we ever bypassed it or changed PaneId.
+        // Actually PaneId::new is the only way to get a PaneId.
+        // Let's just test that it works as expected.
+        let home = Path::new(".");
+        let run_id = "run";
+        let pane = PaneId::new("%1".into()).unwrap();
+        let inbox = inbox_path(home, run_id, &pane);
+        assert!(inbox.as_path().to_string_lossy().ends_with("pane-1.jsonl"));
+    }
+}

--- a/rust/exo-runtime/src/bus.rs
+++ b/rust/exo-runtime/src/bus.rs
@@ -118,7 +118,7 @@ impl Bus for Runtime {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use exo_caps::{AgentName, Branch, MessageBody, MessageKind, NodePath, Summary};
+    use exo_caps::{AgentName, Branch, MessageBody, MessageKind, NodePath, PaneId, Summary};
     use tempfile::tempdir;
 
     #[tokio::test]
@@ -135,6 +135,7 @@ mod tests {
             Some(inbox),
             "run-1".into(),
             "session-1".into(),
+            PaneId::new("%1".into()).unwrap(),
         );
 
         let msg = Message {
@@ -169,6 +170,7 @@ mod tests {
             Some(inbox),
             "run-1".into(),
             "session-1".into(),
+            PaneId::new("%1".into()).unwrap(),
         );
 
         // Build a body that is large enough that when combined with the envelope it exceeds 4096.
@@ -214,6 +216,7 @@ mod tests {
             None,
             "run-1".into(),
             "session-1".into(),
+            PaneId::new("%100".into()).unwrap(),
         );
 
         let resolved = runtime

--- a/rust/exo-runtime/src/runtime.rs
+++ b/rust/exo-runtime/src/runtime.rs
@@ -6,7 +6,7 @@
 //! modules (`git`, `github`, `tmux`, `bus`, `spawner`, `fs`, `process`, `log`, `kv`); this
 //! file owns **only** the struct + its accessors, so cap leaves never collide here.
 
-use exo_caps::{AgentName, Branch, InboxPath, NodePath};
+use exo_caps::{AgentName, Branch, InboxPath, NodePath, PaneId};
 use std::path::{Path, PathBuf};
 
 /// One node's runtime. Holds the node's birth identity + the ambient context the cap
@@ -32,6 +32,8 @@ pub struct Runtime {
     pub(crate) run_id: String,
     /// tmux session name (for pane creation + the tmux-paste delivery last-hop).
     pub(crate) tmux_session: String,
+    /// This node's own tmux pane id.
+    pub(crate) own_pane: PaneId,
 }
 
 impl Runtime {
@@ -43,6 +45,7 @@ impl Runtime {
         parent_inbox: Option<InboxPath>,
         run_id: String,
         tmux_session: String,
+        own_pane: PaneId,
     ) -> Self {
         Runtime {
             node_path,
@@ -51,6 +54,7 @@ impl Runtime {
             parent_inbox,
             run_id,
             tmux_session,
+            own_pane,
         }
     }
 
@@ -73,4 +77,18 @@ impl Runtime {
     pub fn working_dir(&self) -> &Path {
         &self.working_dir
     }
+
+    /// This node's own pane id.
+    pub fn own_pane(&self) -> &PaneId {
+        &self.own_pane
+    }
+
+    /// This node's own ingestion inbox.
+    pub(crate) fn own_inbox(&self) -> InboxPath {
+        exo_caps::paths::inbox_path(&home(), &self.run_id, &self.own_pane)
+    }
+}
+
+fn home() -> PathBuf {
+    std::env::var("HOME").map(PathBuf::from).unwrap_or_else(|_| PathBuf::from("."))
 }

--- a/rust/exo-runtime/src/spawner.rs
+++ b/rust/exo-runtime/src/spawner.rs
@@ -45,7 +45,7 @@ use exo_caps::{
     AgentName, AgentType, Branch, ChildKind, ChildRecord, ForkSpec, GeminiSpec, InboxPath, NodeKind,
     NodePapers, PaneId, SpawnError, Spawner, WorkerSpec,
 };
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tokio::io::AsyncWriteExt;
 
 /// The fixed triple + identity each op hands to the shared `birth` tail. Constructed by
@@ -117,17 +117,36 @@ impl Runtime {
     }
 
     /// The child's OWN ingestion inbox, derived from its pane + the run-id namespace:
-    /// `~/.claude/exo/inboxes/{run_id}/pane-{N}.jsonl` (pane `%317` → `pane-317.jsonl`).
+    /// `~/.claude/exo/inboxes/{run_id}/pane-{N}.jsonl`.
     /// Stored in the child's `Spawned` record so the parent can address DOWN to it.
     pub(crate) fn child_inbox_path(&self, pane: &PaneId) -> InboxPath {
         let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
-        let n = pane.as_str().trim_start_matches('%');
-        InboxPath::new(
-            PathBuf::from(home)
-                .join(".claude/exo/inboxes")
-                .join(&self.run_id)
-                .join(format!("pane-{n}.jsonl")),
-        )
+        exo_caps::paths::inbox_path(Path::new(&home), &self.run_id, pane)
+    }
+
+    pub(crate) async fn resolve_child_name(&self, given: Option<AgentName>, prefix: &str) -> Result<AgentName, SpawnError> {
+        let records = self.read_child_records().await?;
+        let current_set = exo_caps::fold_children(&records);
+
+        if let Some(name) = given {
+            if current_set.contains_key(&name) {
+                return Err(SpawnError::Failed {
+                    op: "spawn",
+                    child: Some(name),
+                    detail: "duplicate child name".into(),
+                });
+            }
+            Ok(name)
+        } else {
+            let mut i = 0;
+            loop {
+                let name = AgentName::new(format!("{}-{}", prefix, i)).unwrap();
+                if !current_set.contains_key(&name) {
+                    return Ok(name);
+                }
+                i += 1;
+            }
+        }
     }
 }
 
@@ -172,15 +191,7 @@ impl Runtime {
         self.append_child_record(&record).await?;
 
         // (e) Write child papers
-        let parent_inbox = if let Ok(pane_str) = std::env::var("TMUX_PANE") {
-            if let Ok(my_pane) = PaneId::new(pane_str) {
-                Some(self.child_inbox_path(&my_pane))
-            } else {
-                None
-            }
-        } else {
-            None
-        };
+        let parent_inbox = Some(self.own_inbox());
 
         let papers = NodePapers::new(
             self.node_path().child(&core.name),
@@ -194,11 +205,7 @@ impl Runtime {
             ChildKind::Worktree => child_dir.join(".exo/node.json"),
             ChildKind::Inline => {
                 let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
-                let n = pane.as_str().trim_start_matches('%');
-                PathBuf::from(home)
-                    .join(".claude/exo/papers")
-                    .join(&self.run_id)
-                    .join(format!("pane-{n}.json"))
+                exo_caps::paths::papers_path(Path::new(&home), &self.run_id, &pane)
             }
         };
 
@@ -298,7 +305,7 @@ impl Runtime {
 #[async_trait]
 impl Spawner for Runtime {
     async fn spawn_worker(&self, spec: WorkerSpec) -> Result<AgentName, SpawnError> {
-        let name = spec.name.unwrap_or_else(|| AgentName::new("worker".into()).unwrap());
+        let name = self.resolve_child_name(spec.name, "worker").await?;
         let core = BirthCore {
             kind: ChildKind::Inline,
             agent_type: AgentType::Gemini,
@@ -311,7 +318,7 @@ impl Spawner for Runtime {
     }
 
     async fn spawn_gemini(&self, spec: GeminiSpec) -> Result<AgentName, SpawnError> {
-        let name = spec.name.unwrap_or_else(|| AgentName::new("dev".into()).unwrap());
+        let name = self.resolve_child_name(spec.name, "dev").await?;
         let core = BirthCore {
             kind: ChildKind::Worktree,
             agent_type: AgentType::Gemini,
@@ -325,10 +332,14 @@ impl Spawner for Runtime {
 
     async fn fork_wave(&self, specs: Vec<ForkSpec>) -> Vec<Result<AgentName, SpawnError>> {
         let mut results = Vec::with_capacity(specs.len());
-        for (i, spec) in specs.into_iter().enumerate() {
-            let name = spec
-                .name
-                .unwrap_or_else(|| AgentName::new(format!("tl-{}", i)).unwrap());
+        for spec in specs {
+            let name = match self.resolve_child_name(spec.name, "tl").await {
+                Ok(n) => n,
+                Err(e) => {
+                    results.push(Err(e));
+                    continue;
+                }
+            };
             let core = BirthCore {
                 kind: ChildKind::Worktree,
                 agent_type: AgentType::Claude,
@@ -405,6 +416,7 @@ mod tests {
             None,
             "test-run".into(),
             "test-session".into(),
+            PaneId::new("%100".into()).unwrap(),
         );
 
         let pane = PaneId::new("%1".into()).unwrap();
@@ -427,6 +439,50 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_resolve_child_name() {
+        let tmp = tempdir().unwrap();
+        let rt = Runtime::new(
+            NodePath::new(vec![an("root")]).unwrap(),
+            Branch::new("main".into()).unwrap(),
+            tmp.path().to_path_buf(),
+            None,
+            "run".into(),
+            "session".into(),
+            PaneId::new("%100".into()).unwrap(),
+        );
+
+        // 1. Unnamed → worker-0
+        let name0 = rt.resolve_child_name(None, "worker").await.unwrap();
+        assert_eq!(name0.as_str(), "worker-0");
+
+        // 2. Add worker-0 to ledger
+        let pane = PaneId::new("%1".into()).unwrap();
+        rt.append_child_record(&ChildRecord::Spawned {
+            child: name0.clone(),
+            kind: ChildKind::Inline,
+            pane: pane.clone(),
+            inbox: rt.child_inbox_path(&pane),
+        })
+        .await
+        .unwrap();
+
+        // 3. Unnamed again → worker-1
+        let name1 = rt.resolve_child_name(None, "worker").await.unwrap();
+        assert_eq!(name1.as_str(), "worker-1");
+
+        // 4. Explicit duplicate → Err
+        let res = rt.resolve_child_name(Some(name0), "worker").await;
+        match res {
+            Err(SpawnError::Failed { detail, .. }) => assert!(detail.contains("duplicate")),
+            _ => panic!("expected duplicate error"),
+        }
+
+        // 5. Explicit unique → Ok
+        let name_unique = rt.resolve_child_name(Some(an("custom")), "worker").await.unwrap();
+        assert_eq!(name_unique.as_str(), "custom");
+    }
+
+    #[tokio::test]
     async fn test_child_inbox_path_derivation() {
         let tmp = tempdir().unwrap();
         let rt = Runtime::new(
@@ -436,6 +492,7 @@ mod tests {
             None,
             "run-42".into(),
             "session".into(),
+            PaneId::new("%100".into()).unwrap(),
         );
 
         let path = rt.child_inbox_path(&PaneId::new("%317".into()).unwrap());

--- a/rust/exo-runtime/src/tmux.rs
+++ b/rust/exo-runtime/src/tmux.rs
@@ -1,9 +1,11 @@
 //! `impl Tmux for Runtime` — pane lifecycle + the tmux-paste delivery last-hop.
 //!
 //! **Leaf R2.** Adapt exomonad-core `TmuxIpc` (`services/tmux_ipc.rs`): `split_window`
-//! /`new_window` for `new_pane`, the buffer-paste pattern (`load-buffer` + `paste-buffer`
-//! + `send-keys Enter`) in `inject_input` for `paste`, `kill_pane` for `kill_pane`. Those
-//! are already async (`tokio::process` under the hood) — do NOT reintroduce blocking calls.
+//! or `new_window` for `new_pane`, the buffer-paste pattern (`load-buffer` +
+//! `paste-buffer` + `send-keys Enter`) in `inject_input` for `paste`,
+//! `kill_pane` for `kill_pane`. Those are already async (`tokio::process`
+//! under the hood) — do NOT reintroduce blocking calls.
+//!
 //! `self.tmux_session` is the session name to target.
 //!
 //! Consumers (why this cap stays, despite "provisional"): the `Bus` last-hop (`paste`)


### PR DESCRIPTION
Harden the exo-runtime spawn/inbox path layer.

1.  **FIX 1 (Path Deduplication)**: Created `exo-caps::paths` with `inbox_path` and `papers_path`. All hand-rolled pane-stripping and path formatting in `exo-runtime` (spawner and bus) now route through these tested helpers.
2.  **FIX 2 (Parent Inbox Reliability)**: Added `own_pane: PaneId` to `Runtime`. Every node now knows its own pane by invariant. In `birth`, `parent_inbox` is structurally guaranteed by setting it to `Some(self.own_inbox())`, eliminating the silent `TMUX_PANE` env fallback.
3.  **FIX 3 (Child Naming Correctness)**: Implemented `resolve_child_name` to handle unique name derivation (e.g., `worker-0`, `worker-1`) and return a loud error on explicit duplicates. `spawn_worker`, `spawn_gemini`, and `fork_wave` now use this helper, preventing silent ledger overwrites.

Includes unit tests for the new path helpers and the naming resolution logic. Verified with `cargo test` and `clippy`.