### PR TITLE
feat(policy): implement on_world_event and wire role toolsets

### DIFF
--- a/rust/exo-policy/src/events.rs
+++ b/rust/exo-policy/src/events.rs
@@ -9,6 +9,9 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::BoxFuture;
+use exo_caps::GitHub;
+
 /// The one typed event enum. A `kind=event` ingestion entry has its body parsed into this
 /// before `on_world_event` runs; the in-process self-poll constructs one directly. There is
 /// **no** parallel `EventType` on the message envelope (`MessageKind::Event` is a bare tag).
@@ -62,9 +65,58 @@ pub enum EventAction {
     NoAction,
 }
 
+pub fn on_world_event<'a, R: GitHub + Send + Sync>(
+    _ctx: &'a R,
+    e: &'a WorldEvent,
+) -> BoxFuture<'a, EventAction> {
+    Box::pin(async move {
+        match e {
+            WorldEvent::PrReview { pr, state } => match state {
+                ReviewState::Approved => EventAction::NotifyParent {
+                    text: format!(
+                        "[PR READY] PR #{} approved by Copilot review. Merge with `merge_pr` tool.",
+                        pr
+                    ),
+                    summary: "[PR READY]".to_string(),
+                },
+                ReviewState::ChangesRequested | ReviewState::Commented => EventAction::NoAction,
+            },
+            WorldEvent::SiblingMerged { pr: _, branch } => {
+                let parent_branch = if let Some(last_dot) = branch.rfind('.') {
+                    &branch[..last_dot]
+                } else {
+                    "main"
+                };
+                EventAction::InjectMessage {
+                    text: format!(
+                        "[Sibling Merged] PR on branch {} was merged into {}. Rebase your branch to pick up the changes: git fetch origin && git rebase origin/{}",
+                        branch, parent_branch, parent_branch
+                    ),
+                    summary: "[Sibling Merged]".to_string(),
+                }
+            }
+            WorldEvent::CiStatus { pr, status } => match status {
+                CiStatus::Failing => EventAction::NotifyParent {
+                    text: format!("[CI FAILING] PR #{} has failing CI status.", pr),
+                    summary: "[CI FAILING]".to_string(),
+                },
+                CiStatus::Passing | CiStatus::Pending => EventAction::NoAction,
+            },
+            WorldEvent::ReviewTimeout { pr } => EventAction::NotifyParent {
+                text: format!(
+                    "[REVIEW TIMEOUT] PR #{} — no Copilot review after 15 minutes. Merge with `merge_pr` using `force: true`.",
+                    pr
+                ),
+                summary: "[REVIEW TIMEOUT]".to_string(),
+            },
+        }
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::testing::MockRuntime;
 
     #[test]
     fn world_event_serde_round_trips() {
@@ -88,5 +140,65 @@ mod tests {
             serde_json::to_value(&a).unwrap(),
             serde_json::json!({ "action": "no_action" })
         );
+    }
+
+    #[tokio::test]
+    async fn test_on_world_event_approved() {
+        let ctx = MockRuntime::default();
+        let e = WorldEvent::PrReview {
+            pr: 123,
+            state: ReviewState::Approved,
+        };
+        let action = on_world_event(&ctx, &e).await;
+        if let EventAction::NotifyParent { text, summary } = action {
+            assert!(text.contains("[PR READY]"));
+            assert!(text.contains("123"));
+            assert_eq!(summary, "[PR READY]");
+        } else {
+            panic!("Expected NotifyParent, got {:?}", action);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_on_world_event_timeout() {
+        let ctx = MockRuntime::default();
+        let e = WorldEvent::ReviewTimeout { pr: 123 };
+        let action = on_world_event(&ctx, &e).await;
+        if let EventAction::NotifyParent { text, summary } = action {
+            assert!(text.contains("[REVIEW TIMEOUT]"));
+            assert!(text.contains("123"));
+            assert_eq!(summary, "[REVIEW TIMEOUT]");
+        } else {
+            panic!("Expected NotifyParent, got {:?}", action);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_on_world_event_changes_requested() {
+        let ctx = MockRuntime::default();
+        let e = WorldEvent::PrReview {
+            pr: 123,
+            state: ReviewState::ChangesRequested,
+        };
+        let action = on_world_event(&ctx, &e).await;
+        assert_eq!(action, EventAction::NoAction);
+    }
+
+    #[tokio::test]
+    async fn test_on_world_event_sibling_merged() {
+        let ctx = MockRuntime::default();
+        let e = WorldEvent::SiblingMerged {
+            pr: 123,
+            branch: "main.feature-a".to_string(),
+        };
+        let action = on_world_event(&ctx, &e).await;
+        if let EventAction::InjectMessage { text, summary } = action {
+            assert!(text.contains("[Sibling Merged]"));
+            assert!(text.contains("main.feature-a"));
+            assert!(text.contains("merged into main"));
+            assert_eq!(summary, "[Sibling Merged]");
+        } else {
+            panic!("Expected InjectMessage, got {:?}", action);
+        }
     }
 }

--- a/rust/exo-policy/src/roles.rs
+++ b/rust/exo-policy/src/roles.rs
@@ -10,9 +10,14 @@
 //! compiles and downstream (the sidecar) can already call `role_def`.
 
 use crate::caps::PolicyCaps;
-use crate::events::{EventAction, WorldEvent};
-use crate::hooks::{HookDecision, HookInput, SessionStartOutput, StopDecision};
+use crate::events::{on_world_event, EventAction, WorldEvent};
+use crate::hooks::{pre_tool_use, session_start, stop, HookDecision, HookInput, SessionStartOutput, StopDecision};
 use crate::tool::{BoxFuture, Tool};
+use crate::tools::file_pr::FilePr;
+use crate::tools::merge_pr::MergePr;
+use crate::tools::messaging::{NotifyParent, SendMessage};
+use crate::tools::spawn::{ForkWave, SpawnGemini, SpawnWorker};
+use crate::tools::tasks::{TaskGet, TaskList, TaskUpdate};
 use exo_caps::NodeKind;
 
 /// A hook is an async fn over the concrete runtime `R`. Stored as a plain fn-pointer so the
@@ -35,39 +40,53 @@ pub struct RoleDef<R: Send + Sync> {
     pub on_event: OnEventFn<R>,
 }
 
-// Default no-op hooks — the scaffold's wiring so the table compiles before P6/P7 supply the
-// real fns. P7 replaces these per-role with the ported guard/stop/event logic.
-fn allow_all<'a, R: PolicyCaps>(_ctx: &'a R, _input: &'a HookInput) -> BoxFuture<'a, HookDecision> {
-    Box::pin(async { HookDecision::Allow })
-}
-fn allow_stop<R: PolicyCaps>(_ctx: &R) -> BoxFuture<'_, StopDecision> {
-    Box::pin(async { StopDecision::Allow })
-}
-fn no_context<R: PolicyCaps>(_ctx: &R) -> BoxFuture<'_, SessionStartOutput> {
-    Box::pin(async { SessionStartOutput::default() })
-}
-fn no_event<'a, R: PolicyCaps>(_ctx: &'a R, _e: &'a WorldEvent) -> BoxFuture<'a, EventAction> {
-    Box::pin(async { EventAction::NoAction })
-}
-
 /// The per-role policy table. Hand-written `match` — the single place a role's tool list +
 /// hooks are named. P1–P6 add tool types to the `tools` vecs; P7 swaps the no-op hooks for
 /// the real per-role fns.
 pub fn role_def<R: PolicyCaps>(kind: NodeKind) -> RoleDef<R> {
-    // Every arm currently shares the no-op hooks + an empty toolset. Distinct arms are kept
-    // so P1–P7 fill each independently without restructuring.
-    let base = || RoleDef::<R> {
-        tools: Vec::new(),
-        pre_tool_use: allow_all::<R>,
-        stop: allow_stop::<R>,
-        session_start: no_context::<R>,
-        on_event: no_event::<R>,
-    };
     match kind {
-        NodeKind::Root => base(),
-        NodeKind::Tl => base(),
-        NodeKind::Dev => base(),
-        NodeKind::Worker => base(),
+        NodeKind::Root | NodeKind::Tl => RoleDef {
+            tools: vec![
+                Box::new(ForkWave),
+                Box::new(SpawnGemini),
+                Box::new(SpawnWorker),
+                Box::new(FilePr),
+                Box::new(MergePr),
+                Box::new(NotifyParent),
+                Box::new(SendMessage),
+            ],
+            pre_tool_use,
+            stop,
+            session_start,
+            on_event: on_world_event,
+        },
+        NodeKind::Dev => RoleDef {
+            tools: vec![
+                Box::new(FilePr),
+                Box::new(NotifyParent),
+                Box::new(SendMessage),
+                Box::new(TaskList),
+                Box::new(TaskGet),
+                Box::new(TaskUpdate),
+            ],
+            pre_tool_use,
+            stop,
+            session_start,
+            on_event: on_world_event,
+        },
+        NodeKind::Worker => RoleDef {
+            tools: vec![
+                Box::new(NotifyParent),
+                Box::new(SendMessage),
+                Box::new(TaskList),
+                Box::new(TaskGet),
+                Box::new(TaskUpdate),
+            ],
+            pre_tool_use,
+            stop,
+            session_start,
+            on_event: on_world_event,
+        },
     }
 }
 
@@ -77,16 +96,33 @@ mod tests {
     use crate::testing::MockRuntime;
 
     #[tokio::test]
-    async fn every_role_builds_and_hooks_default_to_allow() {
+    async fn every_role_builds_non_empty_tools() {
         for kind in [NodeKind::Root, NodeKind::Tl, NodeKind::Dev, NodeKind::Worker] {
             let rd = role_def::<MockRuntime>(kind);
-            let ctx = MockRuntime::default();
-            let input = HookInput {
-                tool_name: "x".into(),
-                tool_input: serde_json::Value::Null,
-            };
-            assert_eq!((rd.pre_tool_use)(&ctx, &input).await, HookDecision::Allow);
-            assert_eq!((rd.stop)(&ctx).await, StopDecision::Allow);
+            assert!(!rd.tools.is_empty(), "Role {:?} should have tools", kind);
+            
+            // Verify hooks are wired (pointers are non-null by definition of fn pointers in Rust)
+            assert_eq!(rd.pre_tool_use as usize, pre_tool_use::<MockRuntime> as *const () as usize);
+            assert_eq!(rd.stop as usize, stop::<MockRuntime> as *const () as usize);
+            assert_eq!(rd.session_start as usize, session_start::<MockRuntime> as *const () as usize);
+            assert_eq!(rd.on_event as usize, on_world_event::<MockRuntime> as *const () as usize);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_role_stop_gate_blocks_when_needed() {
+        let rd = role_def::<MockRuntime>(NodeKind::Dev);
+        let ctx = MockRuntime {
+            pr_for_branch: Some(123),
+            has_unaddressed_changes: true,
+            ..Default::default()
+        };
+        
+        match (rd.stop)(&ctx).await {
+            StopDecision::Block { reason } => {
+                assert!(reason.contains("Open PR #123 has unaddressed ChangesRequested"));
+            }
+            _ => panic!("Should be blocked by unaddressed changes"),
         }
     }
 }

--- a/rust/exo-policy/src/tools/file_pr.rs
+++ b/rust/exo-policy/src/tools/file_pr.rs
@@ -69,9 +69,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_file_pr_dotted_branch() {
-        let mut mock = MockRuntime::default();
-        mock.current_branch = Branch::new("main.policy-claude.p4".into()).unwrap();
-        mock.next_pr = 123;
+        let mock = MockRuntime {
+            current_branch: Branch::new("main.policy-claude.p4".into()).unwrap(),
+            next_pr: 123,
+            ..Default::default()
+        };
 
         let args = FilePrArgs {
             title: "Test PR".into(),
@@ -90,9 +92,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_file_pr_no_dot_branch() {
-        let mut mock = MockRuntime::default();
-        mock.current_branch = Branch::new("feature-branch".into()).unwrap();
-        mock.next_pr = 456;
+        let mock = MockRuntime {
+            current_branch: Branch::new("feature-branch".into()).unwrap(),
+            next_pr: 456,
+            ..Default::default()
+        };
 
         let args = FilePrArgs {
             title: "Standalone PR".into(),

--- a/rust/exo-policy/src/tools/merge_pr.rs
+++ b/rust/exo-policy/src/tools/merge_pr.rs
@@ -101,10 +101,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_merge_pr_self_merge_blocked() {
-        let mut mock = MockRuntime::default();
         let branch = Branch::new("feat.topic".into()).unwrap();
-        mock.current_branch = branch.clone();
-        mock.pr_for_branch = Some(123); // Current branch has PR 123
+        let mock = MockRuntime {
+            current_branch: branch.clone(),
+            pr_for_branch: Some(123), // Current branch has PR 123
+            ..Default::default()
+        };
 
         let args = MergePrArgs { pr: 123 }; // Trying to merge own PR 123
         let out = MergePr::run(&mock, args).await.unwrap();
@@ -123,8 +125,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_merge_pr_unaddressed_changes_blocked() {
-        let mut mock = MockRuntime::default();
-        mock.has_unaddressed_changes = true;
+        let mock = MockRuntime {
+            has_unaddressed_changes: true,
+            ..Default::default()
+        };
 
         let args = MergePrArgs { pr: 123 };
         let out = MergePr::run(&mock, args).await.unwrap();


### PR DESCRIPTION
This PR implements the `on_world_event` handler in `exo-policy/src/events.rs` and wires the real toolsets and hooks into the `role_def` table in `exo-policy/src/roles.rs`.

Key changes:
- Implemented `on_world_event` with logic for `PrReview::Approved`, `SiblingMerged`, `CiStatus::Failing`, and `ReviewTimeout`.
- Wired all MCP tool types into `role_def` for `Root`, `Tl`, `Dev`, and `Worker` roles.
- Replaced no-op scaffold hooks with real `pre_tool_use`, `stop`, `session_start`, and `on_world_event` functions.
- Added comprehensive unit tests for `on_world_event`.
- Updated role tests to verify toolset population and hook wiring.
- Fixed minor clippy warnings in `file_pr.rs` and `merge_pr.rs` (with user permission) to ensure a clean build.

This completes the `exo-policy` layer convergence.
