### PR TITLE
feat: default-allow pre_tool_use nudges and force merge_pr

### DIFF
--- a/docs/design/swarm/04-policy.md
+++ b/docs/design/swarm/04-policy.md
@@ -40,7 +40,7 @@ DSL. Everything else in the old guest was WASM-boundary tax that *deletes* — s
    enum StopDecision { Allow, Block { reason: String } }
    enum EventAction  { InjectMessage{text,summary}, NotifyParent{text,summary}, NoAction }
 
-   fn pre_tool_use<C: Kv>(ctx: &C, input: &HookInput) -> HookDecision; // guards/PII — &C for data-dependent checks (Kv allowlists)
+   fn pre_tool_use<C>(ctx: &C, input: &HookInput) -> HookDecision; // antipattern nudges/PII — &C for data-dependent heuristics
    fn stop<C: GitHub>(ctx: &C) -> StopDecision;                       // LIVE query — no phase
    fn on_world_event<C: GitHub>(ctx: &C, e: &WorldEvent) -> EventAction; // RETURNS an action (loop delivers); bound is per-handler — GitHub here to inspect PR/CI state
    ```
@@ -60,8 +60,7 @@ DSL. Everything else in the old guest was WASM-boundary tax that *deletes* — s
        match kind {
            NodeKind::Dev => RoleDef {
                tools: vec![b(FilePr), b(NotifyParent), b(SendMessage)], // a clean list of tool types
-               pre_tool_use: dev_guard, stop: dev_stop, on_event: dev_events,
-           },
+               pre_tool_use: dev_nudges, stop: dev_stop, on_event: dev_events,           },
            /* Root / Tl / Worker … */
        }
    }
@@ -155,7 +154,7 @@ because the sidecar reliably reaps its own pane on the control message.
 
 - **Tools:** `file_pr`, `merge_pr`, `spawn_*`, `tasks_*`, messaging (already in
   `teams-mcp`). Per-tool `Args`/handlers ported one at a time.
-- **Hooks kept:** `pre_tool_use` (guards + PII-rewrite), `stop` (live PR gate),
+- **Hooks kept:** `pre_tool_use` (antipattern nudges + PII-rewrite), `stop` (live PR gate),
   `session_start` (root identity bootstrap).
 - **Events:** `WorldEvent { PrReview, SiblingMerged, CiStatus, ReviewTimeout }` →
   `EventAction`. Behavior ported from the current poller/event handlers. **This is

--- a/docs/design/swarm/04-policy.md
+++ b/docs/design/swarm/04-policy.md
@@ -60,7 +60,10 @@ DSL. Everything else in the old guest was WASM-boundary tax that *deletes* — s
        match kind {
            NodeKind::Dev => RoleDef {
                tools: vec![b(FilePr), b(NotifyParent), b(SendMessage)], // a clean list of tool types
-               pre_tool_use: dev_nudges, stop: dev_stop, on_event: dev_events,           },
+               pre_tool_use: dev_nudges,
+               stop: dev_stop,
+               on_event: dev_events,
+           },
            /* Root / Tl / Worker … */
        }
    }

--- a/rust/exo-policy/src/hooks.rs
+++ b/rust/exo-policy/src/hooks.rs
@@ -64,12 +64,21 @@ pub fn pre_tool_use<'a, R: Send + Sync>(
 
     Box::pin(async move {
         // Antipattern: Avoid `git add .` or `git add -A`.
-        if tool_name == "run_shell_command" {
+        // Appears in Gemini's `run_shell_command` and Claude's `Bash`.
+        if tool_name == "run_shell_command" || tool_name == "Bash" {
             if let Some(cmd) = tool_input.get("command").and_then(|v| v.as_str()) {
-                if cmd.contains("git add .") || cmd.contains("git add -A") {
-                    return HookDecision::Deny {
-                        reason: "Avoid `git add -A`/`git add .` — stage specific files by path to avoid committing stray artifacts.".into(),
-                    };
+                let parts: Vec<&str> = cmd.split_whitespace().collect();
+                for i in 0..parts.len() {
+                    // Look for 'git add' followed by '.' or '-A' as a distinct argument.
+                    if parts[i] == "git"
+                        && i + 2 < parts.len()
+                        && parts[i + 1] == "add"
+                        && (parts[i + 2] == "." || parts[i + 2] == "-A")
+                    {
+                        return HookDecision::Deny {
+                            reason: "Avoid `git add -A`/`git add .` — stage specific files by path to avoid committing stray artifacts.".into(),
+                        };
+                    }
                 }
             }
         }
@@ -162,37 +171,64 @@ mod tests {
     #[tokio::test]
     async fn test_pre_tool_use_git_add_antipattern_denied() {
         let ctx = MockRuntime::default();
-        let input = HookInput {
-            tool_name: "run_shell_command".into(),
-            tool_input: json!({ "command": "git add ." }),
-        };
-        match pre_tool_use(&ctx, &input).await {
-            HookDecision::Deny { reason } => {
-                assert!(reason.contains("Avoid `git add -A`/`git add .`"));
-            }
-            _ => panic!("Should be Deny for antipattern"),
-        }
+        let tools = ["run_shell_command", "Bash"];
 
-        let input_a = HookInput {
-            tool_name: "run_shell_command".into(),
-            tool_input: json!({ "command": "git add -A" }),
-        };
-        match pre_tool_use(&ctx, &input_a).await {
-            HookDecision::Deny { reason } => {
-                assert!(reason.contains("Avoid `git add -A`/`git add .`"));
+        for tool in tools {
+            let input = HookInput {
+                tool_name: tool.into(),
+                tool_input: json!({ "command": "git add ." }),
+            };
+            match pre_tool_use(&ctx, &input).await {
+                HookDecision::Deny { reason } => {
+                    assert!(reason.contains("Avoid `git add -A`/`git add .`"));
+                }
+                _ => panic!("Should be Deny for {} with 'git add .'", tool),
             }
-            _ => panic!("Should be Deny for antipattern"),
+
+            let input_a = HookInput {
+                tool_name: tool.into(),
+                tool_input: json!({ "command": "git add -A" }),
+            };
+            match pre_tool_use(&ctx, &input_a).await {
+                HookDecision::Deny { reason } => {
+                    assert!(reason.contains("Avoid `git add -A`/`git add .`"));
+                }
+                _ => panic!("Should be Deny for {} with 'git add -A'", tool),
+            }
+
+            // Test with extra whitespace
+            let input_ws = HookInput {
+                tool_name: tool.into(),
+                tool_input: json!({ "command": "  git   add    .  " }),
+            };
+            assert!(matches!(
+                pre_tool_use(&ctx, &input_ws).await,
+                HookDecision::Deny { .. }
+            ));
         }
     }
 
     #[tokio::test]
     async fn test_pre_tool_use_git_add_specific_allowed() {
         let ctx = MockRuntime::default();
-        let input = HookInput {
-            tool_name: "run_shell_command".into(),
-            tool_input: json!({ "command": "git add src/main.rs" }),
-        };
-        assert_eq!(pre_tool_use(&ctx, &input).await, HookDecision::Allow);
+        let cases = [
+            "git add src/main.rs",
+            "git add .gitignore",
+            "git add ./src/file",
+        ];
+
+        for cmd in cases {
+            let input = HookInput {
+                tool_name: "run_shell_command".into(),
+                tool_input: json!({ "command": cmd }),
+            };
+            assert_eq!(
+                pre_tool_use(&ctx, &input).await,
+                HookDecision::Allow,
+                "Should allow '{}'",
+                cmd
+            );
+        }
     }
 
     #[tokio::test]

--- a/rust/exo-policy/src/hooks.rs
+++ b/rust/exo-policy/src/hooks.rs
@@ -1,4 +1,4 @@
-//! Hooks — `pre_tool_use` (guards / PII-rewrite), `stop` (the live PR-gate), and
+//! Hooks — `pre_tool_use` (antipattern nudges), `stop` (the live PR-gate), and
 //! `session_start` (root identity bootstrap). These are **functions generic over the caps
 //! they need** (no `dyn Caps`); the [`RoleDef`](crate::roles::RoleDef) table stores them as
 //! `fn(&R, …) -> BoxFuture<…>` monomorphized at the concrete runtime `R`, so the generic
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::tool::BoxFuture;
-use exo_caps::{Git, GitHub, Kv};
+use exo_caps::{Git, GitHub};
 
 /// A `PreToolUse` verdict. `Modify` rewrites the tool input in place (the PII-rewrite path).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -51,27 +51,30 @@ pub struct HookInput {
 }
 
 /// Ported hook implementations.
-pub fn pre_tool_use<'a, R: Kv + Send + Sync>(
-    ctx: &'a R,
+///
+/// `pre_tool_use` is a **default-ALLOW antipattern-nudge** hook. It inspects tool calls
+/// for known antipatterns and returns `Deny` with a guidance message or `Modify` to
+/// rewrite the call toward a better pattern. It is NOT a security/allowlist gate.
+pub fn pre_tool_use<'a, R: Send + Sync>(
+    _ctx: &'a R,
     input: &'a HookInput,
 ) -> BoxFuture<'a, HookDecision> {
     let tool_name = input.tool_name.clone();
+    let tool_input = input.tool_input.clone();
+
     Box::pin(async move {
-        // Guard check: look up "allowlist:{tool_name}" in KV.
-        // Enforce allowlist semantics (deny by default).
-        let key = format!("allowlist:{}", tool_name);
-        match ctx.get(&key).await {
-            Ok(Some(v)) if v == "allow" => HookDecision::Allow,
-            Ok(Some(v)) => HookDecision::Deny {
-                reason: format!("Tool '{}' is explicitly blocked: {}", tool_name, v),
-            },
-            Ok(None) => HookDecision::Deny {
-                reason: format!("Tool '{}' is not in the allowlist", tool_name),
-            },
-            Err(e) => HookDecision::Deny {
-                reason: format!("Policy lookup failed for tool '{}': {}", tool_name, e),
-            },
+        // Antipattern: Avoid `git add .` or `git add -A`.
+        if tool_name == "run_shell_command" {
+            if let Some(cmd) = tool_input.get("command").and_then(|v| v.as_str()) {
+                if cmd.contains("git add .") || cmd.contains("git add -A") {
+                    return HookDecision::Deny {
+                        reason: "Avoid `git add -A`/`git add .` — stage specific files by path to avoid committing stray artifacts.".into(),
+                    };
+                }
+            }
         }
+
+        HookDecision::Allow
     })
 }
 
@@ -124,6 +127,7 @@ pub fn session_start<'a, R: Send + Sync>(_ctx: &'a R) -> BoxFuture<'a, SessionSt
 mod tests {
     use super::*;
     use crate::testing::MockRuntime;
+    use serde_json::json;
 
     #[test]
     fn hook_decision_serde_is_tagged() {
@@ -146,51 +150,49 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_pre_tool_use_deny_by_default() {
+    async fn test_pre_tool_use_allow_by_default() {
         let ctx = MockRuntime::default();
         let input = HookInput {
-            tool_name: "test_tool".into(),
-            tool_input: Value::Null,
-        };
-        match pre_tool_use(&ctx, &input).await {
-            HookDecision::Deny { reason } => {
-                assert!(reason.contains("not in the allowlist"));
-            }
-            _ => panic!("Should be Deny by default"),
-        }
-    }
-
-    #[tokio::test]
-    async fn test_pre_tool_use_explicit_allow() {
-        let ctx = MockRuntime::default();
-        ctx.kv
-            .lock()
-            .unwrap()
-            .insert("allowlist:test_tool".into(), "allow".into());
-        let input = HookInput {
-            tool_name: "test_tool".into(),
-            tool_input: Value::Null,
+            tool_name: "some_unknown_tool".into(),
+            tool_input: json!({ "arg": 1 }),
         };
         assert_eq!(pre_tool_use(&ctx, &input).await, HookDecision::Allow);
     }
 
     #[tokio::test]
-    async fn test_pre_tool_use_explicit_deny() {
+    async fn test_pre_tool_use_git_add_antipattern_denied() {
         let ctx = MockRuntime::default();
-        ctx.kv
-            .lock()
-            .unwrap()
-            .insert("allowlist:test_tool".into(), "deny".into());
         let input = HookInput {
-            tool_name: "test_tool".into(),
-            tool_input: Value::Null,
+            tool_name: "run_shell_command".into(),
+            tool_input: json!({ "command": "git add ." }),
         };
         match pre_tool_use(&ctx, &input).await {
             HookDecision::Deny { reason } => {
-                assert!(reason.contains("explicitly blocked"));
+                assert!(reason.contains("Avoid `git add -A`/`git add .`"));
             }
-            _ => panic!("Should be Deny"),
+            _ => panic!("Should be Deny for antipattern"),
         }
+
+        let input_a = HookInput {
+            tool_name: "run_shell_command".into(),
+            tool_input: json!({ "command": "git add -A" }),
+        };
+        match pre_tool_use(&ctx, &input_a).await {
+            HookDecision::Deny { reason } => {
+                assert!(reason.contains("Avoid `git add -A`/`git add .`"));
+            }
+            _ => panic!("Should be Deny for antipattern"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_pre_tool_use_git_add_specific_allowed() {
+        let ctx = MockRuntime::default();
+        let input = HookInput {
+            tool_name: "run_shell_command".into(),
+            tool_input: json!({ "command": "git add src/main.rs" }),
+        };
+        assert_eq!(pre_tool_use(&ctx, &input).await, HookDecision::Allow);
     }
 
     #[tokio::test]

--- a/rust/exo-policy/src/tools/merge_pr.rs
+++ b/rust/exo-policy/src/tools/merge_pr.rs
@@ -16,6 +16,9 @@ use crate::tool::{ok_json, parse, schema_json, Tool, ToolOutput};
 pub struct MergePrArgs {
     /// The PR number to merge.
     pub pr: u64,
+    /// If true, skip the readiness guard (unaddressed changes check).
+    #[serde(default)]
+    pub force: bool,
 }
 
 /// The `merge_pr` tool implementation.
@@ -28,7 +31,7 @@ impl MergePr {
     /// 2. **Readiness guard**: Checks if there are unaddressed `ChangesRequested` reviews.
     /// 3. **Merge**: Executes the merge via the GitHub capability.
     pub async fn run<C: Git + GitHub>(ctx: &C, args: MergePrArgs) -> CapResult<ToolOutput> {
-        // 1. Self-merge guard
+        // 1. Self-merge guard (always enforced)
         let current_branch = ctx.current_branch().await?;
         if let Some(own_pr) = ctx.pr_for_branch(&current_branch).await? {
             if own_pr == args.pr {
@@ -40,7 +43,7 @@ impl MergePr {
         }
 
         // 2. Readiness guard: check for unaddressed changes
-        if ctx.has_unaddressed_changes(args.pr).await? {
+        if !args.force && ctx.has_unaddressed_changes(args.pr).await? {
             return Ok(ToolOutput::text(format!(
                 "Copilot requested changes on PR #{}. Wait for the agent to push fixes or use force=true (if supported).",
                 args.pr
@@ -87,7 +90,10 @@ mod tests {
     #[tokio::test]
     async fn test_merge_pr_happy_path() {
         let mock = MockRuntime::default();
-        let args = MergePrArgs { pr: 123 };
+        let args = MergePrArgs {
+            pr: 123,
+            force: false,
+        };
 
         let out = MergePr::run(&mock, args).await.unwrap();
 
@@ -107,7 +113,10 @@ mod tests {
             ..Default::default()
         };
 
-        let args = MergePrArgs { pr: 123 }; // Trying to merge own PR 123
+        let args = MergePrArgs {
+            pr: 123,
+            force: false,
+        }; // Trying to merge own PR 123
         let out = MergePr::run(&mock, args).await.unwrap();
 
         assert!(out.text.contains("Cannot merge your own PR #123"));
@@ -129,7 +138,10 @@ mod tests {
             ..Default::default()
         };
 
-        let args = MergePrArgs { pr: 123 };
+        let args = MergePrArgs {
+            pr: 123,
+            force: false,
+        };
         let out = MergePr::run(&mock, args).await.unwrap();
 
         assert!(out.text.contains("Copilot requested changes on PR #123"));
@@ -145,9 +157,60 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_merge_pr_force_skips_readiness_guard() {
+        let mock = MockRuntime {
+            has_unaddressed_changes: true, // Blocked by default
+            ..Default::default()
+        };
+
+        let args = MergePrArgs {
+            pr: 123,
+            force: true, // Skip the guard
+        };
+        let out = MergePr::run(&mock, args).await.unwrap();
+
+        assert_eq!(out.text, "merged PR #123");
+        assert_eq!(out.data, Some(json!({ "pr": 123 })));
+
+        // Verify merge WAS called
+        let calls = mock.calls_made();
+        assert!(calls.contains(&Call::MergePr { pr: 123 }));
+    }
+
+    #[tokio::test]
+    async fn test_merge_pr_force_still_respects_self_merge_guard() {
+        let mock = MockRuntime {
+            current_branch: Branch::new("feat.topic".into()).unwrap(),
+            pr_for_branch: Some(123),
+            has_unaddressed_changes: true,
+            ..Default::default()
+        };
+
+        let args = MergePrArgs {
+            pr: 123,
+            force: true, // Try to force self-merge
+        };
+        let out = MergePr::run(&mock, args).await.unwrap();
+
+        assert!(out.text.contains("Cannot merge your own PR #123"));
+        assert_eq!(out.data, None);
+
+        // Verify merge was NOT called
+        let calls = mock.calls_made();
+        for call in calls {
+            if let Call::MergePr { .. } = call {
+                panic!("merge_pr should not have been called");
+            }
+        }
+    }
+
+    #[tokio::test]
     async fn test_merge_pr_error_path() {
         let mock = MockRuntime::failing("merge_pr");
-        let args = MergePrArgs { pr: 123 };
+        let args = MergePrArgs {
+            pr: 123,
+            force: false,
+        };
 
         let res = MergePr::run(&mock, args).await;
         assert!(res.is_err());


### PR DESCRIPTION
This PR fixes two policy bugs:
1. Rewrites `pre_tool_use` from a deny-by-default KV-allowlist into a default-ALLOW antipattern-nudge hook. It now includes a seeded nudge to avoid `git add .` or `git add -A`.
2. Adds the missing `force` argument to `merge_pr` tool. This allows bypassing the readiness check (unaddressed changes) while still respecting the self-merge guard.

Changes:
- Modified `rust/exo-policy/src/hooks.rs`: Updated `pre_tool_use` logic and tests.
- Modified `rust/exo-policy/src/tools/merge_pr.rs`: Added `force` field to `MergePrArgs`, updated `run` logic, and added tests.
- Modified `docs/design/swarm/04-policy.md`: Updated documentation to reflect the new `pre_tool_use` semantics.

Verified with:
- `cargo test -p exo-policy`
- `cargo clippy -p exo-policy --all-targets -- -D warnings`
- `cargo fmt -p exo-policy -- --check`
- `cargo check --workspace`