### PR TITLE
feat(github): add review_state and ci_status to GitHub capability (v2)

### DIFF
--- a/rust/exo-caps/src/github.rs
+++ b/rust/exo-caps/src/github.rs
@@ -3,6 +3,7 @@
 
 use crate::types::Branch;
 use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -11,6 +12,22 @@ pub enum GitHubError {
     Failed { op: &'static str, detail: String },
     #[error(transparent)]
     Io(#[from] std::io::Error),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReviewState {
+    Approved,
+    ChangesRequested,
+    Commented,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CiStatus {
+    Passing,
+    Failing,
+    Pending,
 }
 
 #[async_trait]
@@ -22,4 +39,49 @@ pub trait GitHub {
     async fn merge_pr(&self, pr: u64) -> Result<(), GitHubError>;
     /// Does the open PR have unaddressed `ChangesRequested`? (the live stop-gate).
     async fn has_unaddressed_changes(&self, pr: u64) -> Result<bool, GitHubError>;
+    /// The latest review decision on the PR. None if no reviews have arrived.
+    async fn review_state(&self, pr: u64) -> Result<Option<ReviewState>, GitHubError>;
+    /// The rolled-up CI conclusion for the PR's HEAD.
+    async fn ci_status(&self, pr: u64) -> Result<CiStatus, GitHubError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn review_state_serde_round_trip() {
+        let states = vec![
+            ReviewState::Approved,
+            ReviewState::ChangesRequested,
+            ReviewState::Commented,
+        ];
+        for s in states {
+            let j = serde_json::to_string(&s).unwrap();
+            let back: ReviewState = serde_json::from_str(&j).unwrap();
+            assert_eq!(s, back);
+        }
+    }
+
+    #[test]
+    fn ci_status_serde_round_trip() {
+        let statuses = vec![CiStatus::Passing, CiStatus::Failing, CiStatus::Pending];
+        for s in statuses {
+            let j = serde_json::to_string(&s).unwrap();
+            let back: CiStatus = serde_json::from_str(&j).unwrap();
+            assert_eq!(s, back);
+        }
+    }
+
+    #[test]
+    fn review_state_json_representation() {
+        assert_eq!(
+            serde_json::to_value(ReviewState::Approved).unwrap(),
+            serde_json::json!("approved")
+        );
+        assert_eq!(
+            serde_json::to_value(ReviewState::ChangesRequested).unwrap(),
+            serde_json::json!("changes_requested")
+        );
+    }
 }

--- a/rust/exo-caps/src/lib.rs
+++ b/rust/exo-caps/src/lib.rs
@@ -31,7 +31,7 @@ pub use bus::{Addressee, Bus, BusError};
 pub use error::{CapError, CapResult};
 pub use fs::{Fs, FsError};
 pub use git::{Git, GitError};
-pub use github::{GitHub, GitHubError};
+pub use github::{CiStatus, GitHub, GitHubError, ReviewState};
 pub use kv::{Kv, KvError};
 pub use lifecycle::{fold_children, Child, ChildLifecycle, ChildRecord};
 pub use log::Log;

--- a/rust/exo-policy/src/events.rs
+++ b/rust/exo-policy/src/events.rs
@@ -158,6 +158,24 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_on_world_event_sibling_merged() {
+        let ctx = MockRuntime::default();
+        let e = WorldEvent::SiblingMerged {
+            pr: 123,
+            branch: "main.feature-a".to_string(),
+        };
+        let action = on_world_event(&ctx, &e).await;
+        if let EventAction::InjectMessage { text, summary } = action {
+            assert!(text.contains("[Sibling Merged]"));
+            assert!(text.contains("main.feature-a"));
+            assert!(text.contains("merged into main"));
+            assert_eq!(summary, "[Sibling Merged]");
+        } else {
+            panic!("Expected InjectMessage, got {:?}", action);
+        }
+    }
+
+    #[tokio::test]
     async fn test_mock_runtime_new_methods() {
         let ctx = MockRuntime {
             review_state: Some(ReviewState::Approved),

--- a/rust/exo-policy/src/events.rs
+++ b/rust/exo-policy/src/events.rs
@@ -10,7 +10,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::BoxFuture;
-use exo_caps::GitHub;
+pub use exo_caps::{CiStatus, GitHub, ReviewState};
 
 /// The one typed event enum. A `kind=event` ingestion entry has its body parsed into this
 /// before `on_world_event` runs; the in-process self-poll constructs one directly. There is
@@ -26,22 +26,6 @@ pub enum WorldEvent {
     CiStatus { pr: u64, status: CiStatus },
     /// No review arrived within the timeout window (≈15 min, resets on each feedback round).
     ReviewTimeout { pr: u64 },
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum ReviewState {
-    Approved,
-    ChangesRequested,
-    Commented,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum CiStatus {
-    Passing,
-    Failing,
-    Pending,
 }
 
 /// What a world-event handler decides to do. The loop performs the IO: `InjectMessage` →
@@ -174,20 +158,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_on_world_event_sibling_merged() {
-        let ctx = MockRuntime::default();
-        let e = WorldEvent::SiblingMerged {
-            pr: 123,
-            branch: "main.feature-a".to_string(),
+    async fn test_mock_runtime_new_methods() {
+        let ctx = MockRuntime {
+            review_state: Some(ReviewState::Approved),
+            ci_status: CiStatus::Failing,
+            ..Default::default()
         };
-        let action = on_world_event(&ctx, &e).await;
-        if let EventAction::InjectMessage { text, summary } = action {
-            assert!(text.contains("[Sibling Merged]"));
-            assert!(text.contains("main.feature-a"));
-            assert!(text.contains("merged into main"));
-            assert_eq!(summary, "[Sibling Merged]");
-        } else {
-            panic!("Expected InjectMessage, got {:?}", action);
-        }
+
+        assert_eq!(
+            ctx.review_state(123).await.unwrap(),
+            Some(ReviewState::Approved)
+        );
+        assert_eq!(ctx.ci_status(123).await.unwrap(), CiStatus::Failing);
     }
 }

--- a/rust/exo-policy/src/testing.rs
+++ b/rust/exo-policy/src/testing.rs
@@ -12,9 +12,9 @@
 
 use async_trait::async_trait;
 use exo_caps::{
-    Addressee, AgentName, Branch, Bus, BusError, ForkSpec, Fs, FsError, GeminiSpec, Git, GitError,
-    GitHub, GitHubError, Kv, KvError, Log, Message, PaneId, Process, ProcessError, SpawnError,
-    Spawner, Tmux, TmuxError, WorkerSpec,
+    Addressee, AgentName, Branch, Bus, BusError, CiStatus, ForkSpec, Fs, FsError, GeminiSpec, Git,
+    GitError, GitHub, GitHubError, Kv, KvError, Log, Message, PaneId, Process, ProcessError,
+    ReviewState, SpawnError, Spawner, Tmux, TmuxError, WorkerSpec,
 };
 use std::collections::HashMap;
 use std::path::Path;
@@ -78,6 +78,8 @@ pub struct MockRuntime {
     pub current_branch: Branch,
     pub pr_for_branch: Option<u64>,
     pub has_unaddressed_changes: bool,
+    pub review_state: Option<ReviewState>,
+    pub ci_status: CiStatus,
     pub is_clean: bool,
     /// Next `file_pr` returns this PR number.
     pub next_pr: u64,
@@ -95,6 +97,8 @@ impl Default for MockRuntime {
             current_branch: Branch::new("dev.policy-claude".into()).unwrap(),
             pr_for_branch: None,
             has_unaddressed_changes: false,
+            review_state: None,
+            ci_status: CiStatus::Passing,
             is_clean: true,
             next_pr: 1,
             fail: Mutex::new(None),
@@ -182,6 +186,12 @@ impl GitHub for MockRuntime {
     }
     async fn has_unaddressed_changes(&self, _pr: u64) -> Result<bool, GitHubError> {
         Ok(self.has_unaddressed_changes)
+    }
+    async fn review_state(&self, _pr: u64) -> Result<Option<ReviewState>, GitHubError> {
+        Ok(self.review_state)
+    }
+    async fn ci_status(&self, _pr: u64) -> Result<CiStatus, GitHubError> {
+        Ok(self.ci_status)
     }
 }
 

--- a/rust/exo-runtime/src/github.rs
+++ b/rust/exo-runtime/src/github.rs
@@ -95,6 +95,7 @@ impl GitHub for Runtime {
         let reviews = octo
             .pulls(owner, repo)
             .list_reviews(pr)
+            .per_page(100)
             .send()
             .await
             .map_err(|e| GitHubError::Failed {
@@ -139,7 +140,7 @@ impl GitHub for Runtime {
             })?;
 
         if runs.check_runs.is_empty() {
-            return Ok(CiStatus::Passing);
+            return Ok(CiStatus::Pending);
         }
 
         let mut any_failed = false;

--- a/rust/exo-runtime/src/github.rs
+++ b/rust/exo-runtime/src/github.rs
@@ -6,8 +6,8 @@
 
 use crate::runtime::Runtime;
 use async_trait::async_trait;
-use exo_caps::{Branch, GitHub, GitHubError};
-use octocrab::models::pulls::ReviewState;
+use exo_caps::{Branch, CiStatus, GitHub, GitHubError, ReviewState};
+use octocrab::models::pulls::ReviewState as OctoReviewState;
 use octocrab::{params, Octocrab, OctocrabBuilder};
 use tokio::process::Command;
 
@@ -82,10 +82,95 @@ impl GitHub for Runtime {
         if let Some(last_review) = reviews.into_iter().last() {
             Ok(matches!(
                 last_review.state,
-                Some(ReviewState::ChangesRequested)
+                Some(OctoReviewState::ChangesRequested)
             ))
         } else {
             Ok(false)
+        }
+    }
+
+    async fn review_state(&self, pr: u64) -> Result<Option<ReviewState>, GitHubError> {
+        let (owner, repo) = self.repo().await?;
+        let octo = self.octocrab().await?;
+        let reviews = octo
+            .pulls(owner, repo)
+            .list_reviews(pr)
+            .send()
+            .await
+            .map_err(|e| GitHubError::Failed {
+                op: "review_state",
+                detail: e.to_string(),
+            })?;
+
+        if let Some(last_review) = reviews.into_iter().last() {
+            match last_review.state {
+                Some(OctoReviewState::Approved) => Ok(Some(ReviewState::Approved)),
+                Some(OctoReviewState::ChangesRequested) => Ok(Some(ReviewState::ChangesRequested)),
+                Some(OctoReviewState::Commented) => Ok(Some(ReviewState::Commented)),
+                _ => Ok(None),
+            }
+        } else {
+            Ok(None)
+        }
+    }
+
+    async fn ci_status(&self, pr: u64) -> Result<CiStatus, GitHubError> {
+        let (owner, repo) = self.repo().await?;
+        let octo = self.octocrab().await?;
+
+        let pr_model =
+            octo.pulls(&owner, &repo)
+                .get(pr)
+                .await
+                .map_err(|e| GitHubError::Failed {
+                    op: "ci_status",
+                    detail: format!("failed to get PR {}: {}", pr, e),
+                })?;
+        let sha = pr_model.head.sha;
+
+        let runs = octo
+            .checks(owner, repo)
+            .list_check_runs_for_git_ref(params::repos::Commitish(sha))
+            .send()
+            .await
+            .map_err(|e| GitHubError::Failed {
+                op: "ci_status",
+                detail: e.to_string(),
+            })?;
+
+        if runs.check_runs.is_empty() {
+            return Ok(CiStatus::Passing);
+        }
+
+        let mut any_failed = false;
+        let mut any_pending = false;
+
+        for run in runs.check_runs {
+            match run.conclusion.as_deref() {
+                Some("success") | Some("neutral") | Some("skipped") => {}
+                Some("failure")
+                | Some("error")
+                | Some("timed_out")
+                | Some("cancelled")
+                | Some("action_required")
+                | Some("startup_failure") => {
+                    any_failed = true;
+                }
+                None => {
+                    any_pending = true;
+                }
+                _ => {
+                    any_pending = true;
+                }
+            }
+        }
+
+        if any_failed {
+            Ok(CiStatus::Failing)
+        } else if any_pending {
+            Ok(CiStatus::Pending)
+        } else {
+            Ok(CiStatus::Passing)
         }
     }
 }


### PR DESCRIPTION
This PR extends the `exo_caps::GitHub` capability with `review_state` and `ci_status` methods required for the N3 self-poll to produce `WorldEvent`s.

Updates in this version (addressing Copilot review):
- `ci_status` now returns `Pending` instead of `Passing` if no check runs exist.
- `review_state` now requests up to 100 reviews per page to ensure the latest review is likely captured.
- Restored `test_on_world_event_sibling_merged` to maintain test coverage.

Key changes:
- Moved `ReviewState` and `CiStatus` enums from `exo-policy` to `exo-caps` to avoid circular dependencies.
- Added `review_state` (latest review decision) and `ci_status` (rolled-up check-runs) methods to the `GitHub` trait.
- Implemented these methods in `exo-runtime` using `octocrab`, following the logic patterns from `exomonad-core`.
- Updated `MockRuntime` in `exo-policy` to support testing of these new methods.
- Added unit tests for enum serialization and mock implementation.

Verified with:
- `cargo test -p exo-caps -p exo-runtime -p exo-policy`
- `cargo clippy` (clean)
- `cargo fmt` (clean)