### PR TITLE
feat: implement outbound MCP serve over stdio

### DIFF
--- a/rust/exo-node/src/outbound.rs
+++ b/rust/exo-node/src/outbound.rs
@@ -13,11 +13,191 @@
 
 use std::sync::Arc;
 
+use exo_policy::role_def;
+use exo_policy::tool::Tool;
+use exo_runtime::Runtime;
+use serde_json::{json, Value};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
 use crate::bootstrap::NodeContext;
 use crate::error::NodeResult;
 
 /// Serve the policy toolset over rmcp/stdio until the stream closes.
 pub async fn serve(ctx: Arc<NodeContext>) -> NodeResult<()> {
-    let _ = ctx;
-    todo!("N1: rmcp stdio server exposing role_def(kind).tools; tools/call -> Tool::call(&*ctx.runtime, args)")
+    let tools = role_def::<Runtime>(ctx.kind).tools;
+    let stdin = tokio::io::stdin();
+    let mut reader = BufReader::new(stdin).lines();
+    let mut stdout = tokio::io::stdout();
+
+    while let Ok(Some(line)) = reader.next_line().await {
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        let msg: Value = match serde_json::from_str(&line) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+
+        if let Some(response) = handle_rpc(&tools, &ctx.runtime, msg).await {
+            let mut bytes = serde_json::to_vec(&response).map_err(std::io::Error::other)?;
+            bytes.push(b'\n');
+            stdout.write_all(&bytes).await?;
+            stdout.flush().await?;
+        }
+    }
+
+    Ok(())
+}
+
+async fn handle_rpc(
+    tools: &[Box<dyn Tool<Runtime>>],
+    runtime: &Runtime,
+    msg: Value,
+) -> Option<Value> {
+    let id = msg.get("id").cloned();
+    let method = msg.get("method").and_then(|m| m.as_str()).unwrap_or("");
+    let is_notification = id.is_none() || id.as_ref().map(|v| v.is_null()).unwrap_or(false);
+
+    let result: Option<Result<Value, (i32, String)>> = match method {
+        "initialize" => Some(Ok(json!({
+            "protocolVersion": "2024-11-05",
+            "capabilities": { "tools": {} },
+            "serverInfo": { "name": "exomonad-node", "version": env!("CARGO_PKG_VERSION") }
+        }))),
+        "notifications/initialized" => None,
+        "tools/list" => {
+            let tool_list: Vec<_> = tools
+                .iter()
+                .map(|t| {
+                    json!({
+                        "name": t.name(),
+                        "inputSchema": t.schema(),
+                    })
+                })
+                .collect();
+            Some(Ok(json!({ "tools": tool_list })))
+        }
+        "tools/call" => {
+            let params = msg.get("params");
+            let name = params.and_then(|p| p.get("name")).and_then(|n| n.as_str());
+            let arguments = params
+                .and_then(|p| p.get("arguments"))
+                .cloned()
+                .unwrap_or(json!({}));
+
+            if let Some(name) = name {
+                if let Some(tool) = tools.iter().find(|t| t.name() == name) {
+                    match tool.call(runtime, arguments).await {
+                        Ok(output) => {
+                            // Map ToolOutput (text, data) to MCP CallToolResult
+                            let mut content = vec![json!({
+                                "type": "text",
+                                "text": output.get("text").and_then(|t| t.as_str()).unwrap_or(""),
+                            })];
+
+                            if let Some(data) = output.get("data") {
+                                if !data.is_null() {
+                                    content.push(json!({
+                                        "type": "text",
+                                        "text": format!("Data: {}", serde_json::to_string_pretty(data).unwrap_or_default()),
+                                    }));
+                                }
+                            }
+
+                            Some(Ok(json!({ "content": content })))
+                        }
+                        Err(e) => Some(Err((-32603, e.to_string()))),
+                    }
+                } else {
+                    Some(Err((-32601, format!("Tool not found: {}", name))))
+                }
+            } else {
+                Some(Err((-32602, "Missing tool name".to_string())))
+            }
+        }
+        _ => {
+            if is_notification {
+                None
+            } else {
+                Some(Err((-32601, format!("Method not found: {}", method))))
+            }
+        }
+    };
+
+    if let (Some(res), Some(id)) = (result, id) {
+        match res {
+            Ok(val) => Some(json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "result": val
+            })),
+            Err((code, message)) => Some(json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "error": { "code": code, "message": message }
+            })),
+        }
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use exo_caps::{AgentName, Branch, NodeKind, NodePath, PaneId};
+
+    fn test_runtime(temp_path: std::path::PathBuf) -> Runtime {
+        Runtime::new(
+            NodePath::new(vec![AgentName::new("root".into()).unwrap()]).unwrap(),
+            Branch::new("main".into()).unwrap(),
+            temp_path,
+            None,
+            "test-run".into(),
+            "test-session".into(),
+            PaneId::new("%1".into()).unwrap(),
+        )
+    }
+
+    #[tokio::test]
+    async fn test_handle_rpc_tools_list() {
+        // Build a minimal Runtime for testing
+        let temp = tempfile::tempdir().unwrap();
+        let runtime = test_runtime(temp.path().to_path_buf());
+        let tools = role_def::<Runtime>(NodeKind::Dev).tools;
+
+        let request = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/list"
+        });
+
+        let response = handle_rpc(&tools, &runtime, request).await.unwrap();
+        assert_eq!(response["id"], 1);
+        let tools_out = response["result"]["tools"].as_array().unwrap();
+        let names: Vec<_> = tools_out
+            .iter()
+            .map(|t| t["name"].as_str().unwrap())
+            .collect();
+        assert!(names.contains(&"file_pr"));
+        assert!(names.contains(&"notify_parent"));
+    }
+
+    #[tokio::test]
+    async fn test_handle_rpc_initialize() {
+        let temp = tempfile::tempdir().unwrap();
+        let runtime = test_runtime(temp.path().to_path_buf());
+        let tools = vec![];
+
+        let request = json!({
+            "jsonrpc": "2.0",
+            "id": "init-1",
+            "method": "initialize"
+        });
+
+        let response = handle_rpc(&tools, &runtime, request).await.unwrap();
+        assert_eq!(response["id"], "init-1");
+        assert_eq!(response["result"]["serverInfo"]["name"], "exomonad-node");
+    }
 }


### PR DESCRIPTION
This PR implements the N1 outbound MCP serve in `exo-node`.

Key changes:
- Implemented `pub async fn serve(ctx: Arc<NodeContext>)` in `rust/exo-node/src/outbound.rs`.
- Added a hand-written JSON-RPC loop over stdio using `tokio::io::stdin` and `tokio::io::stdout`.
- Implemented `handle_rpc` to process `initialize`, `tools/list`, and `tools/call` requests.
- Tool calls are dispatched to the `Runtime` via `Tool::call`.
- `ToolOutput` is mapped to MCP `CallToolResult` format.
- Added unit tests verifying `tools/list` and `initialize` responses.

Verification:
- `cargo build -p exo-node` passes.
- `cargo test -p exo-node` passes (2 tests added).
- `cargo clippy -p exo-node -- -D warnings` passes.
- `cargo fmt -p exo-node -- --check` passes.