### PR TITLE
feat: experimental node namespace and spawner rewiring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -413,11 +413,19 @@ Claude Code → stdio (JSON-RPC) → exomonad mcp-stdio (translates JSON-RPC →
 ```
 
 **Hook Call:**
-```
+
+*Legacy (production, server-based):*
 Claude Code → exomonad hook pre-tool-use (reads stdin JSON)
 → UDS request to server → WASM handle_pre_tool_use
 → Haskell decides allow/deny → HookEnvelope { stdout, exit_code }
 → Claude Code proceeds or blocks
+
+*Experimental (Wave 2, node-based):*
+Claude Code → exomonad experimental hook pre-tool-use --papers node.json
+→ bootstrap NodeContext from papers
+→ run exo-policy hook directly (no server)
+→ stdout verdict
+
 ```
 
 **Session Start:**

--- a/rust/CLAUDE.md
+++ b/rust/CLAUDE.md
@@ -126,8 +126,11 @@ nix develop .#wasm -c wasm32-wasi-cabal build --project-file=cabal.project.wasm 
 # MCP server (stdio)
 exomonad mcp-stdio --role root --agent-id root
 
-# Handle Claude Code hook
+# Handle Claude Code hook (legacy, forwards to server)
 echo '{"hook_event_name":"PreToolUse",...}' | exomonad hook pre-tool-use
+
+# Handle Claude Code hook (experimental node mode, no server)
+echo '{"hook_event_name":"PreToolUse",...}' | exomonad experimental hook pre-tool-use --papers node.json
 ```
 
 **Note:** WASM is loaded from `.exo/wasm/` at runtime. To update WASM, run `just wasm-all` or `exomonad recompile --role devswarm`.

--- a/rust/exo-node/src/hook.rs
+++ b/rust/exo-node/src/hook.rs
@@ -1,4 +1,4 @@
-//! **N4 — Hook mode.** `exomonad hook <event>` reads the CC hook payload on stdin, self-IDs
+//! **N4 — Hook mode.** `exomonad experimental hook <event>` reads the CC hook payload on stdin, self-IDs
 //! (same papers + exo-scry path as the sidecar), runs the role's `exo-policy` hook, and emits
 //! the verdict on stdout. **No central server** — the hook is a short-lived process that
 //! builds a `Runtime` and calls policy directly.

--- a/rust/exo-node/src/lib.rs
+++ b/rust/exo-node/src/lib.rs
@@ -9,7 +9,7 @@
 //!                   last-hop dispatch (N2a) by agent_type: CC-in-team → Teams inbox; else tmux-paste.
 //!   SELF-POLL (N3): while an open PR exists, poll review_state/ci_status → WorldEvent →
 //!                   on_world_event → InjectMessage / NotifyParent.
-//!   HOOK (N4):      `exomonad hook` → exo-policy pre_tool_use / stop / session_start.
+//!   HOOK (N4):      `exomonad experimental hook` → exo-policy pre_tool_use / stop / session_start.
 //! ```
 //!
 //! See `docs/design/swarm/02-bus-and-sidecar.md` (two-loop model + cursor/restart),

--- a/rust/exo-runtime/src/spawner.rs
+++ b/rust/exo-runtime/src/spawner.rs
@@ -7,7 +7,7 @@
 //!   → (`git worktree add` for a Worktree child — Inline shares the parent's cwd)
 //!   → `tmux new_pane`
 //!   → write child papers (`node.json`, incl. `parent_inbox` = my inbox)
-//!   → launch `exomonad mcp-stdio` in the pane.
+//!   → launch `exomonad experimental node --papers <node.json>` in the pane.
 //!
 //! Decomposition:
 //!   - **S1**: safe branch-gen (`Branch::from_path`) + `git worktree add` (Worktree only).
@@ -32,7 +32,7 @@
 //!   3. Append `Spawned { child, kind, pane: %N, inbox }` to `children.jsonl`. ← THE GUARD.
 //!   4. Write the child's `node.json` papers (`parent_inbox` = *my* inbox).
 //!   5. `Tmux::paste(%N, "<launch cmd>\n")` — inject the agent command into the holding
-//!      shell, starting `claude`/`gemini` (+ its `exomonad mcp-stdio` sidecar via .mcp.json).
+//!      shell, starting `claude`/`gemini` (+ its `exomonad experimental node` sidecar via .mcp.json).
 //!
 //! The record precedes the **agent** launch (step 3 before step 5). The holding shell
 //! (step 2) carries no agent, so a crash before step 5 leaves only a bare shell — nothing
@@ -283,20 +283,20 @@ impl Runtime {
         })?;
         tokio::fs::write(&papers_path, papers_json).await?;
 
+        // Every value interpolated into `launch_cmd` is pasted into a shell, so each is
+        // shell-escaped — a name/path with a space or metachar must not break the command.
+        let esc = |s: &str| shell_escape::escape(s.to_string().into()).into_owned();
+
         // (f) Launch the agent
         let mcp_config = serde_json::json!({
             "mcpServers": {
                 "exomonad": {
                     "type": "stdio",
                     "command": "exomonad",
-                    "args": ["mcp-stdio", "--role", core.role.role_str(), "--name", core.name.as_str()]
+                    "args": ["experimental", "node", "--papers", papers_path.to_string_lossy()]
                 }
             }
         });
-
-        // Every value interpolated into `launch_cmd` is pasted into a shell, so each is
-        // shell-escaped — a name/path with a space or metachar must not break the command.
-        let esc = |s: &str| shell_escape::escape(s.to_string().into()).into_owned();
 
         let mut env_prefix = format!(
             "EXOMONAD_AGENT_ID={} EXOMONAD_ROLE={} ",
@@ -316,9 +316,41 @@ impl Runtime {
                     })?,
                 )
                 .await?;
+
+                // Write .claude/settings.local.json with experimental hooks
+                let claude_dir = child_dir.join(".claude");
+                tokio::fs::create_dir_all(&claude_dir).await?;
+                let settings_path = claude_dir.join("settings.local.json");
+                let p_str = esc(&papers_path.to_string_lossy());
+                let settings = serde_json::json!({
+                    "hooks": {
+                        "PreToolUse": [{
+                            "matcher": "*",
+                            "hooks": [{"type": "command", "command": format!("exomonad experimental hook pre-tool-use --papers {}", p_str)}]
+                        }],
+                        "Stop": [{
+                            "hooks": [{"type": "command", "command": format!("exomonad experimental hook stop --papers {}", p_str)}]
+                        }],
+                        "SessionStart": [{
+                            "hooks": [{"type": "command", "command": format!("exomonad experimental hook session-start --papers {}", p_str)}]
+                        }]
+                    },
+                    "_exomonad_generated": true
+                });
+                tokio::fs::write(
+                    &settings_path,
+                    serde_json::to_vec_pretty(&settings).map_err(|e| SpawnError::Failed {
+                        op: "write_claude_settings",
+                        child: Some(core.name.clone()),
+                        detail: e.to_string(),
+                    })?,
+                )
+                .await?;
+
                 "claude --dangerously-skip-permissions"
             }
             AgentType::Gemini => {
+                // Gemini child hooks are not wired (not supported in the same command-type way)
                 let settings_path = papers_path.with_file_name("settings.json");
                 let settings = mcp_config.clone();
                 tokio::fs::write(

--- a/rust/exomonad/CLAUDE.md
+++ b/rust/exomonad/CLAUDE.md
@@ -6,11 +6,14 @@ Unified sidecar binary: Rust host with Haskell WASM plugin.
 
 **All logic is in Haskell WASM. Rust handles I/O only.**
 
-WASM is loaded from `.exo/wasm/wasm-guest-devswarm.wasm` at runtime by `exomonad serve`. The `exomonad hook` command is a thin UDS client that forwards hook events to the running server — it does NOT load WASM itself.
+WASM is loaded from `.exo/wasm/wasm-guest-devswarm.wasm` at runtime by `exomonad serve`. The `exomonad hook` command (legacy) is a thin UDS client that forwards hook events to the running server — it does NOT load WASM itself. The `exomonad experimental hook` command handles hooks via `exo-policy` against node papers (no server).
 
 ```
 # Hook mode (thin UDS client → server)
 Claude Code → exomonad hook → UDS (.exo/server.sock) → server WASM → HookEnvelope → stdout
+
+# Experimental Hook mode (Wave 2, no server)
+Claude Code → exomonad experimental hook --papers node.json → exo-policy → stdout
 
 # MCP mode (multi-agent, devswarm WASM)
 N agents → exomonad serve → UDS (.exo/server.sock) → Unified WASM (handles all roles) → effects → I/O
@@ -21,7 +24,9 @@ N agents → exomonad serve → UDS (.exo/server.sock) → Unified WASM (handles
 ## CLI Usage
 
 ```bash
-exomonad hook pre-tool-use        # Handle Claude Code hook
+exomonad hook pre-tool-use        # Handle Claude Code hook (legacy, forwards to server)
+exomonad experimental node        # Run swarm-sidecar node mode (Wave 2)
+exomonad experimental hook        # Handle hook via exo-policy (Wave 2, no server)
 exomonad mcp-stdio                # Stdio MCP server (single agent)
 exomonad serve                    # UDS MCP server (multi-agent, hot reload)
 exomonad recompile [--role ROLE]  # Build WASM from Haskell source

--- a/rust/exomonad/src/main.rs
+++ b/rust/exomonad/src/main.rs
@@ -51,12 +51,12 @@ enum Commands {
         /// The runtime environment (Claude or Gemini)
         #[arg(long, default_value = "claude")]
         runtime: HookRuntime,
+    },
 
-        /// Swarm node mode (Wave 2): handle the hook via `exo-policy` against a node's
-        /// papers, with NO central server. When present, routes to the node hook path;
-        /// when absent, the legacy WASM-server-forward path is used (unchanged).
-        #[arg(long)]
-        papers: Option<std::path::PathBuf>,
+    /// Experimental Wave 2 features (swarm-sidecar node mode)
+    Experimental {
+        #[command(subcommand)]
+        command: ExperimentalCommands,
     },
 
     /// Initialize tmux session for this project.
@@ -102,15 +102,6 @@ enum Commands {
         name: String,
     },
 
-    /// Run the swarm-sidecar node mode (Wave 2): self-ID from papers, then the two-loop
-    /// sidecar (outbound MCP serve + inbound ingestion-inbox watch + self-poll). The new
-    /// path; coexists with the WASM `serve`/`mcp-stdio` during transition.
-    Node {
-        /// Path to this node's birth papers (`node.json`), written by the parent at spawn.
-        #[arg(long)]
-        papers: std::path::PathBuf,
-    },
-
     /// Reply to a UI request
     Reply {
         /// Request ID
@@ -131,6 +122,32 @@ enum Commands {
 
     /// Gracefully shut down the running server
     Shutdown,
+}
+
+#[derive(Subcommand)]
+enum ExperimentalCommands {
+    /// Run the swarm-sidecar node mode: self-ID from papers, then the two-loop
+    /// sidecar (outbound MCP serve + inbound ingestion-inbox watch + self-poll).
+    Node {
+        /// Path to this node's birth papers (`node.json`), written by the parent at spawn.
+        #[arg(long)]
+        papers: std::path::PathBuf,
+    },
+
+    /// Handle a hook via `exo-policy` against a node's papers, with NO central server.
+    Hook {
+        /// The hook event type to handle
+        #[arg(value_enum)]
+        event: HookEventType,
+
+        /// The runtime environment (Claude or Gemini). Reserved/unused in this path.
+        #[arg(long, default_value = "claude")]
+        runtime: HookRuntime,
+
+        /// Path to this node's birth papers (`node.json`).
+        #[arg(long)]
+        papers: std::path::PathBuf,
+    },
 }
 
 // Main
@@ -154,13 +171,41 @@ async fn main() -> Result<()> {
             return mcp_stdio::run(role, name).await;
         }
 
-        Commands::Node { ref papers } => {
-            let cwd = std::env::current_dir().context("resolving node cwd")?;
-            let ctx = exo_node::bootstrap(papers, cwd)
-                .map(std::sync::Arc::new)
-                .context("node self-ID / bootstrap")?;
-            return exo_node::run_node(ctx).await.context("node run");
-        }
+        Commands::Experimental { command } => match command {
+            ExperimentalCommands::Node { papers } => {
+                let cwd = std::env::current_dir().context("resolving node cwd")?;
+                let ctx = exo_node::bootstrap(&papers, cwd)
+                    .map(std::sync::Arc::new)
+                    .context("node self-ID / bootstrap")?;
+                return exo_node::run_node(ctx).await.context("node run");
+            }
+            ExperimentalCommands::Hook {
+                event,
+                runtime: _,
+                papers,
+            } => {
+                let node_event = match event {
+                    HookEventType::PreToolUse => exo_node::HookEvent::PreToolUse,
+                    HookEventType::Stop => exo_node::HookEvent::Stop,
+                    HookEventType::SessionStart => exo_node::HookEvent::SessionStart,
+                    other => {
+                        eprintln!(
+                            "[exomonad] node hook: unhandled event {other:?}, passing through"
+                        );
+                        println!("{{\"continue\": true}}");
+                        return Ok(());
+                    }
+                };
+                let mut body = String::new();
+                use std::io::Read;
+                std::io::stdin().read_to_string(&mut body)?;
+                let verdict = exo_node::handle_hook(node_event, &papers, &body)
+                    .await
+                    .context("node hook")?;
+                println!("{verdict}");
+                return Ok(());
+            }
+        },
 
         Commands::Recompile { ref role } => {
             let role_str = role.as_deref().unwrap_or(&config.wasm_name);
@@ -181,31 +226,7 @@ async fn main() -> Result<()> {
             return serve::run(&config).await;
         }
 
-        Commands::Hook { event, runtime, papers } => {
-            // Wave-2 node path: handle the hook via exo-policy against papers, no server.
-            if let Some(papers_path) = papers {
-                let node_event = match event {
-                    HookEventType::PreToolUse => exo_node::HookEvent::PreToolUse,
-                    HookEventType::Stop => exo_node::HookEvent::Stop,
-                    HookEventType::SessionStart => exo_node::HookEvent::SessionStart,
-                    other => {
-                        // Node path only handles the three policy hooks; anything else is a
-                        // no-op pass-through (don't block the agent on an unhandled event).
-                        eprintln!("[exomonad] node hook: unhandled event {other:?}, passing through");
-                        println!("{{\"continue\": true}}");
-                        return Ok(());
-                    }
-                };
-                let mut body = String::new();
-                use std::io::Read;
-                std::io::stdin().read_to_string(&mut body)?;
-                let verdict = exo_node::handle_hook(node_event, &papers_path, &body)
-                    .await
-                    .context("node hook")?;
-                println!("{verdict}");
-                return Ok(());
-            }
-
+        Commands::Hook { event, runtime } => {
             let mut path = format!("/hook?event={}&runtime={}", event, runtime);
             if let Ok(agent_id) = std::env::var("EXOMONAD_AGENT_ID") {
                 path.push_str(&format!("&agent_id={}", encode(&agent_id)));


### PR DESCRIPTION
Addressed Copilot review comments:
- Fixed shell escaping for `--papers` argument in generated `.claude/settings.local.json` hook commands.
- Marked `experimental hook --runtime` as reserved/unused in the CLI help text.

Original PR description:
Moves the swarm-sidecar node mode behind an `experimental` command namespace and rewires the spawner to use this new path for child agents.

### Changes
- **CLI**:
  - `exomonad node` -> `exomonad experimental node`
  - `exomonad hook --papers ...` -> `exomonad experimental hook --papers ...`
  - Top-level `exomonad hook` is now strictly for the legacy WASM-server-forward path.
- **Spawner**:
  - Spawned children now use `exomonad experimental node --papers <child papers_path>` in their `.mcp.json`.
  - Claude children now get a `.claude/settings.local.json` file with hooks pointing to the experimental node hook path.
  - Added a comment noting that Gemini child hooks are not currently wired.
- **Maintenance**:
  - Updated doc comments in `exo-node` and documentation in `CLAUDE.md` files.
  - Fixed a clippy warning in `exomonad-core` (`last()` -> `next_back()`).
  - Ran `cargo fmt` across the workspace.