### PR TITLE
test: add unit tests and update docs for exo-node

### DIFF
--- a/rust/exo-node/src/bootstrap.rs
+++ b/rust/exo-node/src/bootstrap.rs
@@ -20,6 +20,7 @@ use crate::error::{NodeError, NodeResult};
 /// the ambient context the loops read. `Runtime` does not itself store the [`NodeKind`]
 /// (its identity is the tree address + branch), so the context carries it for
 /// [`exo_policy::role_def`].
+#[derive(Debug)]
 pub struct NodeContext {
     /// The concrete runtime — implements every `exo-caps` capability. Policy monomorphizes
     /// against this `R`; the outbound loop serves `role_def::<Runtime>(kind).tools`.
@@ -105,4 +106,63 @@ pub fn bootstrap(papers_path: &Path, working_dir: PathBuf) -> NodeResult<NodeCon
         parent_inbox,
         run_id,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use exo_caps::{AgentName, Branch, InboxPath, NodeKind, NodePapers, NodePath, PaneId};
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_bootstrap_logic() {
+        let dir = tempdir().unwrap();
+        let papers_path = dir.path().join("papers.json");
+        let working_dir = dir.path().join("work");
+        fs::create_dir(&working_dir).unwrap();
+
+        let own_pane = PaneId::new("%42".into()).unwrap();
+        let parent_inbox = InboxPath::new(dir.path().join("parent-inbox.jsonl"));
+        let node_path = NodePath::new(vec![
+            AgentName::new("root".into()).unwrap(),
+            AgentName::new("me".into()).unwrap(),
+        ])
+        .unwrap();
+        let branch = Branch::new("root.me".into()).unwrap();
+
+        let papers = NodePapers {
+            v: 1,
+            role: NodeKind::Tl,
+            path: node_path.clone(),
+            branch: branch.clone(),
+            pane: own_pane.clone(),
+            parent_inbox: Some(parent_inbox.clone()),
+        };
+
+        let papers_json = serde_json::to_string(&papers).unwrap();
+        fs::write(&papers_path, papers_json).unwrap();
+
+        // 1. Success case
+        std::env::set_var("EXOMONAD_SWARM_RUN_ID", "test-run");
+        std::env::set_var("EXOMONAD_TMUX_SESSION", "test-session");
+        std::env::set_var("HOME", dir.path().to_str().unwrap());
+
+        let ctx = bootstrap(&papers_path, working_dir.clone()).unwrap();
+
+        assert_eq!(ctx.kind, NodeKind::Tl);
+        assert_eq!(ctx.own_pane, own_pane);
+        assert_eq!(ctx.parent_inbox, Some(parent_inbox));
+        assert_eq!(ctx.run_id, "test-run");
+        assert_eq!(ctx.runtime.name(), AgentName::new("me".into()).unwrap());
+
+        // 2. Missing env case
+        std::env::remove_var("EXOMONAD_SWARM_RUN_ID");
+        let res = bootstrap(&papers_path, working_dir.clone());
+        assert!(res.is_err());
+
+        // Cleanup env
+        std::env::remove_var("EXOMONAD_TMUX_SESSION");
+        std::env::remove_var("HOME");
+    }
 }

--- a/rust/exo-node/src/dispatch.rs
+++ b/rust/exo-node/src/dispatch.rs
@@ -1,21 +1,15 @@
-//! **N2a — Last-hop dispatch.** Route one consumed ingestion entry INTO this agent, by the
-//! node's own `agent_type` (= `kind.agent_type()`) + CC team membership (resolved via
-//! `exo-scry`):
+//! **N2a — Last-hop dispatch.** Routes ingestion entries into the agent based on its
+//! `agent_type` and CC team membership. This module handles the final delivery of messages
+//! to the agent's native interface.
 //!
-//! | this node | mechanism |
-//! |---|---|
-//! | CC, in a team | write the CC Teams inbox → InboxPoller → `<teammate-message>` |
-//! | CC, no team   | tmux-paste into its own pane |
-//! | gemini        | tmux-paste into its own pane |
+//! Delivery mechanisms:
+//! - **Claude Code in a team**: Writes to the CC Teams inbox, which is then picked up
+//!   by the InboxPoller and delivered as a `<teammate-message>`.
+//! - **Claude Code (no team) or Gemini**: Uses tmux injection (buffer pattern) to paste
+//!   the message directly into the agent's pane, rendered with a `[from: X, kind: Y]` header.
 //!
-//! For the tmux-paste path, render the entry with a `[from: X, kind: Y]` header (the input
-//! box *is* the receive channel for non-CC runtimes). Reuse exomonad-core's tmux injection
-//! (buffer pattern) + CC-inbox delivery — adapt, don't rewrite.
-//!
-//! **Status: stub (N2a leaf fills this).** Acceptance: a `Chat` entry delivered to a gemini
-//! node lands pasted-with-header in its pane; a CC-in-team node's entry lands in its Teams
-//! inbox. The dispatch is pure last-hop — `kind`-based routing (event/control) is N2b's job;
-//! this only does the agent-facing write for entries N2b decides to deliver.
+//! This is pure last-hop dispatch; it focuses on the agent-facing write for entries
+//! that have already been routed to this node.
 
 use std::sync::Arc;
 
@@ -172,5 +166,65 @@ mod tests {
                 to: "bob".to_string()
             }
         );
+    }
+
+    #[test]
+    fn test_decide_lasthop_claude_in_team_no_me() {
+        use exo_scry::identity::TeamName;
+        use std::path::PathBuf;
+
+        let active_team = exo_scry::ActiveTeam {
+            claude_pid: None,
+            team: TeamName("myteam".to_string()),
+            tasks_dir: PathBuf::from("/tmp"),
+            lead_inbox: Some("lead".to_string()),
+            lead_session_id: None,
+            me: None,
+        };
+
+        let hop = decide_lasthop(AgentType::Claude, Some(active_team));
+        assert_eq!(
+            hop,
+            LastHop::TeamsInbox {
+                team: "myteam".to_string(),
+                to: "lead".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn test_decide_lasthop_claude_in_team_no_recipients() {
+        use exo_scry::identity::TeamName;
+        use std::path::PathBuf;
+
+        let active_team = exo_scry::ActiveTeam {
+            claude_pid: None,
+            team: TeamName("myteam".to_string()),
+            tasks_dir: PathBuf::from("/tmp"),
+            lead_inbox: None,
+            lead_session_id: None,
+            me: None,
+        };
+
+        let hop = decide_lasthop(AgentType::Claude, Some(active_team));
+        assert_eq!(hop, LastHop::TmuxPaste);
+    }
+
+    #[test]
+    fn test_render_entry_event() {
+        let entry = IngestionEntry {
+            v: 1,
+            ts: Utc::now(),
+            from: Persona::Synthetic(exo_caps::SyntheticName::new("github".to_string()).unwrap()),
+            msg: Message {
+                text: MessageBody::new("PR #1 Approved".to_string()).unwrap(),
+                summary: Summary::new("[PR READY]".to_string()).unwrap(),
+                kind: MessageKind::Event,
+            },
+        };
+
+        let rendered = render_entry(&entry);
+        assert!(rendered.contains("[from: github, kind: event]"));
+        assert!(rendered.contains("\n\n[PR READY]\nPR #1 Approved"));
     }
 }

--- a/rust/exo-node/src/hook.rs
+++ b/rust/exo-node/src/hook.rs
@@ -1,19 +1,16 @@
-//! **N4 — Hook mode.** `exomonad experimental hook <event>` reads the CC hook payload on stdin, self-IDs
-//! (same papers + exo-scry path as the sidecar), runs the role's `exo-policy` hook, and emits
-//! the verdict on stdout. **No central server** — the hook is a short-lived process that
-//! builds a `Runtime` and calls policy directly.
+//! **N4 — Hook mode.** Implements the `exomonad experimental hook` interface for Claude Code.
+//! This module handles hook events by performing a papers-based identity bootstrap and
+//! executing policy hooks directly in a short-lived process, without requiring a central server.
 //!
-//! - `pre_tool_use` → `HookDecision` (default-allow antipattern *nudge*, NOT a gate — C3).
-//! - `stop` → `StopDecision` (the live PR-gate: open PR with unaddressed ChangesRequested).
-//! - `session_start` → `SessionStartOutput`. **Must do the REAL papers-based root identity
-//!   bootstrap** (currently a `default()` no-op): inject `additionalContext` describing the
-//!   node's tree identity (role/path/parent) so a fresh agent knows who it is. See doc 01.
+//! Supported hooks:
+//! - `pre_tool_use`: Evaluates tool use against policy, providing nudges or anti-pattern
+//!   warnings.
+//! - `stop`: Implements the PR-gate, blocking session termination if there is an open PR
+//!   with unaddressed changes.
+//! - `session_start`: Performs the identity bootstrap, injecting context about the node's
+//!   role, path, and parent into the agent's session so it understands its place in the swarm.
 //!
-//! Reads the role's hook fns from `exo_policy::role_def::<Runtime>(kind)`.
-//!
-//! **Status: stub (N4 leaf fills this).** Acceptance: a `pre_tool_use` payload for an
-//! unrecognized tool → `{"decision":"allow"}`; a `session_start` for a non-root node →
-//! `additionalContext` naming its role + parent.
+//! Policy logic is dynamically resolved from `exo_policy::role_def` based on the node's role.
 
 use std::path::Path;
 
@@ -129,6 +126,7 @@ async fn run_hook(
 mod tests {
     use super::*;
     use exo_caps::{AgentName, Branch, NodeKind, NodePath, PaneId};
+    use exo_policy::{HookDecision, HookInput, RoleDef, StopDecision};
     use exo_runtime::Runtime;
     use serde_json::{json, Value};
     use std::sync::Arc;
@@ -218,5 +216,105 @@ mod tests {
             .unwrap();
         assert!(add_ctx.contains("dev-node"));
         assert!(add_ctx.contains("role: dev"));
+    }
+
+    fn mock_stop_block<'a>(
+        _: &'a exo_runtime::Runtime,
+    ) -> exo_policy::tool::BoxFuture<'a, StopDecision> {
+        Box::pin(async {
+            StopDecision::Block {
+                reason: "test reason".into(),
+            }
+        })
+    }
+
+    #[tokio::test]
+    async fn test_run_hook_stop_blocked() {
+        let ctx = mock_ctx(NodeKind::Dev, vec!["root", "dev"], "main", false);
+        let rd = RoleDef {
+            tools: vec![],
+            pre_tool_use: exo_policy::hooks::pre_tool_use,
+            stop: mock_stop_block,
+            session_start: exo_policy::hooks::session_start,
+            on_event: exo_policy::events::on_world_event,
+        };
+
+        let res = run_hook(ctx, rd, HookEvent::Stop, "").await.unwrap();
+        let val: Value = serde_json::from_str(&res).unwrap();
+        assert_eq!(val["decision"], "block");
+        assert_eq!(val["reason"], "test reason");
+    }
+
+    fn mock_pre_tool_deny<'a>(
+        _: &'a exo_runtime::Runtime,
+        _: &'a HookInput,
+    ) -> exo_policy::tool::BoxFuture<'a, HookDecision> {
+        Box::pin(async {
+            HookDecision::Deny {
+                reason: "test deny".into(),
+            }
+        })
+    }
+
+    #[tokio::test]
+    async fn test_run_hook_pre_tool_deny() {
+        let ctx = mock_ctx(NodeKind::Dev, vec!["root", "dev"], "main", false);
+        let rd = RoleDef {
+            tools: vec![],
+            pre_tool_use: mock_pre_tool_deny,
+            stop: exo_policy::hooks::stop,
+            session_start: exo_policy::hooks::session_start,
+            on_event: exo_policy::events::on_world_event,
+        };
+        let stdin = json!({
+            "tool_name": "any",
+            "tool_input": {}
+        })
+        .to_string();
+
+        let res = run_hook(ctx, rd, HookEvent::PreToolUse, &stdin)
+            .await
+            .unwrap();
+        let val: Value = serde_json::from_str(&res).unwrap();
+        assert_eq!(val["continue"], true);
+        assert_eq!(val["systemMessage"], "test deny");
+    }
+
+    fn mock_pre_tool_modify<'a>(
+        _: &'a exo_runtime::Runtime,
+        _: &'a HookInput,
+    ) -> exo_policy::tool::BoxFuture<'a, HookDecision> {
+        Box::pin(async {
+            HookDecision::Modify {
+                input: json!({"modified": true}),
+            }
+        })
+    }
+
+    #[tokio::test]
+    async fn test_run_hook_pre_tool_modify() {
+        let ctx = mock_ctx(NodeKind::Dev, vec!["root", "dev"], "main", false);
+        let rd = RoleDef {
+            tools: vec![],
+            pre_tool_use: mock_pre_tool_modify,
+            stop: exo_policy::hooks::stop,
+            session_start: exo_policy::hooks::session_start,
+            on_event: exo_policy::events::on_world_event,
+        };
+        let stdin = json!({
+            "tool_name": "any",
+            "tool_input": {}
+        })
+        .to_string();
+
+        let res = run_hook(ctx, rd, HookEvent::PreToolUse, &stdin)
+            .await
+            .unwrap();
+        let val: Value = serde_json::from_str(&res).unwrap();
+        assert_eq!(val["continue"], true);
+        assert_eq!(
+            val["hookSpecificOutput"]["toolInput"],
+            json!({"modified": true})
+        );
     }
 }

--- a/rust/exo-node/src/inbound.rs
+++ b/rust/exo-node/src/inbound.rs
@@ -493,4 +493,62 @@ mod tests {
         assert_eq!(d.len(), 1);
         assert_eq!(d[0].msg.text.as_str(), "new");
     }
+
+    #[tokio::test]
+    async fn test_cursor_durability_across_restart() {
+        let dir = tempdir().unwrap();
+        let inbox_path = dir.path().join("pane-1.jsonl");
+        let cursor_path = inbox_path.with_extension("cursor");
+        let mut offset = 0;
+
+        // 1. Process N entries
+        write_entry(&inbox_path, "one");
+        write_entry(&inbox_path, "two");
+
+        let delivered = Arc::new(Mutex::new(Vec::new()));
+        let handler = MockHandler {
+            delivered: delivered.clone(),
+            fail_on: None,
+        };
+
+        process_inbox(&handler, &inbox_path, &cursor_path, &mut offset)
+            .await
+            .unwrap();
+
+        {
+            let d = delivered.lock().unwrap();
+            assert_eq!(d.len(), 2);
+        }
+
+        // 2. Simulate restart: reload offset from cursor file
+        let mut new_offset = std::fs::read_to_string(&cursor_path)
+            .unwrap()
+            .trim()
+            .parse::<u64>()
+            .unwrap();
+        assert_eq!(new_offset, offset);
+        assert!(new_offset > 0);
+
+        // 3. Append M more entries
+        write_entry(&inbox_path, "three");
+        write_entry(&inbox_path, "four");
+
+        let delivered2 = Arc::new(Mutex::new(Vec::new()));
+        let handler2 = MockHandler {
+            delivered: delivered2.clone(),
+            fail_on: None,
+        };
+
+        // 4. Process again, should only get the M new ones
+        process_inbox(&handler2, &inbox_path, &cursor_path, &mut new_offset)
+            .await
+            .unwrap();
+
+        {
+            let d = delivered2.lock().unwrap();
+            assert_eq!(d.len(), 2);
+            assert_eq!(d[0].msg.text.as_str(), "three");
+            assert_eq!(d[1].msg.text.as_str(), "four");
+        }
+    }
 }

--- a/rust/exo-node/src/outbound.rs
+++ b/rust/exo-node/src/outbound.rs
@@ -1,15 +1,12 @@
-//! **N1 — Outbound.** Serve the node's `exo-policy` tools over rmcp/stdio, and route
-//! `send_message`/`notify_parent` through `Bus::deliver` (append to the *target's* ingestion
-//! inbox — runtime-agnostic; policy never names Teams or tmux).
+//! **N1 — Outbound.** Serves the node's `exo-policy` tools over rmcp/stdio and routes
+//! communication through the node's ingestion system. This module implements the rmcp
+//! stdio server that Claude Code or other agents connect to for tool execution.
 //!
-//! Refactors the `teams-mcp` outbound server (`rust/teams-mcp/src/main.rs`): instead of
-//! writing CC Teams inboxes directly, it exposes `role_def::<Runtime>(kind).tools` and the
-//! tools' `Bus::deliver` writes the **ingestion** inbox. The rmcp `tools/list` →
-//! `Tool::schema`, `tools/call` → `Tool::call(&*ctx.runtime, args)`.
-//!
-//! **Status: stub (N1 leaf fills this).** Acceptance: `tools/list` returns the role's tool
-//! schemas; `tools/call` dispatches to `Tool::call` against the real `Runtime`; a
-//! `notify_parent` call appends one `IngestionEntry` to `ctx.parent_inbox`.
+//! It exposes tools defined in `exo_policy::role_def` for the node's specific role.
+//! Tools like `send_message` and `notify_parent` are routed through the `Bus::deliver`
+//! mechanism, which appends `IngestionEntry` objects to target inboxes (e.g., the
+//! parent's ingestion inbox), maintaining runtime-agnostic communication where the
+//! policy layer doesn't need to know about Teams or tmux.
 
 use std::sync::Arc;
 

--- a/rust/exo-node/src/poll.rs
+++ b/rust/exo-node/src/poll.rs
@@ -1,23 +1,16 @@
-//! **N3 — Self-poll.** The per-agent realization of the old central poller. While this node
-//! has an open PR, periodically poll its own PR/CI state, turn transitions into
-//! [`exo_policy::WorldEvent`]s, run `exo_policy::on_world_event`, and act on the result
-//! (`InjectMessage` → own inbox; `NotifyParent` → parent inbox).
+//! **N3 — Self-poll.** Implements per-agent polling of PR and CI state. When a node has an
+//! open PR, this module periodically monitors its status and translates state transitions
+//! into [`exo_policy::WorldEvent`]s.
 //!
-//! WorldEvent producers (the "no dead variant" converge gate — see `06-migration.md`):
-//! - `PrReview { state }` ← `ctx.runtime.review_state(pr)` (C2 cap).
-//! - `CiStatus { status }` ← `ctx.runtime.ci_status(pr)` (C2 cap).
-//! - `ReviewTimeout` ← when `review_state(pr).is_none()` past the ~15-min window (the window
-//!   **resets on each feedback round**). Reuse `exomonad-core/.../github_poller.rs` timeout
-//!   logic — adapt, don't rewrite.
-//! - `SiblingMerged` is NOT produced here — it's parent-side, fanned out on the parent's
-//!   merge path (it holds the child ledger). See [`crate::poll::fan_sibling_merged`].
+//! It triggers `exo_policy::on_world_event` and handles the resulting actions, such as
+//! injecting messages into the node's own inbox or notifying its parent. It monitors:
+//! - `PrReview`: Transitions in PR review state (e.g., Changes Requested, Approved).
+//! - `CiStatus`: Changes in CI build status.
+//! - `ReviewTimeout`: Detects when a review is overdue based on configurable windows.
 //!
-//! Discipline (bounds API load — no central poller): poll **every ~3 min, ONLY while an open
-//! PR exists** (no PR → no polling → a swarm is sparse). **Tracked `AbortHandle`:** abort the
-//! poll task when the PR merges/closes; a re-`file_pr` must dedup/replace, never leak a second
-//! poller (a bare `tokio::spawn` double-polls).
-//!
-//! **Status: stub (N3 leaf fills this).** Acceptance: with a mock GitHub cap returning
+//! Polling is disciplined to minimize API load, running only when an open PR exists.
+//! Polling tasks are managed via `AbortHandle` to ensure they are cleaned up when a PR
+//! is closed or merged, preventing duplicate pollers.
 //! Approved, one poll cycle emits a `PrReview{Approved}` → `NotifyParent([PR READY])` to the
 //! parent inbox; aborting closes the task with no leak.
 


### PR DESCRIPTION
This PR adds unit and deterministic integration test coverage to the `exo-node` crate and replaces stale module doc-comments with accurate descriptions.

### Changes
- **DOC CLEANUP**: Updated module doc-comments in `outbound.rs`, `dispatch.rs`, `poll.rs`, and `hook.rs` to reflect current implementation and remove stub language.
- **TEST `bootstrap.rs`**: Added tests for the `bootstrap` function using tempfiles and mocked environment variables.
- **TEST `hook.rs`**: Added tests for `Stop` and `PreToolUse` (Deny/Modify) events using custom `RoleDef` mocks.
- **TEST `inbound.rs`**: Added a test for cursor durability across simulated restarts.
- **TEST `dispatch.rs`**: Added coverage for missing `decide_lasthop` and `render_entry` cases.

### Note on `poll_once` Edge-Triggering
The `poll_once` edge-triggering test was skipped because `poll_once` is not currently generic over the GitHub/CI capabilities. Refactoring it to be testable would require changing the production `NodeContext` and `poll_once` signatures, which was explicitly out of scope for this task.

### Verification
- `cargo fmt -p exo-node`
- `cargo test -p exo-node`
- `cargo clippy -p exo-node --all-targets -- -D warnings`
- All 24 unit tests in `exo-node` are passing.
- 3 integration tests in `tests/converge.rs` are passing.