### PR TITLE
feat: implement merge strategy and git fetch in merge_pr tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1059,6 +1059,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/rust/exo-caps/src/git.rs
+++ b/rust/exo-caps/src/git.rs
@@ -19,6 +19,7 @@ pub enum GitError {
 pub trait Git {
     async fn current_branch(&self) -> Result<Branch, GitError>;
     async fn is_clean(&self) -> Result<bool, GitError>;
+    async fn fetch(&self) -> Result<(), GitError>;
     async fn worktree_add(&self, branch: &Branch, at: &Path) -> Result<(), GitError>;
     async fn worktree_remove(&self, at: &Path) -> Result<(), GitError>;
 }

--- a/rust/exo-caps/src/github.rs
+++ b/rust/exo-caps/src/github.rs
@@ -30,13 +30,41 @@ pub enum CiStatus {
     Pending,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum MergeStrategy {
+    #[default]
+    Squash,
+    Merge,
+    Rebase,
+}
+
+impl MergeStrategy {
+    pub fn parse(s: &str) -> Self {
+        match s.to_lowercase().as_str() {
+            "squash" => Self::Squash,
+            "merge" => Self::Merge,
+            "rebase" => Self::Rebase,
+            _ => Self::Squash,
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Squash => "squash",
+            Self::Merge => "merge",
+            Self::Rebase => "rebase",
+        }
+    }
+}
+
 #[async_trait]
 pub trait GitHub {
     /// Create or update the PR for the current branch; returns the PR number.
     async fn file_pr(&self, title: &str, body: &str, base: &Branch) -> Result<u64, GitHubError>;
     /// The open PR number for a branch, if any.
     async fn pr_for_branch(&self, branch: &Branch) -> Result<Option<u64>, GitHubError>;
-    async fn merge_pr(&self, pr: u64) -> Result<(), GitHubError>;
+    async fn merge_pr(&self, pr: u64, strategy: MergeStrategy) -> Result<(), GitHubError>;
     /// Does the open PR have unaddressed `ChangesRequested`? (the live stop-gate).
     async fn has_unaddressed_changes(&self, pr: u64) -> Result<bool, GitHubError>;
     /// The latest review decision on the PR. None if no reviews have arrived.

--- a/rust/exo-caps/src/github.rs
+++ b/rust/exo-caps/src/github.rs
@@ -40,12 +40,12 @@ pub enum MergeStrategy {
 }
 
 impl MergeStrategy {
-    pub fn parse(s: &str) -> Self {
+    pub fn parse(s: &str) -> Option<Self> {
         match s.to_lowercase().as_str() {
-            "squash" => Self::Squash,
-            "merge" => Self::Merge,
-            "rebase" => Self::Rebase,
-            _ => Self::Squash,
+            "squash" => Some(Self::Squash),
+            "merge" => Some(Self::Merge),
+            "rebase" => Some(Self::Rebase),
+            _ => None,
         }
     }
 

--- a/rust/exo-caps/src/lib.rs
+++ b/rust/exo-caps/src/lib.rs
@@ -32,7 +32,7 @@ pub use bus::{Addressee, Bus, BusError};
 pub use error::{CapError, CapResult};
 pub use fs::{Fs, FsError};
 pub use git::{Git, GitError};
-pub use github::{CiStatus, GitHub, GitHubError, ReviewState};
+pub use github::{CiStatus, GitHub, GitHubError, MergeStrategy, ReviewState};
 pub use kv::{Kv, KvError};
 pub use lifecycle::{fold_children, Child, ChildLifecycle, ChildRecord};
 pub use log::Log;

--- a/rust/exo-policy/Cargo.toml
+++ b/rust/exo-policy/Cargo.toml
@@ -13,6 +13,7 @@ exo-caps = { path = "../exo-caps" }
 
 serde = { workspace = true }
 serde_json = { workspace = true }
+tracing = { workspace = true }
 thiserror = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }

--- a/rust/exo-policy/src/testing.rs
+++ b/rust/exo-policy/src/testing.rs
@@ -13,8 +13,8 @@
 use async_trait::async_trait;
 use exo_caps::{
     Addressee, AgentName, Branch, Bus, BusError, CiStatus, ForkSpec, Fs, FsError, GeminiSpec, Git,
-    GitError, GitHub, GitHubError, Kv, KvError, Log, Message, PaneId, Process, ProcessError,
-    ReviewState, SpawnError, Spawner, Tmux, TmuxError, WorkerSpec,
+    GitError, GitHub, GitHubError, Kv, KvError, Log, MergeStrategy, Message, PaneId, Process,
+    ProcessError, ReviewState, SpawnError, Spawner, Tmux, TmuxError, WorkerSpec,
 };
 use std::collections::HashMap;
 use std::path::Path;
@@ -35,7 +35,9 @@ pub enum Call {
     },
     MergePr {
         pr: u64,
+        strategy: MergeStrategy,
     },
+    Fetch,
     SpawnWorker {
         spec_task: String,
         step_count: usize,
@@ -149,6 +151,16 @@ impl Git for MockRuntime {
     async fn is_clean(&self) -> Result<bool, GitError> {
         Ok(self.is_clean)
     }
+    async fn fetch(&self) -> Result<(), GitError> {
+        if self.should_fail("fetch") {
+            return Err(GitError::Failed {
+                op: "fetch",
+                detail: "mock forced failure".into(),
+            });
+        }
+        self.record(Call::Fetch);
+        Ok(())
+    }
     async fn worktree_add(&self, _branch: &Branch, _at: &Path) -> Result<(), GitError> {
         Ok(())
     }
@@ -176,14 +188,14 @@ impl GitHub for MockRuntime {
     async fn pr_for_branch(&self, _branch: &Branch) -> Result<Option<u64>, GitHubError> {
         Ok(self.pr_for_branch)
     }
-    async fn merge_pr(&self, pr: u64) -> Result<(), GitHubError> {
+    async fn merge_pr(&self, pr: u64, strategy: MergeStrategy) -> Result<(), GitHubError> {
         if self.should_fail("merge_pr") {
             return Err(GitHubError::Failed {
                 op: "merge_pr",
                 detail: "mock forced failure".into(),
             });
         }
-        self.record(Call::MergePr { pr });
+        self.record(Call::MergePr { pr, strategy });
         Ok(())
     }
     async fn has_unaddressed_changes(&self, _pr: u64) -> Result<bool, GitHubError> {
@@ -348,6 +360,6 @@ mod tests {
     #[tokio::test]
     async fn forced_failure_surfaces() {
         let m = MockRuntime::failing("merge_pr");
-        assert!(m.merge_pr(3).await.is_err());
+        assert!(m.merge_pr(3, MergeStrategy::Squash).await.is_err());
     }
 }

--- a/rust/exo-policy/src/tools/merge_pr.rs
+++ b/rust/exo-policy/src/tools/merge_pr.rs
@@ -4,7 +4,7 @@
 //! `Git` and `GitHub` capabilities to verify readiness (checking for unaddressed
 //! changes and self-merge attempts) before performing the merge.
 
-use exo_caps::{CapResult, Git, GitHub};
+use exo_caps::{CapResult, Git, GitHub, MergeStrategy};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -16,6 +16,8 @@ use crate::tool::{ok_json, parse, schema_json, Tool, ToolOutput};
 pub struct MergePrArgs {
     /// The PR number to merge.
     pub pr: u64,
+    /// The merge strategy to use (squash, merge, or rebase). Defaults to squash.
+    pub strategy: Option<String>,
     /// If true, skip the readiness guard (unaddressed changes check).
     #[serde(default)]
     pub force: bool,
@@ -30,6 +32,7 @@ impl MergePr {
     /// 1. **Self-merge guard**: Prevents an agent from merging its own PR.
     /// 2. **Readiness guard**: Checks if there are unaddressed `ChangesRequested` reviews.
     /// 3. **Merge**: Executes the merge via the GitHub capability.
+    /// 4. **Fetch**: Syncs local state after a successful merge (best-effort).
     pub async fn run<C: Git + GitHub>(ctx: &C, args: MergePrArgs) -> CapResult<ToolOutput> {
         // 1. Self-merge guard (always enforced)
         let current_branch = ctx.current_branch().await?;
@@ -51,15 +54,29 @@ impl MergePr {
         }
 
         // 3. Merge
-        // TODO(cap): GitHub::merge_pr does not support merge strategies (squash/merge/rebase) yet.
-        ctx.merge_pr(args.pr).await?;
+        let strategy = args
+            .strategy
+            .as_deref()
+            .map(MergeStrategy::parse)
+            .unwrap_or_default();
+        ctx.merge_pr(args.pr, strategy).await?;
 
-        // TODO(cap): Git capability does not support 'pull' or 'fetch' to sync local state after merge.
-        // TODO(cap): No capability for agent shutdown/cleanup yet.
+        // 4. Fetch (best-effort): pulls merged changes
+        if let Err(e) = ctx.fetch().await {
+            tracing::warn!(error = %e, "post-merge git fetch failed (ignoring)");
+        }
+
+        // NOTE: Agent teardown (worktree reclaim + pane kill) is parent-side at
+        // convergence by design (Spawner::reclaim_worktree / kill_pane) —
+        // merge_pr does not shut down the merged agent.
 
         Ok(ToolOutput::with_data(
-            format!("merged PR #{}", args.pr),
-            json!({ "pr": args.pr }),
+            format!(
+                "merged PR #{} using {} strategy",
+                args.pr,
+                strategy.as_str()
+            ),
+            json!({ "pr": args.pr, "strategy": strategy.as_str() }),
         ))
     }
 }
@@ -92,17 +109,65 @@ mod tests {
         let mock = MockRuntime::default();
         let args = MergePrArgs {
             pr: 123,
+            strategy: None,
             force: false,
         };
 
         let out = MergePr::run(&mock, args).await.unwrap();
 
-        assert_eq!(out.text, "merged PR #123");
-        assert_eq!(out.data, Some(json!({ "pr": 123 })));
+        assert_eq!(out.text, "merged PR #123 using squash strategy");
+        assert_eq!(out.data, Some(json!({ "pr": 123, "strategy": "squash" })));
 
         // Verify merge was called
         let calls = mock.calls_made();
-        assert!(calls.contains(&Call::MergePr { pr: 123 }));
+        assert!(calls.contains(&Call::MergePr {
+            pr: 123,
+            strategy: MergeStrategy::Squash
+        }));
+        assert!(calls.contains(&Call::Fetch));
+    }
+
+    #[tokio::test]
+    async fn test_merge_pr_with_explicit_strategy() {
+        let mock = MockRuntime::default();
+        let args = MergePrArgs {
+            pr: 123,
+            strategy: Some("rebase".into()),
+            force: false,
+        };
+
+        let out = MergePr::run(&mock, args).await.unwrap();
+
+        assert_eq!(out.text, "merged PR #123 using rebase strategy");
+        assert_eq!(out.data, Some(json!({ "pr": 123, "strategy": "rebase" })));
+
+        let calls = mock.calls_made();
+        assert!(calls.contains(&Call::MergePr {
+            pr: 123,
+            strategy: MergeStrategy::Rebase
+        }));
+    }
+
+    #[tokio::test]
+    async fn test_merge_pr_fetch_failure_ignored() {
+        let mock = MockRuntime::failing("fetch");
+        let args = MergePrArgs {
+            pr: 123,
+            strategy: None,
+            force: false,
+        };
+
+        let out = MergePr::run(&mock, args).await.unwrap();
+
+        assert_eq!(out.text, "merged PR #123 using squash strategy");
+        let calls = mock.calls_made();
+        assert!(calls.contains(&Call::MergePr {
+            pr: 123,
+            strategy: MergeStrategy::Squash
+        }));
+        // fetch should NOT be in calls if it failed (in MockRuntime implementation)
+        // Wait, MockRuntime record happens AFTER failure check.
+        // Let's check MockRuntime fetch impl.
     }
 
     #[tokio::test]
@@ -115,6 +180,7 @@ mod tests {
 
         let args = MergePrArgs {
             pr: 123,
+            strategy: None,
             force: false,
         }; // Trying to merge own PR 123
         let out = MergePr::run(&mock, args).await.unwrap();
@@ -140,6 +206,7 @@ mod tests {
 
         let args = MergePrArgs {
             pr: 123,
+            strategy: None,
             force: false,
         };
         let out = MergePr::run(&mock, args).await.unwrap();
@@ -165,16 +232,20 @@ mod tests {
 
         let args = MergePrArgs {
             pr: 123,
+            strategy: None,
             force: true, // Skip the guard
         };
         let out = MergePr::run(&mock, args).await.unwrap();
 
-        assert_eq!(out.text, "merged PR #123");
-        assert_eq!(out.data, Some(json!({ "pr": 123 })));
+        assert_eq!(out.text, "merged PR #123 using squash strategy");
+        assert_eq!(out.data, Some(json!({ "pr": 123, "strategy": "squash" })));
 
         // Verify merge WAS called
         let calls = mock.calls_made();
-        assert!(calls.contains(&Call::MergePr { pr: 123 }));
+        assert!(calls.contains(&Call::MergePr {
+            pr: 123,
+            strategy: MergeStrategy::Squash
+        }));
     }
 
     #[tokio::test]
@@ -188,6 +259,7 @@ mod tests {
 
         let args = MergePrArgs {
             pr: 123,
+            strategy: None,
             force: true, // Try to force self-merge
         };
         let out = MergePr::run(&mock, args).await.unwrap();
@@ -209,6 +281,7 @@ mod tests {
         let mock = MockRuntime::failing("merge_pr");
         let args = MergePrArgs {
             pr: 123,
+            strategy: None,
             force: false,
         };
 

--- a/rust/exo-policy/src/tools/merge_pr.rs
+++ b/rust/exo-policy/src/tools/merge_pr.rs
@@ -17,6 +17,7 @@ pub struct MergePrArgs {
     /// The PR number to merge.
     pub pr: u64,
     /// The merge strategy to use (squash, merge, or rebase). Defaults to squash.
+    /// Invalid values will result in an error.
     pub strategy: Option<String>,
     /// If true, skip the readiness guard (unaddressed changes check).
     #[serde(default)]
@@ -54,11 +55,19 @@ impl MergePr {
         }
 
         // 3. Merge
-        let strategy = args
-            .strategy
-            .as_deref()
-            .map(MergeStrategy::parse)
-            .unwrap_or_default();
+        let strategy = if let Some(s) = args.strategy.as_deref() {
+            MergeStrategy::parse(s).ok_or_else(|| {
+                exo_caps::CapError::invalid(
+                    "strategy",
+                    format!(
+                        "Invalid merge strategy: '{}'. Must be squash, merge, or rebase.",
+                        s
+                    ),
+                )
+            })?
+        } else {
+            MergeStrategy::Squash
+        };
         ctx.merge_pr(args.pr, strategy).await?;
 
         // 4. Fetch (best-effort): pulls merged changes
@@ -165,9 +174,8 @@ mod tests {
             pr: 123,
             strategy: MergeStrategy::Squash
         }));
-        // fetch should NOT be in calls if it failed (in MockRuntime implementation)
-        // Wait, MockRuntime record happens AFTER failure check.
-        // Let's check MockRuntime fetch impl.
+        // Verify fetch was NOT recorded because it failed
+        assert!(!calls.contains(&Call::Fetch));
     }
 
     #[tokio::test]
@@ -274,6 +282,21 @@ mod tests {
                 panic!("merge_pr should not have been called");
             }
         }
+    }
+
+    #[tokio::test]
+    async fn test_merge_pr_invalid_strategy() {
+        let mock = MockRuntime::default();
+        let args = MergePrArgs {
+            pr: 123,
+            strategy: Some("sqush".into()),
+            force: false,
+        };
+
+        let res = MergePr::run(&mock, args).await;
+        assert!(res.is_err());
+        let err = res.unwrap_err();
+        assert!(err.to_string().contains("Invalid merge strategy: 'sqush'"));
     }
 
     #[tokio::test]

--- a/rust/exo-runtime/src/git.rs
+++ b/rust/exo-runtime/src/git.rs
@@ -26,6 +26,11 @@ impl Git for Runtime {
         Ok(String::from_utf8_lossy(&output.stdout).trim().is_empty())
     }
 
+    async fn fetch(&self) -> Result<(), GitError> {
+        self.git(&["fetch"]).await?;
+        Ok(())
+    }
+
     async fn worktree_add(&self, branch: &Branch, at: &Path) -> Result<(), GitError> {
         self.git(&[
             "worktree",

--- a/rust/exo-runtime/src/github.rs
+++ b/rust/exo-runtime/src/github.rs
@@ -6,8 +6,9 @@
 
 use crate::runtime::Runtime;
 use async_trait::async_trait;
-use exo_caps::{Branch, CiStatus, GitHub, GitHubError, ReviewState};
+use exo_caps::{Branch, CiStatus, GitHub, GitHubError, MergeStrategy, ReviewState};
 use octocrab::models::pulls::ReviewState as OctoReviewState;
+use octocrab::params::pulls::MergeMethod;
 use octocrab::{params, Octocrab, OctocrabBuilder};
 use tokio::process::Command;
 
@@ -52,11 +53,19 @@ impl GitHub for Runtime {
         Ok(page.into_iter().next().map(|pr| pr.number))
     }
 
-    async fn merge_pr(&self, pr: u64) -> Result<(), GitHubError> {
+    async fn merge_pr(&self, pr: u64, strategy: MergeStrategy) -> Result<(), GitHubError> {
         let (owner, repo) = self.repo().await?;
         let octo = self.octocrab().await?;
+
+        let method = match strategy {
+            MergeStrategy::Squash => MergeMethod::Squash,
+            MergeStrategy::Merge => MergeMethod::Merge,
+            MergeStrategy::Rebase => MergeMethod::Rebase,
+        };
+
         octo.pulls(owner, repo)
             .merge(pr)
+            .method(method)
             .send()
             .await
             .map_err(|e| GitHubError::Failed {


### PR DESCRIPTION
This PR closes the two `TODO(cap)` gaps in the `exo-policy` `merge_pr` tool:
1.  **Merge-strategy selection**: Added `MergeStrategy` enum (Squash, Merge, Rebase) to `exo-caps` and updated `GitHub::merge_pr` signature. Implemented in `exo-runtime` via `octocrab`. Strategy parsing is now robust and rejects unknown values.
2.  **Post-merge `git fetch`**: Added `Git::fetch` capability and implemented it in `exo-runtime`. Updated `merge_pr` tool to call `fetch` best-effort after a successful merge.

Additional changes:
- Replaced the agent-shutdown TODO with a doc note explaining it's parent-side by design.
- Updated `MockRuntime` in `exo-policy` to match new signatures and record new calls.
- Fixed all call sites and updated tests, including new test cases for strategy validation and fetch failure handling.
- Added `tracing` dependency to `exo-policy` for best-effort fetch logging.

Verified with `cargo check --workspace`, `cargo test`, and `cargo clippy`. Addressing Copilot review: strategy parsing is no longer silent-fallback, and tests are cleaned up.