### PR TITLE
refactor: extract claude node config writer to shared helper

### DIFF
--- a/rust/exo-runtime/src/lib.rs
+++ b/rust/exo-runtime/src/lib.rs
@@ -27,8 +27,10 @@ mod git;
 mod github;
 mod kv;
 mod log;
+pub mod node_config;
 mod process;
 mod spawner;
 mod tmux;
 
+pub use node_config::write_node_agent_config;
 pub use runtime::Runtime;

--- a/rust/exo-runtime/src/node_config.rs
+++ b/rust/exo-runtime/src/node_config.rs
@@ -1,0 +1,60 @@
+use std::path::Path;
+use tokio::io::AsyncWriteExt;
+
+/// Write the Claude-specific configuration files (`.mcp.json` and `.claude/settings.local.json`)
+/// to the given agent directory. This is identity-free and can be used for both the root agent
+/// and child agents.
+pub async fn write_node_agent_config(agent_dir: &Path, papers_path: &Path) -> std::io::Result<()> {
+    let esc = |s: &str| shell_escape::escape(s.to_string().into()).into_owned();
+
+    // 1. .mcp.json (MCP sidecar config)
+    let mcp_config = serde_json::json!({
+        "mcpServers": {
+            "exomonad": {
+                "type": "stdio",
+                "command": "exomonad",
+                "args": exo_caps::invocation::node_args(&papers_path.to_string_lossy())
+            }
+        }
+    });
+
+    let mcp_path = agent_dir.join(".mcp.json");
+    let mcp_json = serde_json::to_vec_pretty(&mcp_config).map_err(|e| {
+        std::io::Error::other(format!("mcp_config encode: {e}"))
+    })?;
+    let mut f = tokio::fs::File::create(&mcp_path).await?;
+    f.write_all(&mcp_json).await?;
+    f.sync_all().await?;
+
+    // 2. .claude/settings.local.json (CC experimental hooks)
+    let claude_dir = agent_dir.join(".claude");
+    tokio::fs::create_dir_all(&claude_dir).await?;
+
+    let p_str = esc(&papers_path.to_string_lossy());
+    use exo_caps::invocation::{hook_command, PRE_TOOL_USE, SESSION_START, STOP};
+    let settings = serde_json::json!({
+        "hooks": {
+            "PreToolUse": [{
+                "matcher": "*",
+                "hooks": [{"type": "command", "command": hook_command(PRE_TOOL_USE, &p_str)}]
+            }],
+            "Stop": [{
+                "hooks": [{"type": "command", "command": hook_command(STOP, &p_str)}]
+            }],
+            "SessionStart": [{
+                "hooks": [{"type": "command", "command": hook_command(SESSION_START, &p_str)}]
+            }]
+        },
+        "_exomonad_generated": true
+    });
+
+    let settings_path = claude_dir.join("settings.local.json");
+    let settings_json = serde_json::to_vec_pretty(&settings).map_err(|e| {
+        std::io::Error::other(format!("settings encode: {e}"))
+    })?;
+    let mut f = tokio::fs::File::create(&settings_path).await?;
+    f.write_all(&settings_json).await?;
+    f.sync_all().await?;
+
+    Ok(())
+}

--- a/rust/exo-runtime/src/spawner.rs
+++ b/rust/exo-runtime/src/spawner.rs
@@ -288,16 +288,6 @@ impl Runtime {
         let esc = |s: &str| shell_escape::escape(s.to_string().into()).into_owned();
 
         // (f) Launch the agent
-        let mcp_config = serde_json::json!({
-            "mcpServers": {
-                "exomonad": {
-                    "type": "stdio",
-                    "command": "exomonad",
-                    "args": exo_caps::invocation::node_args(&papers_path.to_string_lossy())
-                }
-            }
-        });
-
         let mut env_prefix = format!(
             "EXOMONAD_AGENT_ID={} EXOMONAD_ROLE={} ",
             esc(core.name.as_str()),
@@ -306,51 +296,27 @@ impl Runtime {
 
         let agent_bin = match core.agent_type {
             AgentType::Claude => {
-                let mcp_path = child_dir.join(".mcp.json");
-                tokio::fs::write(
-                    &mcp_path,
-                    serde_json::to_vec_pretty(&mcp_config).map_err(|e| SpawnError::Failed {
-                        op: "write_mcp_config",
+                crate::node_config::write_node_agent_config(&child_dir, &papers_path)
+                    .await
+                    .map_err(|e| SpawnError::Failed {
+                        op: "write_node_agent_config",
                         child: Some(core.name.clone()),
                         detail: e.to_string(),
-                    })?,
-                )
-                .await?;
-
-                // Write .claude/settings.local.json with experimental hooks
-                let claude_dir = child_dir.join(".claude");
-                tokio::fs::create_dir_all(&claude_dir).await?;
-                let settings_path = claude_dir.join("settings.local.json");
-                let p_str = esc(&papers_path.to_string_lossy());
-                use exo_caps::invocation::{hook_command, PRE_TOOL_USE, SESSION_START, STOP};
-                let settings = serde_json::json!({
-                    "hooks": {
-                        "PreToolUse": [{
-                            "matcher": "*",
-                            "hooks": [{"type": "command", "command": hook_command(PRE_TOOL_USE, &p_str)}]
-                        }],
-                        "Stop": [{
-                            "hooks": [{"type": "command", "command": hook_command(STOP, &p_str)}]
-                        }],
-                        "SessionStart": [{
-                            "hooks": [{"type": "command", "command": hook_command(SESSION_START, &p_str)}]
-                        }]
-                    },
-                    "_exomonad_generated": true
-                });
-                tokio::fs::write(
-                    &settings_path,
-                    serde_json::to_vec_pretty(&settings).map_err(|e| SpawnError::Failed {
-                        op: "write_claude_settings",
-                        child: Some(core.name.clone()),
-                        detail: e.to_string(),
-                    })?,
-                )
-                .await?;
+                    })?;
 
                 "claude --dangerously-skip-permissions"
             }
             AgentType::Gemini => {
+                let mcp_config = serde_json::json!({
+                    "mcpServers": {
+                        "exomonad": {
+                            "type": "stdio",
+                            "command": "exomonad",
+                            "args": exo_caps::invocation::node_args(&papers_path.to_string_lossy())
+                        }
+                    }
+                });
+
                 // Gemini child hooks are not wired (not supported in the same command-type way)
                 let settings_path = papers_path.with_file_name("settings.json");
                 let settings = mcp_config.clone();


### PR DESCRIPTION
Extract the Claude-child config-writing logic (for `.mcp.json` and `.claude/settings.local.json`) from `spawner.rs` into a new, shared, identity-free helper function `write_node_agent_config` in `exo-runtime`.

This refactor is behavior-preserving and ensures that the root agent (which has no child identity) can reuse the same logic for its own configuration, preventing drift between root and child agent setups.

Verification:
- `cargo build -p exo-runtime` passes
- `cargo test -p exo-runtime` passes
- `cargo clippy -p exo-runtime` passes
- JSON output is byte-identical to previous implementation (same shapes, same escaping, same hook commands).
- Gemini configuration logic remains untouched in `spawner.rs`.