### PR TITLE
feat: best-effort teardown (kill pane + reclaim worktree) on merge

### DIFF
--- a/rust/exo-policy/src/testing.rs
+++ b/rust/exo-policy/src/testing.rs
@@ -62,6 +62,12 @@ pub enum Call {
     LogError {
         msg: String,
     },
+    KillPane {
+        child: AgentName,
+    },
+    ReclaimWorktree {
+        child: AgentName,
+    },
 }
 
 /// Canned return values + a recording log. Interior-mutable so the cap methods take `&self`
@@ -195,10 +201,16 @@ impl Spawner for MockRuntime {
             })
             .collect()
     }
-    async fn reclaim_worktree(&self, _child: &AgentName) -> Result<(), SpawnError> {
+    async fn reclaim_worktree(&self, child: &AgentName) -> Result<(), SpawnError> {
+        self.record(Call::ReclaimWorktree {
+            child: child.clone(),
+        });
         Ok(())
     }
-    async fn kill_pane(&self, _child: &AgentName) -> Result<(), SpawnError> {
+    async fn kill_pane(&self, child: &AgentName) -> Result<(), SpawnError> {
+        self.record(Call::KillPane {
+            child: child.clone(),
+        });
         Ok(())
     }
 }

--- a/rust/exo-policy/src/testing.rs
+++ b/rust/exo-policy/src/testing.rs
@@ -202,12 +202,26 @@ impl Spawner for MockRuntime {
             .collect()
     }
     async fn reclaim_worktree(&self, child: &AgentName) -> Result<(), SpawnError> {
+        if self.should_fail("reclaim_worktree") {
+            return Err(SpawnError::Failed {
+                op: "reclaim_worktree",
+                child: Some(child.clone()),
+                detail: "mock forced failure".into(),
+            });
+        }
         self.record(Call::ReclaimWorktree {
             child: child.clone(),
         });
         Ok(())
     }
     async fn kill_pane(&self, child: &AgentName) -> Result<(), SpawnError> {
+        if self.should_fail("kill_pane") {
+            return Err(SpawnError::Failed {
+                op: "kill_pane",
+                child: Some(child.clone()),
+                detail: "mock forced failure".into(),
+            });
+        }
         self.record(Call::KillPane {
             child: child.clone(),
         });

--- a/rust/exo-policy/src/tools/merge.rs
+++ b/rust/exo-policy/src/tools/merge.rs
@@ -17,6 +17,8 @@ use crate::tool::{ok_json, parse, schema_json, Tool, ToolOutput};
 pub struct MergeArgs {
     /// The child's branch to fold into this node's branch (e.g. `main.root.feature`).
     pub branch: String,
+    /// The child's agent name (e.g. `feature`). Derived from branch if omitted.
+    pub child: Option<String>,
 }
 
 /// The `merge` tool: local fold of a child branch.
@@ -28,17 +30,28 @@ impl Merge {
         ctx.merge(&branch).await?;
 
         let mut teardown = String::new();
-        if let Some(seg) = branch.as_str().rsplit('.').next() {
-            if let Ok(child) = AgentName::new(seg.to_string()) {
+        let child_candidate = args
+            .child
+            .or_else(|| branch.as_str().rsplit('.').next().map(|s| s.to_string()));
+
+        if let Some(name_str) = child_candidate {
+            if let Ok(child) = AgentName::new(name_str) {
                 let killed = ctx.kill_pane(&child).await;
                 let reclaimed = ctx.reclaim_worktree(&child).await;
-                teardown = match (killed, reclaimed) {
-                    (Ok(_), Ok(_)) => format!(" (reclaimed {})", child.as_str()),
-                    (k, r) => format!(
-                        " (teardown best-effort: kill={:?} reclaim={:?})",
-                        k.err(),
-                        r.err()
-                    ),
+
+                let k_msg = match killed {
+                    Ok(_) => "ok".to_string(),
+                    Err(e) => e.to_string(),
+                };
+                let r_msg = match reclaimed {
+                    Ok(_) => "ok".to_string(),
+                    Err(e) => e.to_string(),
+                };
+
+                teardown = if k_msg == "ok" && r_msg == "ok" {
+                    format!(" (reclaimed {})", child.as_str())
+                } else {
+                    format!(" (teardown best-effort: kill={} reclaim={})", k_msg, r_msg)
                 };
             }
         }
@@ -85,6 +98,7 @@ mod tests {
             &mock,
             MergeArgs {
                 branch: "main.root.feature".into(),
+                child: None,
             },
         )
         .await
@@ -108,12 +122,53 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_merge_explicit_child() {
+        let mock = MockRuntime::default();
+        // Agent name v1.2 becomes branch v1-2. Explicitly passing the real name
+        // should override the branch-based heuristic.
+        let out = Merge::run(
+            &mock,
+            MergeArgs {
+                branch: "main.root.v1-2".into(),
+                child: Some("v1.2".into()),
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(out.text, "merged branch main.root.v1-2 (reclaimed v1.2)");
+        let calls = mock.calls_made();
+        assert!(calls
+            .iter()
+            .any(|c| matches!(c, Call::KillPane { child } if child.as_str() == "v1.2")));
+    }
+
+    #[tokio::test]
+    async fn test_merge_teardown_failure_formatting() {
+        let mock = MockRuntime::failing("kill_pane");
+        let out = Merge::run(
+            &mock,
+            MergeArgs {
+                branch: "main.root.feature".into(),
+                child: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        // The exact error message depends on SpawnError's Display impl in MockRuntime
+        assert!(out.text.contains("teardown best-effort: kill="));
+        assert!(out.text.contains("reclaim=ok"));
+    }
+
+    #[tokio::test]
     async fn test_merge_error_path() {
         let mock = MockRuntime::failing("merge");
         let res = Merge::run(
             &mock,
             MergeArgs {
                 branch: "main.root.feature".into(),
+                child: None,
             },
         )
         .await;

--- a/rust/exo-policy/src/tools/merge.rs
+++ b/rust/exo-policy/src/tools/merge.rs
@@ -5,7 +5,7 @@
 //! when added, runs *before* this (gating the merge); this tool is just the fold. A merge
 //! conflict surfaces as a tool error for the TL to resolve.
 
-use exo_caps::{Branch, CapResult, Git};
+use exo_caps::{AgentName, Branch, CapResult, Git, Spawner};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -23,18 +23,35 @@ pub struct MergeArgs {
 pub struct Merge;
 
 impl Merge {
-    pub async fn run<C: Git>(ctx: &C, args: MergeArgs) -> CapResult<ToolOutput> {
+    pub async fn run<C: Git + Spawner>(ctx: &C, args: MergeArgs) -> CapResult<ToolOutput> {
         let branch = Branch::new(args.branch.clone())?;
         ctx.merge(&branch).await?;
+
+        let mut teardown = String::new();
+        if let Some(seg) = branch.as_str().rsplit('.').next() {
+            if let Ok(child) = AgentName::new(seg.to_string()) {
+                let killed = ctx.kill_pane(&child).await;
+                let reclaimed = ctx.reclaim_worktree(&child).await;
+                teardown = match (killed, reclaimed) {
+                    (Ok(_), Ok(_)) => format!(" (reclaimed {})", child.as_str()),
+                    (k, r) => format!(
+                        " (teardown best-effort: kill={:?} reclaim={:?})",
+                        k.err(),
+                        r.err()
+                    ),
+                };
+            }
+        }
+
         Ok(ToolOutput::with_data(
-            format!("merged branch {}", branch.as_str()),
+            format!("merged branch {}{}", branch.as_str(), teardown),
             json!({ "branch": branch.as_str() }),
         ))
     }
 }
 
 #[async_trait::async_trait]
-impl<R: Git + Send + Sync> Tool<R> for Merge {
+impl<R: Git + Spawner + Send + Sync> Tool<R> for Merge {
     fn name(&self) -> &str {
         "merge"
     }
@@ -73,12 +90,21 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(out.text, "merged branch main.root.feature");
+        assert_eq!(
+            out.text,
+            "merged branch main.root.feature (reclaimed feature)"
+        );
         assert_eq!(out.data, Some(json!({ "branch": "main.root.feature" })));
         let calls = mock.calls_made();
         assert!(calls.iter().any(
             |c| matches!(c, Call::Merge { branch } if branch.as_str() == "main.root.feature")
         ));
+        assert!(calls
+            .iter()
+            .any(|c| matches!(c, Call::KillPane { child } if child.as_str() == "feature")));
+        assert!(calls
+            .iter()
+            .any(|c| matches!(c, Call::ReclaimWorktree { child } if child.as_str() == "feature")));
     }
 
     #[tokio::test]


### PR DESCRIPTION
This PR implements best-effort teardown for child agents after their branch has been successfully merged.

Changes:
- In `rust/exo-policy/src/tools/merge.rs`:
    - Added `Spawner` bound to `Merge::run`.
    - Added logic to derive child agent name from the branch name.
    - Added best-effort calls to `kill_pane` and `reclaim_worktree` after merge success.
    - Updated tool output text to include reclamation status with improved formatting.
    - **Update**: Added optional `child` argument to `MergeArgs` to allow explicit child identification (addressing Copilot review).
    - Updated unit tests to verify teardown calls and status formatting.
- In `rust/exo-policy/src/testing.rs`:
    - Added `KillPane` and `ReclaimWorktree` variants to the `Call` enum.
    - Updated `MockRuntime`'s `Spawner` implementation to record these calls and support forced failures for testing.

Verification:
- `cargo test -p exo-policy` passes.
- `cargo clippy -p exo-policy --all-targets` passes.
- `cargo fmt -p exo-policy` applied.