### PR TITLE
feat(runtime): prepend worktree-context preamble to child prompts

### DIFF
--- a/rust/exo-runtime/src/spawner.rs
+++ b/rust/exo-runtime/src/spawner.rs
@@ -415,13 +415,21 @@ impl Runtime {
             }
         };
 
-        let worktree_prompt = format!(
-            "You are working in an ISOLATED git worktree at `{}` — this is your repo root. ALL file \
-             paths are relative to it. Do NOT read or write files outside this directory (never touch \
-             the parent repository). Commit your work to your branch here.\n\n{}",
-            child_dir.display(),
-            core.task
-        );
+        let preamble = match core.kind {
+            ChildKind::Worktree => format!(
+                "You are working in an ISOLATED git worktree at `{}` — this is your repo root. ALL file \
+                 paths are relative to it. Do NOT read or write files outside this directory (never touch \
+                 the parent repository). Commit your work to your branch here.\n\n",
+                child_dir.display()
+            ),
+            ChildKind::Inline => format!(
+                "You are working in the repository at `{}`. ALL file paths are relative to it. \
+                 Do NOT read or write files outside this directory.\n\n",
+                child_dir.display()
+            ),
+        };
+
+        let worktree_prompt = format!("{}{}", preamble, core.task);
 
         let prompt_file = exomonad_core::services::agent_control::launch::write_prompt_file(
             child_dir,

--- a/rust/exo-runtime/src/spawner.rs
+++ b/rust/exo-runtime/src/spawner.rs
@@ -415,10 +415,18 @@ impl Runtime {
             }
         };
 
+        let worktree_prompt = format!(
+            "You are working in an ISOLATED git worktree at `{}` — this is your repo root. ALL file \
+             paths are relative to it. Do NOT read or write files outside this directory (never touch \
+             the parent repository). Commit your work to your branch here.\n\n{}",
+            child_dir.display(),
+            core.task
+        );
+
         let prompt_file = exomonad_core::services::agent_control::launch::write_prompt_file(
             child_dir,
             core.name.as_str(),
-            &core.task,
+            &worktree_prompt,
         )
         .await
         .map_err(|e| SpawnError::Failed {


### PR DESCRIPTION
In the v2 node-mode spawner, this PR prepends a worktree-context preamble to every spawned child's prompt. This ensures children know their isolated worktree root and are instructed to never read or write outside it, preventing accidental escapes into the parent repository.

Changes:
- Modified `rust/exo-runtime/src/spawner.rs` in `birth_finish` to wrap `core.task` with the isolation preamble.
- Adjusted the preamble message based on whether the child is a `Worktree` or `Inline` agent to avoid misleading terminology for inline workers.
- Fixed a potential move error by ensuring `core.task` is correctly handled within the `format!` macro.
- Reuses existing `child_dir` and `core.task` variables.
- Verified with `cargo build`, `cargo test`, and `cargo clippy`.
- Formatted with `cargo fmt -p exo-runtime`.