### PR TITLE
feat(swarm): `tree` introspection tool (subtree + parent + pane-liveness)

### DIFF
--- a/rust/exo-caps/CLAUDE.md
+++ b/rust/exo-caps/CLAUDE.md
@@ -32,6 +32,7 @@ Eight caps, each one trait per file. `exo-runtime::Runtime` implements all of th
 - **`Kv`** — `get`, `set`.
 - **`Process`** — `run`.
 - **`Log`** — `info`, `error` (sync, infallible).
+- **`Topology`** — `topology()` → the caller's subtree (folded recursively from the per-node `children.jsonl` ledgers) + parent + per-node pane-liveness. Backs the `tree` tool.
 
 ## Domain types (the invariants worth knowing)
 

--- a/rust/exo-caps/src/error.rs
+++ b/rust/exo-caps/src/error.rs
@@ -26,6 +26,8 @@ pub enum CapError {
     Process(#[from] crate::process::ProcessError),
     #[error(transparent)]
     Kv(#[from] crate::kv::KvError),
+    #[error(transparent)]
+    Topology(#[from] crate::topology::TopologyError),
 
     #[error("io: {0}")]
     Io(#[from] std::io::Error),

--- a/rust/exo-caps/src/lib.rs
+++ b/rust/exo-caps/src/lib.rs
@@ -16,6 +16,7 @@ pub mod lifecycle;
 pub mod papers;
 pub mod paths;
 pub mod spawner;
+pub mod topology;
 pub mod types;
 
 // IO caps — one trait per file.
@@ -37,6 +38,7 @@ pub use papers::NodePapers;
 pub use process::{Process, ProcessError};
 pub use spawner::{ForkSpec, GeminiSpec, SpawnError, Spawner, WorkerSpec};
 pub use tmux::{Tmux, TmuxError};
+pub use topology::{Topology, TopologyError, TopologyView, TreeNode};
 pub use types::{
     AgentName, AgentType, Branch, ChildKind, ControlKind, InboxPath, IngestionEntry, Message,
     MessageBody, MessageKind, NodeKind, NodePath, PaneId, Persona, Summary, SyntheticName,

--- a/rust/exo-caps/src/topology.rs
+++ b/rust/exo-caps/src/topology.rs
@@ -1,0 +1,62 @@
+//! `Topology` capability — a node's view of its own place in the swarm tree: the caller's
+//! subtree (folded recursively from the per-node `children.jsonl` ledgers), its parent, and a
+//! per-node liveness proxy.
+//!
+//! The filesystem *is* the registry — each node appends a `Spawned` record to its own
+//! `.exo/children.jsonl` ([`ChildRecord`](crate::ChildRecord)). This cap walks that, descending
+//! into each worktree child's nested ledger, so a Root/Tl can answer "what does my subtree look
+//! like, who's my parent, who's still alive?". Liveness is **pane-existence** (the agent's tmux
+//! pane is still there) — a true sidecar round-trip ping isn't available (the sidecar is
+//! stdio-bound to its agent, not socket-pingable).
+
+use crate::types::ChildKind;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// `Topology` failures.
+#[derive(Debug, Error)]
+pub enum TopologyError {
+    #[error("topology {op} failed: {detail}")]
+    Failed { op: &'static str, detail: String },
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}
+
+/// One node in the tree view. `kind` is `None` for the caller itself (the runtime doesn't store
+/// its own `ChildKind`) and `Some(_)` for nodes folded from a parent's ledger.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TreeNode {
+    /// The node's name (last segment of its tree address).
+    pub name: String,
+    /// How the node relates to its parent's worktree; `None` for the caller/self.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<ChildKind>,
+    /// The node's tmux pane id.
+    pub pane: String,
+    /// Liveness proxy: the node's tmux pane still exists.
+    pub pane_alive: bool,
+    /// Children folded from this node's ledger (recursive; worktree children only — inline
+    /// children share the parent's worktree and spawn nothing).
+    pub children: Vec<TreeNode>,
+}
+
+/// What [`Topology::topology`] returns: the caller (self + its subtree), its parent, and its
+/// full tree address.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TopologyView {
+    /// The caller node and its recursive subtree.
+    pub node: TreeNode,
+    /// The parent node's name; `None` for the root.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent: Option<String>,
+    /// The caller's full tree address (`NodePath` segments, root-first).
+    pub path: Vec<String>,
+}
+
+#[async_trait]
+pub trait Topology {
+    /// The caller's subtree + parent + per-node pane-liveness. Liveness is best-effort: a tmux
+    /// probe failure marks nodes not-alive rather than failing the whole call.
+    async fn topology(&self) -> Result<TopologyView, TopologyError>;
+}

--- a/rust/exo-policy/CLAUDE.md
+++ b/rust/exo-policy/CLAUDE.md
@@ -28,6 +28,7 @@ The Bucket-C logic that genuinely ports from the old Haskell DSL: MCP tool defin
 | `submit_branch` | `Git`+`Bus` | tl, dev | **The done-signal** (local analogue of file_pr): runs preconditions (v1: committed), then delivers `[READY] branch X` to the parent for it to `merge`. |
 | `notify_parent` | `Bus` | tl, dev, worker | Status/failure update to `Addressee::Parent` (NOT the done-signal). |
 | `send_message` | `Bus` | root, tl | Deliver to a child (`Inline`/`Worktree`) — **tree-edges only**. |
+| `tree` | `Topology` | root, tl | Read-only: the caller's subtree (recursive ledger fold) + parent + per-node `pane_alive` liveness. |
 
 Every tool implements `Tool::description()` (added to the trait); `exo-node`'s `tools/list`
 emits it, so the toolset is self-documenting — an agent learns the local-merge loop (commit →

--- a/rust/exo-policy/src/caps.rs
+++ b/rust/exo-policy/src/caps.rs
@@ -9,16 +9,16 @@
 //! `Send + Sync + 'static` is required because the sidecar drives tools/hooks across tokio
 //! tasks (`R: Send + Sync + 'static` at the dispatch boundary).
 
-use exo_caps::{Bus, Fs, Git, Kv, Log, Process, Spawner, Tmux};
+use exo_caps::{Bus, Fs, Git, Kv, Log, Process, Spawner, Tmux, Topology};
 
 /// The full cap set a runtime must provide to back a role. A blanket impl (below) makes this
 /// automatic for any type that impls all the caps — never implemented by hand.
 pub trait PolicyCaps:
-    Git + Bus + Spawner + Kv + Fs + Tmux + Process + Log + Send + Sync + 'static
+    Git + Bus + Spawner + Kv + Fs + Tmux + Process + Log + Topology + Send + Sync + 'static
 {
 }
 
 impl<T> PolicyCaps for T where
-    T: Git + Bus + Spawner + Kv + Fs + Tmux + Process + Log + Send + Sync + 'static
+    T: Git + Bus + Spawner + Kv + Fs + Tmux + Process + Log + Topology + Send + Sync + 'static
 {
 }

--- a/rust/exo-policy/src/roles.rs
+++ b/rust/exo-policy/src/roles.rs
@@ -19,6 +19,7 @@ use crate::tools::merge::Merge;
 use crate::tools::messaging::{NotifyParent, SendMessage};
 use crate::tools::spawn::{ForkWave, SpawnGemini, SpawnWorker};
 use crate::tools::submit::SubmitBranch;
+use crate::tools::tree::Tree;
 use exo_caps::NodeKind;
 
 /// A hook is an async fn over the concrete runtime `R`. Stored as a plain fn-pointer so the
@@ -53,6 +54,7 @@ pub fn role_def<R: PolicyCaps>(kind: NodeKind) -> RoleDef<R> {
                 Box::new(SpawnWorker),
                 Box::new(Merge),
                 Box::new(SendMessage),
+                Box::new(Tree),
             ],
             pre_tool_use,
             // Root has nothing to fold upward — never gate its exit (blocking it bricks the session).
@@ -70,6 +72,7 @@ pub fn role_def<R: PolicyCaps>(kind: NodeKind) -> RoleDef<R> {
                 Box::new(NotifyParent),
                 Box::new(SendMessage),
                 Box::new(SubmitBranch),
+                Box::new(Tree),
             ],
             pre_tool_use,
             stop,

--- a/rust/exo-policy/src/testing.rs
+++ b/rust/exo-policy/src/testing.rs
@@ -12,9 +12,9 @@
 
 use async_trait::async_trait;
 use exo_caps::{
-    Addressee, AgentName, Branch, Bus, BusError, ForkSpec, Fs, FsError, GeminiSpec, Git, GitError,
-    Kv, KvError, Log, Message, PaneId, Process, ProcessError, SpawnError, Spawner, Tmux, TmuxError,
-    WorkerSpec,
+    Addressee, AgentName, Branch, Bus, BusError, ChildKind, ForkSpec, Fs, FsError, GeminiSpec, Git,
+    GitError, Kv, KvError, Log, Message, PaneId, Process, ProcessError, SpawnError, Spawner, Tmux,
+    TmuxError, Topology, TopologyError, TopologyView, TreeNode, WorkerSpec,
 };
 use std::collections::HashMap;
 use std::path::Path;
@@ -281,6 +281,30 @@ impl Log for MockRuntime {
     }
     fn error(&self, msg: &str) {
         self.record(Call::LogError { msg: msg.into() });
+    }
+}
+
+#[async_trait]
+impl Topology for MockRuntime {
+    async fn topology(&self) -> Result<TopologyView, TopologyError> {
+        // A small canned tree: self `mock` (under `mock-parent`) with one worktree child.
+        Ok(TopologyView {
+            node: TreeNode {
+                name: "mock".into(),
+                kind: None,
+                pane: "%0".into(),
+                pane_alive: true,
+                children: vec![TreeNode {
+                    name: "child-a".into(),
+                    kind: Some(ChildKind::Worktree),
+                    pane: "%1".into(),
+                    pane_alive: true,
+                    children: vec![],
+                }],
+            },
+            parent: Some("mock-parent".into()),
+            path: vec!["mock-parent".into(), "mock".into()],
+        })
     }
 }
 

--- a/rust/exo-policy/src/tools/mod.rs
+++ b/rust/exo-policy/src/tools/mod.rs
@@ -5,9 +5,11 @@
 //!
 //! The tools, one file each: `messaging` (notify_parent / send_message), `spawn` (the three
 //! per-op spawn tools), `merge` (the local on-disk fold), `submit` (a leaf's done / ready-to-
-//! merge signal). They are wired into [`role_def`](crate::roles::role_def).
+//! merge signal), `tree` (the caller's subtree + parent + liveness). They are wired into
+//! [`role_def`](crate::roles::role_def).
 
 pub mod merge;
 pub mod messaging;
 pub mod spawn;
 pub mod submit;
+pub mod tree;

--- a/rust/exo-policy/src/tools/tree.rs
+++ b/rust/exo-policy/src/tools/tree.rs
@@ -1,0 +1,95 @@
+//! `tree` tool — show the caller's place in the swarm: its subtree (folded recursively from the
+//! `.exo/children.jsonl` ledgers) + its parent, with a per-node pane-liveness proxy.
+//!
+//! A thin shim over the [`Topology`] cap: the runtime owns identity + IO and does the ledger
+//! walk + tmux probe; this tool just surfaces the structured view. Served by Root/Tl (the roles
+//! that have children).
+
+use exo_caps::{CapResult, Topology};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::tool::{ok_json, parse, schema_json, Tool, ToolOutput};
+
+/// Arguments for the `tree` tool — none; it reports the caller's own position.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct TreeArgs {}
+
+/// The `tree` tool.
+pub struct Tree;
+
+impl Tree {
+    pub async fn run<C: Topology>(ctx: &C, _args: TreeArgs) -> CapResult<ToolOutput> {
+        let view = ctx.topology().await?;
+        let (total, alive) = count(&view.node);
+        let summary = format!(
+            "{} — parent: {}; {} node(s) in subtree, {} alive",
+            view.node.name,
+            view.parent.as_deref().unwrap_or("none (root)"),
+            total,
+            alive,
+        );
+        let data = serde_json::to_value(&view).map_err(|e| exo_caps::CapError::Json {
+            context: "tree topology view".into(),
+            source: e,
+        })?;
+        Ok(ToolOutput::with_data(summary, data))
+    }
+}
+
+/// Count `(total, alive)` over a subtree, inclusive of the node itself.
+fn count(node: &exo_caps::TreeNode) -> (usize, usize) {
+    node.children
+        .iter()
+        .fold((1, usize::from(node.pane_alive)), |(t, a), c| {
+            let (ct, ca) = count(c);
+            (t + ct, a + ca)
+        })
+}
+
+#[async_trait::async_trait]
+impl<R: Topology + Send + Sync> Tool<R> for Tree {
+    fn name(&self) -> &str {
+        "tree"
+    }
+
+    fn description(&self) -> &str {
+        "Show your place in the swarm tree: your subtree (every descendant, folded from the \
+         on-disk ledgers) plus your parent, with a per-node liveness flag (`pane_alive` = the \
+         node's tmux pane still exists). Read-only; takes no arguments."
+    }
+
+    fn schema(&self) -> serde_json::Value {
+        schema_json(schemars::schema_for!(TreeArgs))
+    }
+
+    async fn call(&self, ctx: &R, args: serde_json::Value) -> CapResult<serde_json::Value> {
+        let args: TreeArgs = parse(args)?;
+        let out = Self::run(ctx, args).await?;
+        ok_json(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testing::MockRuntime;
+
+    #[tokio::test]
+    async fn test_tree_returns_view() {
+        let mock = MockRuntime::default();
+        let out = Tree::run(&mock, TreeArgs {}).await.unwrap();
+
+        // summary mentions self + parent
+        assert!(out.text.contains("mock"));
+        assert!(out.text.contains("mock-parent"));
+
+        // structured data round-trips back to the view (self + one child)
+        let data = out.data.expect("tree returns structured data");
+        let view: exo_caps::TopologyView = serde_json::from_value(data).unwrap();
+        assert_eq!(view.node.name, "mock");
+        assert_eq!(view.parent.as_deref(), Some("mock-parent"));
+        assert_eq!(view.node.children.len(), 1);
+        assert_eq!(view.node.children[0].name, "child-a");
+    }
+}

--- a/rust/exo-runtime/src/lib.rs
+++ b/rust/exo-runtime/src/lib.rs
@@ -29,6 +29,7 @@ mod process;
 pub mod session_boot;
 mod spawner;
 mod tmux;
+mod topology;
 
 pub use node_config::write_node_agent_config;
 pub use runtime::Runtime;

--- a/rust/exo-runtime/src/topology.rs
+++ b/rust/exo-runtime/src/topology.rs
@@ -1,0 +1,208 @@
+//! `impl Topology for Runtime` — fold this node's place in the swarm tree from the on-disk
+//! ledgers + a tmux pane-liveness probe.
+//!
+//! The runtime owns identity (`node_path`, `working_dir`, `own_pane`), so it does the walk; the
+//! policy `tree` tool is a thin shim. The recursive ledger read is sync fs work, run inside
+//! `spawn_blocking` so it never blocks the tokio executor (the crate's HARD RULE); the one tmux
+//! probe is async and best-effort.
+
+use crate::runtime::Runtime;
+use async_trait::async_trait;
+use exo_caps::{
+    fold_children, ChildKind, ChildRecord, Topology, TopologyError, TopologyView, TreeNode,
+};
+use std::collections::HashSet;
+use std::path::Path;
+
+/// Defensive bound on recursion depth. The worktree tree is physically acyclic (a child's
+/// worktree nests under its parent's `.exo/worktrees`), so this is pure insurance.
+const MAX_DEPTH: usize = 32;
+
+#[async_trait]
+impl Topology for Runtime {
+    async fn topology(&self) -> Result<TopologyView, TopologyError> {
+        let alive = live_panes().await;
+        let wd = self.working_dir().to_path_buf();
+        let children = tokio::task::spawn_blocking(move || subtree(&wd, &alive, MAX_DEPTH))
+            .await
+            .map_err(|e| TopologyError::Failed {
+                op: "subtree",
+                detail: e.to_string(),
+            })?;
+
+        let node = TreeNode {
+            name: self.name().as_str().to_string(),
+            kind: None,
+            pane: self.own_pane().as_str().to_string(),
+            // Self is, definitionally, alive — it's the node answering the call.
+            pane_alive: true,
+            children,
+        };
+
+        let parent = self
+            .node_path()
+            .parent()
+            .map(|p| p.name().as_str().to_string());
+        let path = self
+            .node_path()
+            .segments()
+            .iter()
+            .map(|s| s.as_str().to_string())
+            .collect();
+
+        Ok(TopologyView { node, parent, path })
+    }
+}
+
+/// Fold `{working_dir}/.exo/children.jsonl` into [`TreeNode`]s, recursing into each **Worktree**
+/// child's own ledger at `{working_dir}/.exo/worktrees/{name}/.exo/children.jsonl`. Inline
+/// children share the parent worktree and spawn nothing, so they're leaves.
+fn subtree(working_dir: &Path, alive: &HashSet<String>, depth: usize) -> Vec<TreeNode> {
+    if depth == 0 {
+        return Vec::new();
+    }
+    let records = read_records(&working_dir.join(".exo/children.jsonl"));
+    fold_children(&records)
+        .into_values()
+        .map(|c| {
+            let pane = c.pane.as_str().to_string();
+            let children = match c.kind {
+                ChildKind::Worktree => {
+                    let child_wd = working_dir.join(".exo/worktrees").join(c.name.as_str());
+                    subtree(&child_wd, alive, depth - 1)
+                }
+                ChildKind::Inline => Vec::new(),
+            };
+            TreeNode {
+                name: c.name.as_str().to_string(),
+                kind: Some(c.kind),
+                pane_alive: alive.contains(&pane),
+                pane,
+                children,
+            }
+        })
+        .collect()
+}
+
+/// Read + tolerantly parse a `children.jsonl` (missing file → empty; a malformed line is skipped,
+/// mirroring the bus/inbound tolerant parse).
+fn read_records(path: &Path) -> Vec<ChildRecord> {
+    let content = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(_) => return Vec::new(),
+    };
+    content
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .filter_map(|l| serde_json::from_str::<ChildRecord>(l).ok())
+        .collect()
+}
+
+/// The set of currently-existing tmux pane ids. **Best-effort**: a tmux failure yields an empty
+/// set (every node then reads as not-alive) plus a warning — liveness is a proxy, never fatal.
+async fn live_panes() -> HashSet<String> {
+    match tokio::process::Command::new("tmux")
+        .args(["list-panes", "-a", "-F", "#{pane_id}"])
+        .output()
+        .await
+    {
+        Ok(out) if out.status.success() => String::from_utf8_lossy(&out.stdout)
+            .lines()
+            .map(|l| l.trim().to_string())
+            .filter(|l| !l.is_empty())
+            .collect(),
+        _ => {
+            tracing::warn!("topology: `tmux list-panes` failed; reporting all nodes as not-alive");
+            HashSet::new()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use exo_caps::{AgentName, Branch, InboxPath, NodePath, PaneId};
+
+    fn write_ledger(dir: &Path, records: &[ChildRecord]) {
+        std::fs::create_dir_all(dir.join(".exo")).unwrap();
+        let body: String = records
+            .iter()
+            .map(|r| format!("{}\n", serde_json::to_string(r).unwrap()))
+            .collect();
+        std::fs::write(dir.join(".exo/children.jsonl"), body).unwrap();
+    }
+
+    fn spawned(name: &str, kind: ChildKind, pane: &str) -> ChildRecord {
+        ChildRecord::Spawned {
+            child: AgentName::new(name.into()).unwrap(),
+            kind,
+            pane: PaneId::new(pane.into()).unwrap(),
+            inbox: InboxPath::new(format!("/tmp/{name}.jsonl").into()),
+        }
+    }
+
+    #[test]
+    fn subtree_folds_recursively_into_worktree_children() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        // root's direct children: worktree "a", inline "b"
+        write_ledger(
+            root,
+            &[
+                spawned("a", ChildKind::Worktree, "%1"),
+                spawned("b", ChildKind::Inline, "%2"),
+            ],
+        );
+        // a's nested ledger: worktree grandchild "c"
+        let a_wd = root.join(".exo/worktrees/a");
+        write_ledger(&a_wd, &[spawned("c", ChildKind::Worktree, "%3")]);
+
+        let alive: HashSet<String> = ["%1".to_string()].into_iter().collect();
+        let tree = subtree(root, &alive, MAX_DEPTH);
+
+        assert_eq!(tree.len(), 2);
+        let a = tree.iter().find(|n| n.name == "a").unwrap();
+        let b = tree.iter().find(|n| n.name == "b").unwrap();
+        assert!(a.pane_alive, "a's pane %1 is in the alive set");
+        assert!(!b.pane_alive, "b's pane %2 is not in the alive set");
+        // recursion: a (worktree) descends into "c"; b (inline) is a leaf
+        assert_eq!(a.children.len(), 1);
+        assert_eq!(a.children[0].name, "c");
+        assert!(b.children.is_empty());
+    }
+
+    #[test]
+    fn missing_ledger_is_empty_not_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(subtree(dir.path(), &HashSet::new(), MAX_DEPTH).is_empty());
+    }
+
+    #[tokio::test]
+    async fn topology_reports_self_parent_and_path() {
+        let dir = tempfile::tempdir().unwrap();
+        write_ledger(dir.path(), &[spawned("a", ChildKind::Worktree, "%1")]);
+
+        let node_path = NodePath::new(vec![
+            AgentName::new("root".into()).unwrap(),
+            AgentName::new("me".into()).unwrap(),
+        ])
+        .unwrap();
+        let rt = Runtime::new(
+            node_path,
+            Branch::new("root.me".into()).unwrap(),
+            dir.path().to_path_buf(),
+            None,
+            "run".into(),
+            "session".into(),
+            PaneId::new("%9".into()).unwrap(),
+        );
+
+        let view = rt.topology().await.unwrap();
+        assert_eq!(view.node.name, "me");
+        assert!(view.node.pane_alive); // self
+        assert_eq!(view.parent.as_deref(), Some("root"));
+        assert_eq!(view.path, vec!["root".to_string(), "me".to_string()]);
+        assert_eq!(view.node.children.len(), 1);
+        assert_eq!(view.node.children[0].name, "a");
+    }
+}

--- a/rust/exo-runtime/src/topology.rs
+++ b/rust/exo-runtime/src/topology.rs
@@ -34,7 +34,9 @@ impl Topology for Runtime {
             name: self.name().as_str().to_string(),
             kind: None,
             pane: self.own_pane().as_str().to_string(),
-            // Self is, definitionally, alive — it's the node answering the call.
+            // Self is, definitionally, alive — it's the node answering the call. Deliberately NOT
+            // derived from the `alive` probe set: a best-effort `tmux list-panes` failure would
+            // then mis-report this node as dead, which is strictly wrong (it's clearly running).
             pane_alive: true,
             children,
         };
@@ -84,17 +86,32 @@ fn subtree(working_dir: &Path, alive: &HashSet<String>, depth: usize) -> Vec<Tre
         .collect()
 }
 
-/// Read + tolerantly parse a `children.jsonl` (missing file → empty; a malformed line is skipped,
-/// mirroring the bus/inbound tolerant parse).
+/// Read + tolerantly parse a `children.jsonl`. A **missing** file is expected (a node with no
+/// children) → empty, silently. A real IO error (permissions, etc.) and a malformed line are
+/// each `warn!`-ed and skipped — best-effort like the bus/inbound parse, but never silent about
+/// a genuine problem (which would otherwise make the topology view quietly wrong).
 fn read_records(path: &Path) -> Vec<ChildRecord> {
     let content = match std::fs::read_to_string(path) {
         Ok(c) => c,
-        Err(_) => return Vec::new(),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Vec::new(),
+        Err(e) => {
+            tracing::warn!("topology: could not read {}: {e}", path.display());
+            return Vec::new();
+        }
     };
     content
         .lines()
         .filter(|l| !l.trim().is_empty())
-        .filter_map(|l| serde_json::from_str::<ChildRecord>(l).ok())
+        .filter_map(|l| match serde_json::from_str::<ChildRecord>(l) {
+            Ok(r) => Some(r),
+            Err(e) => {
+                tracing::warn!(
+                    "topology: skipping malformed children.jsonl line in {}: {e}",
+                    path.display()
+                );
+                None
+            }
+        })
         .collect()
 }
 
@@ -199,7 +216,8 @@ mod tests {
 
         let view = rt.topology().await.unwrap();
         assert_eq!(view.node.name, "me");
-        assert!(view.node.pane_alive); // self
+        assert_eq!(view.node.pane, "%9"); // self's pane id (deterministic; no tmux dependency)
+        assert!(view.node.pane_alive); // self is always alive (hardcoded, not probe-derived)
         assert_eq!(view.parent.as_deref(), Some("root"));
         assert_eq!(view.path, vec!["root".to_string(), "me".to_string()]);
         assert_eq!(view.node.children.len(), 1);


### PR DESCRIPTION
## What

A node-mode MCP tool, `tree`, that answers "where am I in the swarm?" — the caller's subtree + its parent + a per-node liveness flag. Served by **Root + Tl** (the roles that have children).

## How

- **`Topology` capability** (`exo-caps/src/topology.rs`) — `topology()` returns `TopologyView { node (self + recursive subtree), parent, path }`; `TreeNode` carries `name / kind / pane / pane_alive / children`. `TopologyError` composes into `CapError` via `#[from]`.
- **Runtime impl** (`exo-runtime/src/topology.rs`) — folds the caller's `.exo/children.jsonl`, recurses into each **worktree** child's nested ledger (inline children are leaves), computes parent/path from the `NodePath`, and marks `pane_alive` from **one** best-effort `tmux list-panes -a` (a tmux failure → all not-alive + a `warn!`, never fails the call). The sync ledger walk runs in `spawn_blocking` so it never blocks the executor; the ledger parse is tolerant (missing file → empty, bad line skipped); depth-capped.
- **`tree` tool** (`exo-policy/src/tools/tree.rs`) — a thin shim over `Topology` (mirrors `merge.rs`). Added to Root + Tl in `roles.rs`; `Topology` added to the `PolicyCaps` union and the `MockRuntime`. `exo-node`'s `tools/list` already emits `description()`.

## Liveness note

A true "is the sidecar MCP responsive" round-trip isn't available — each sidecar is stdio-bound to its agent, not socket-pingable. `pane_alive` (the tmux pane still exists) is the agreed proxy.

## Tests / checks

`cargo build` + `clippy --all-targets` clean across exo-caps/runtime/policy; full workspace builds. New tests: recursive ledger fold + parent/path/self (runtime), and `Tree::run` vs the mock view (policy). Scope-respected: did not touch `merge.rs` / `submit.rs` / `spawner.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)