### PR TITLE
feat(swarm): v2 review/build gate — pre-merge checks + spawned reviewer + System messages

### DIFF
--- a/rust/exo-caps/CLAUDE.md
+++ b/rust/exo-caps/CLAUDE.md
@@ -40,7 +40,7 @@ Eight caps, each one trait per file. `exo-runtime::Runtime` implements all of th
 - **`NodePath`** — tree address as a `Vec<AgentName>`, **not** a dot-string (branch segments may contain `.`, so a joined form can't round-trip). `name()` = last segment, `parent()` = prefix, `child()` extends. `Branch::from_path` generates a *safe* branch (sanitize segments to `[A-Za-z0-9_-]`, join `.`) decoupled from the path.
 - **`NodeKind`** (`Root`/`Tl`/`Dev`/`Worker`) — the one stored archetype. `agent_type()` **derives** (`Root`/`Tl`→Claude, `Dev`/`Worker`→Gemini) — never stored separately, so `(Root, Gemini)` is unnameable.
 - **`Message`** = `{text, summary, kind}` — what *policy* builds. It carries **no `from`/`ts`/`id`**: the runtime stamps the `IngestionEntry` envelope at append, so **a tool cannot spoof its sender** (anti-spoof is structural, not convention). `Persona` = `Agent(AgentName) | Synthetic(SyntheticName)`.
-- **`MessageKind`** = `Chat | Event | Control(Shutdown{grace_ms})`. `Event` is delivered like `Chat` (tagged `kind: event` in the last-hop header) — there is no world-event handler in v2.
+- **`MessageKind`** = `Chat | Event | Control(Shutdown{grace_ms}) | System(SystemMessage)`. `Event` is delivered like `Chat`. **`System`** is the sidecar-vs-LLM routing bit: a `System` message is consumed by the recipient's *sidecar* (inbound loop), never rendered to its LLM unless the handler decides it must act. The granular, serde-tagged, extensible **`SystemMessage`** variants (`review_approved` / `review_denied` / `review_changes`, …) are the real identifiers — new node-to-node control signals are new variants there, not a churn of the envelope.
 
 ## Load-bearing principles (encoded in the types)
 

--- a/rust/exo-caps/src/git.rs
+++ b/rust/exo-caps/src/git.rs
@@ -18,6 +18,9 @@ pub enum GitError {
 #[async_trait]
 pub trait Git {
     async fn current_branch(&self) -> Result<Branch, GitError>;
+    /// The current `HEAD` commit sha (full 40-char). Used to sha-tag review verdicts so the
+    /// sidecar only escalates an approval that still matches the committed state.
+    async fn head_sha(&self) -> Result<String, GitError>;
     async fn is_clean(&self) -> Result<bool, GitError>;
     async fn fetch(&self) -> Result<(), GitError>;
     /// Merge `branch` into the current branch (the local fold; no remote). Non-interactive.

--- a/rust/exo-caps/src/lib.rs
+++ b/rust/exo-caps/src/lib.rs
@@ -42,4 +42,5 @@ pub use topology::{Topology, TopologyError, TopologyView, TreeNode};
 pub use types::{
     AgentName, AgentType, Branch, ChildKind, ControlKind, InboxPath, IngestionEntry, Message,
     MessageBody, MessageKind, NodeKind, NodePath, PaneId, Persona, Summary, SyntheticName,
+    SystemMessage,
 };

--- a/rust/exo-caps/src/spawner.rs
+++ b/rust/exo-caps/src/spawner.rs
@@ -72,6 +72,10 @@ pub struct ForkSpec {
 pub trait Spawner {
     async fn spawn_worker(&self, spec: WorkerSpec) -> Result<AgentName, SpawnError>;
     async fn spawn_gemini(&self, spec: GeminiSpec) -> Result<AgentName, SpawnError>;
+    /// Spawn a short-lived **reviewer** of the caller's branch: a Gemini in its OWN worktree
+    /// branched off the *current* branch (the under-review code), `role = Reviewer`. Mirrors
+    /// `spawn_gemini` but fixes the role — the reviewer reads the diff, emits a `verdict`, exits.
+    async fn spawn_reviewer(&self, spec: GeminiSpec) -> Result<AgentName, SpawnError>;
     /// Fork a wave — **per-spec results**, so one bad fork doesn't discard the children
     /// that did spawn (the TL converges on what succeeded, re-decomposes the failures).
     async fn fork_wave(&self, specs: Vec<ForkSpec>) -> Vec<Result<AgentName, SpawnError>>;

--- a/rust/exo-caps/src/types.rs
+++ b/rust/exo-caps/src/types.rs
@@ -306,6 +306,10 @@ pub enum NodeKind {
     Tl,
     Dev,
     Worker,
+    /// A short-lived Gemini spawned by a submitting node to review its branch. Works in its own
+    /// worktree off the under-review code (full YOLO; its blast radius is its own branch) and
+    /// emits a `verdict`. Not a tree-building archetype — it reviews, then exits.
+    Reviewer,
 }
 
 impl NodeKind {
@@ -313,7 +317,7 @@ impl NodeKind {
     pub fn agent_type(self) -> AgentType {
         match self {
             NodeKind::Root | NodeKind::Tl => AgentType::Claude,
-            NodeKind::Dev | NodeKind::Worker => AgentType::Gemini,
+            NodeKind::Dev | NodeKind::Worker | NodeKind::Reviewer => AgentType::Gemini,
         }
     }
     /// The `role_def` key / wire string.
@@ -323,6 +327,7 @@ impl NodeKind {
             NodeKind::Tl => "tl",
             NodeKind::Dev => "dev",
             NodeKind::Worker => "worker",
+            NodeKind::Reviewer => "reviewer",
         }
     }
 }
@@ -398,6 +403,11 @@ pub enum MessageKind {
     Event,
     /// lifecycle (exomonad-internal) — see `ControlKind`.
     Control(ControlKind),
+    /// a node-to-node **system signal** — consumed by the recipient's *sidecar*, NOT rendered
+    /// into its LLM conversation unless the handler decides the agent must act. This one
+    /// envelope variant is just the sidecar-vs-LLM routing bit; the real, granular identifiers
+    /// are the [`SystemMessage`] variant tags (so `MessageKind` doesn't bloat per signal).
+    System(SystemMessage),
 }
 
 /// A directed control **message**. Lifecycle **records** (`AgentSpawned`/`AgentStarted`)
@@ -406,6 +416,33 @@ pub enum MessageKind {
 #[serde(rename_all = "snake_case")]
 pub enum ControlKind {
     Shutdown { grace_ms: u32 },
+}
+
+/// System signals carried over the bus and handled by the recipient's sidecar (see
+/// [`MessageKind::System`]). Serde-tagged on `type` (`review_approved` / `review_denied` /
+/// `review_changes`) — **granular, flat, extensible**: new node-to-node control signals are new
+/// variants here, never a churn of the core envelope. Tolerantly parsed (an unknown variant is
+/// logged + skipped), so a mixed-version swarm won't crash.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum SystemMessage {
+    /// The reviewer approved `branch@sha`. The submitter's sidecar auto-escalates `[READY]`
+    /// upward (no LLM turn) iff `sha` still matches the submitter's HEAD.
+    ReviewApproved { branch: Branch, sha: String },
+    /// The reviewer rejected with feedback. Rendered + delivered to the submitter's LLM to address.
+    ReviewDenied {
+        branch: Branch,
+        sha: String,
+        message: String,
+    },
+    /// The reviewer committed a counter-proposal to `changes_branch`. Rendered + delivered to the
+    /// submitter's LLM to `merge` + re-submit.
+    ReviewChanges {
+        branch: Branch,
+        sha: String,
+        changes_branch: Branch,
+        message: String,
+    },
 }
 
 #[cfg(test)]

--- a/rust/exo-caps/src/types.rs
+++ b/rust/exo-caps/src/types.rs
@@ -421,8 +421,11 @@ pub enum ControlKind {
 /// System signals carried over the bus and handled by the recipient's sidecar (see
 /// [`MessageKind::System`]). Serde-tagged on `type` (`review_approved` / `review_denied` /
 /// `review_changes`) — **granular, flat, extensible**: new node-to-node control signals are new
-/// variants here, never a churn of the core envelope. Tolerantly parsed (an unknown variant is
-/// logged + skipped), so a mixed-version swarm won't crash.
+/// variants here, never a churn of the core envelope. There is no catch-all variant: an unknown
+/// `type` fails to deserialize the whole bus line, which the inbound loop's tolerant parser then
+/// skips + logs — the swarm won't crash, but that one message is dropped. (Add a
+/// `#[serde(other)]` catch-all here if graceful per-variant forward-compat is ever needed for a
+/// mixed-version swarm.)
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum SystemMessage {

--- a/rust/exo-node/src/dispatch.rs
+++ b/rust/exo-node/src/dispatch.rs
@@ -103,6 +103,7 @@ fn render_entry(entry: &IngestionEntry) -> String {
         MessageKind::Chat => "chat",
         MessageKind::Event => "event",
         MessageKind::Control(_) => "control",
+        MessageKind::System(_) => "system",
     };
 
     format!(

--- a/rust/exo-node/src/inbound.rs
+++ b/rust/exo-node/src/inbound.rs
@@ -27,7 +27,11 @@ use notify::{Config, Event, RecommendedWatcher, RecursiveMode, Watcher};
 use tokio::sync::mpsc;
 use tracing::{error, info, warn};
 
-use exo_caps::{ControlKind, IngestionEntry, MessageKind};
+use chrono::Utc;
+use exo_caps::{
+    Addressee, ControlKind, IngestionEntry, Message, MessageBody, MessageKind, Persona, Summary,
+    SyntheticName,
+};
 
 use crate::bootstrap::NodeContext;
 use crate::error::NodeResult;
@@ -165,18 +169,81 @@ impl InboundHandler for RealHandler {
 
 impl RealHandler {
     /// Route a [`SystemMessage`] (sidecar-side; never injected into the LLM directly).
-    ///
-    /// **Scaffold stub — leaf (c) implements the real routing:**
-    /// - `ReviewApproved { branch, sha }` & `sha == my HEAD` → deliver `[READY]` to my parent
-    ///   inbox (no LLM turn). Stale sha → ignore.
-    /// - `ReviewDenied` / `ReviewChanges` → render + deliver to the LLM (existing dispatch path),
-    ///   so the submitter wakes to fix / merge + re-submit.
     async fn handle_system(&self, system: &exo_caps::SystemMessage) -> NodeResult<()> {
-        warn!(
-            "system-message review handler not yet implemented: {:?}",
-            system
-        );
-        Ok(())
+        use exo_caps::SystemMessage;
+        match system {
+            SystemMessage::ReviewApproved { branch, sha } => {
+                let head = exo_caps::Git::head_sha(&*self.ctx.runtime)
+                    .await
+                    .map_err(|e| std::io::Error::other(e.to_string()))?;
+                if &head != sha {
+                    warn!(
+                        "stale approval for {} @ {} (HEAD is {}) — ignoring",
+                        branch.as_str(),
+                        sha,
+                        head
+                    );
+                    return Ok(());
+                }
+                // Escalate [READY] to the parent — sidecar-side, no LLM turn.
+                let my_branch = self.ctx.runtime.branch().clone();
+                let text = format!(
+                    "[READY] branch `{}` was approved by review and is ready for merge.",
+                    my_branch.as_str()
+                );
+                let summary = format!("[READY] {}", my_branch.as_str());
+                let msg = Message {
+                    text: MessageBody::new(text).map_err(|e| std::io::Error::other(e.to_string()))?,
+                    summary: Summary::new(summary)
+                        .map_err(|e| std::io::Error::other(e.to_string()))?,
+                    kind: MessageKind::Chat,
+                };
+                exo_caps::Bus::deliver(&*self.ctx.runtime, Addressee::Parent, msg)
+                    .await
+                    .map_err(|e| std::io::Error::other(e.to_string()))?;
+                info!(
+                    "review approved for {} — escalated [READY] to parent",
+                    my_branch.as_str()
+                );
+                Ok(())
+            }
+            SystemMessage::ReviewDenied { message, .. } => {
+                self.deliver_to_llm(&format!(
+                    "[REVIEW: changes requested] Your branch was not approved. Address this feedback, commit, then call submit_branch again:\n{}",
+                    message
+                )).await
+            }
+            SystemMessage::ReviewChanges {
+                changes_branch,
+                message,
+                ..
+            } => {
+                self.deliver_to_llm(&format!(
+                    "[REVIEW: proposed changes] The reviewer committed improvements on branch `{}`. Merge it with the `merge` tool to incorporate, then call submit_branch again:\n{}",
+                    changes_branch.as_str(), message
+                )).await
+            }
+        }
+    }
+
+    /// Inject a message into THIS node's own LLM conversation via the last-hop dispatch.
+    async fn deliver_to_llm(&self, text: &str) -> NodeResult<()> {
+        let entry = IngestionEntry {
+            v: 1,
+            ts: Utc::now(),
+            from: Persona::Synthetic(
+                SyntheticName::new("reviewer".into())
+                    .map_err(|e| std::io::Error::other(e.to_string()))?,
+            ),
+            msg: Message {
+                text: MessageBody::new(text.to_string())
+                    .map_err(|e| std::io::Error::other(e.to_string()))?,
+                summary: Summary::new("[REVIEW]".into())
+                    .map_err(|e| std::io::Error::other(e.to_string()))?,
+                kind: MessageKind::Chat,
+            },
+        };
+        crate::dispatch::dispatch(&self.ctx, &entry).await
     }
 }
 

--- a/rust/exo-node/src/inbound.rs
+++ b/rust/exo-node/src/inbound.rs
@@ -173,6 +173,18 @@ impl RealHandler {
         use exo_caps::SystemMessage;
         match system {
             SystemMessage::ReviewApproved { branch, sha } => {
+                // The approval must be for THIS node's branch at its CURRENT commit. A mismatched
+                // branch (with the right sha) must not escalate [READY] for my branch, and a stale
+                // sha (work committed after the review) needs a fresh review.
+                let my_branch = self.ctx.runtime.branch().clone();
+                if branch.as_str() != my_branch.as_str() {
+                    warn!(
+                        "approval names branch {} but my branch is {} — ignoring",
+                        branch.as_str(),
+                        my_branch.as_str()
+                    );
+                    return Ok(());
+                }
                 let head = exo_caps::Git::head_sha(&*self.ctx.runtime)
                     .await
                     .map_err(|e| std::io::Error::other(e.to_string()))?;
@@ -186,7 +198,6 @@ impl RealHandler {
                     return Ok(());
                 }
                 // Escalate [READY] to the parent — sidecar-side, no LLM turn.
-                let my_branch = self.ctx.runtime.branch().clone();
                 let text = format!(
                     "[READY] branch `{}` was approved by review and is ready for merge.",
                     my_branch.as_str()

--- a/rust/exo-node/src/inbound.rs
+++ b/rust/exo-node/src/inbound.rs
@@ -154,7 +154,29 @@ impl InboundHandler for RealHandler {
                     .map_err(|e| std::io::Error::other(e.to_string()))?;
                 Ok(Some(true))
             }
+            // System signals are consumed by the sidecar, never delivered to the LLM directly.
+            MessageKind::System(system) => {
+                self.handle_system(system).await?;
+                Ok(Some(false))
+            }
         }
+    }
+}
+
+impl RealHandler {
+    /// Route a [`SystemMessage`] (sidecar-side; never injected into the LLM directly).
+    ///
+    /// **Scaffold stub — leaf (c) implements the real routing:**
+    /// - `ReviewApproved { branch, sha }` & `sha == my HEAD` → deliver `[READY]` to my parent
+    ///   inbox (no LLM turn). Stale sha → ignore.
+    /// - `ReviewDenied` / `ReviewChanges` → render + deliver to the LLM (existing dispatch path),
+    ///   so the submitter wakes to fix / merge + re-submit.
+    async fn handle_system(&self, system: &exo_caps::SystemMessage) -> NodeResult<()> {
+        warn!(
+            "system-message review handler not yet implemented: {:?}",
+            system
+        );
+        Ok(())
     }
 }
 

--- a/rust/exo-policy/CLAUDE.md
+++ b/rust/exo-policy/CLAUDE.md
@@ -25,8 +25,9 @@ The Bucket-C logic that genuinely ports from the old Haskell DSL: MCP tool defin
 | `spawn_gemini` | `Spawner` | root, tl | Spawn a Gemini dev in its own worktree. |
 | `spawn_worker` | `Spawner` | root, tl | Spawn an ephemeral Gemini worker (inline pane). |
 | `merge` | `Git` | root, tl | **The local fold:** `git merge <child-branch>`. No PR, no remote, no GitHub. |
-| `submit_branch` | `Git`+`Bus` | tl, dev | **The done-signal** (local analogue of file_pr): runs preconditions (v1: committed), then delivers `[READY] branch X` to the parent for it to `merge`. |
-| `notify_parent` | `Bus` | tl, dev, worker | Status/failure update to `Addressee::Parent` (NOT the done-signal). |
+| `submit_branch` | `Git`+`Process`+`Spawner`+`Fs` | tl, dev | **Request review.** Runs the precondition checks (committed + `.exo/checks/pre-merge/*` scripts), then spawns a **reviewer** off this branch and returns "stop & wait". It does NOT deliver `[READY]` — only the sidecar does, on an approve-verdict (the structural gate). |
+| `verdict` | `Bus` | reviewer | A reviewer's one output → a `System(SystemMessage)` to its parent: `approve` / `deny`+msg / `changes`+branch. |
+| `notify_parent` | `Bus` | tl, dev, worker, reviewer | Status/failure update to `Addressee::Parent` (NOT the done-signal). |
 | `send_message` | `Bus` | root, tl | Deliver to a child (`Inline`/`Worktree`) — **tree-edges only**. |
 | `tree` | `Topology` | root, tl | Read-only: the caller's subtree (recursive ledger fold) + parent + per-node `pane_alive` liveness. |
 
@@ -47,6 +48,21 @@ one entry.
 | **Tl** | Claude | spawns, merge, notify_parent, send_message, submit_branch | `stop` (clean-gate) |
 | **Dev** | Gemini | notify_parent, submit_branch | `stop` (clean-gate) |
 | **Worker** | Gemini | notify_parent | `stop_allow` (inline child, no own branch to submit) |
+| **Reviewer** | Gemini | verdict, notify_parent | `stop_allow` (ephemeral; reviews a branch off its own worktree, then exits) |
+
+## The review gate (how `submit_branch` → `merge` is gated)
+
+A node commits, then calls `submit_branch`. It runs the checks, then spawns a **reviewer** (a full
+Gemini in its own worktree branched off the under-review code — it can build/test freely, blast
+radius is its own branch) handed the diff + `.exo/acceptance.md` (the node's spawn prompt +
+`done_criteria`, persisted at birth). The reviewer calls `verdict`, which rides the bus as a
+`System` message to the submitter's **sidecar**:
+- **approve** & sha==HEAD → the sidecar escalates `[READY]` to the parent — *no LLM turn*.
+- **deny** / **changes** → delivered into the submitter's LLM to fix / `merge` the reviewer's
+  branch, then re-submit (new sha → fresh reviewer).
+
+`submit_branch` never delivers `[READY]` itself, so the gate is **structural** — the LLM has no
+tool that skips review. (System messages are a general sidecar-consumed primitive; see exo-caps.)
 
 ## The hooks
 
@@ -57,6 +73,6 @@ one entry.
 ## Gaps / not-yet
 
 - **No convergence teardown.** `merge` folds the branch but nothing reclaims the child's worktree or kills its pane afterward (`Spawner::reclaim_worktree`/`kill_pane` exist but no tool calls them). After a fold the child pane + worktree linger. This is the main open lifecycle gap.
-- **No reviewers.** The planned short-lived adversarial Gemini reviewer loop is not built — `merge` is an unguarded fold. The natural seam is `submit_branch`'s ordered check list (a reviewer-verdict gate) and/or a gate in `merge`.
+- **Reviewers: built** (see "The review gate" above) — `submit_branch` spawns a reviewer and only the sidecar escalates `[READY]` on approval. Follow-ups: a two-way colleague back-channel (submitter→reviewer reply needs `send_message` on dev), and review is currently always-on (no config to disable).
 - `pre_tool_use` is intentionally minimal (one nudge); classic exomonad's richer antipattern set + PII rewrite are not ported.
 - `stop`'s dirty-gate can wedge an agent that holds untracked artifacts it won't commit (mitigated only by the agent being told to commit) — watch for this in smokes.

--- a/rust/exo-policy/src/roles.rs
+++ b/rust/exo-policy/src/roles.rs
@@ -20,6 +20,7 @@ use crate::tools::messaging::{NotifyParent, SendMessage};
 use crate::tools::spawn::{ForkWave, SpawnGemini, SpawnWorker};
 use crate::tools::submit::SubmitBranch;
 use crate::tools::tree::Tree;
+use crate::tools::verdict::Verdict;
 use exo_caps::NodeKind;
 
 /// A hook is an async fn over the concrete runtime `R`. Stored as a plain fn-pointer so the
@@ -94,6 +95,16 @@ pub fn role_def<R: PolicyCaps>(kind: NodeKind) -> RoleDef<R> {
             stop: stop_allow,
             session_start,
         },
+        // A reviewer reads the under-review branch and emits a `verdict`, then exits. It does not
+        // submit or merge; `notify_parent` is its colleague back-channel ("why'd you do this?").
+        NodeKind::Reviewer => RoleDef {
+            tools: vec![Box::new(Verdict), Box::new(NotifyParent)],
+            pre_tool_use,
+            // Ephemeral; it exits after the verdict — nothing to fold, so don't gate (would only
+            // risk wedging on stray review artifacts).
+            stop: stop_allow,
+            session_start,
+        },
     }
 }
 
@@ -120,7 +131,7 @@ mod tests {
             );
             // Root/Worker never file a PR → no gate (stop_allow); Tl/Dev gate via `stop`.
             let expected_stop = match kind {
-                NodeKind::Root | NodeKind::Worker => {
+                NodeKind::Root | NodeKind::Worker | NodeKind::Reviewer => {
                     stop_allow::<MockRuntime> as *const () as usize
                 }
                 NodeKind::Tl | NodeKind::Dev => stop::<MockRuntime> as *const () as usize,

--- a/rust/exo-policy/src/testing.rs
+++ b/rust/exo-policy/src/testing.rs
@@ -40,6 +40,10 @@ pub enum Call {
         spec_task: String,
         step_count: usize,
     },
+    SpawnReviewer {
+        spec_task: String,
+        step_count: usize,
+    },
     ForkWave {
         n: usize,
     },
@@ -80,6 +84,7 @@ pub struct MockRuntime {
 
     // canned git state (the stop-gate clean check + merge tests read these)
     pub current_branch: Branch,
+    pub head_sha: String,
     pub is_clean: bool,
     /// If set, the named cap method returns its `*Error` instead of the happy path. Keyed by
     /// a short op label (e.g. "merge") so a test can exercise error branches.
@@ -93,6 +98,7 @@ impl Default for MockRuntime {
             kv: Mutex::new(HashMap::new()),
             files: Mutex::new(HashMap::new()),
             current_branch: Branch::new("dev.policy-claude".into()).unwrap(),
+            head_sha: "0000000000000000000000000000000000000000".into(),
             is_clean: true,
             fail: Mutex::new(None),
         }
@@ -136,6 +142,9 @@ impl Bus for MockRuntime {
 impl Git for MockRuntime {
     async fn current_branch(&self) -> Result<Branch, GitError> {
         Ok(self.current_branch.clone())
+    }
+    async fn head_sha(&self) -> Result<String, GitError> {
+        Ok(self.head_sha.clone())
     }
     async fn is_clean(&self) -> Result<bool, GitError> {
         Ok(self.is_clean)
@@ -189,6 +198,22 @@ impl Spawner for MockRuntime {
         Ok(spec
             .name
             .unwrap_or_else(|| AgentName::new("gemini-mock".into()).unwrap()))
+    }
+    async fn spawn_reviewer(&self, spec: GeminiSpec) -> Result<AgentName, SpawnError> {
+        if self.should_fail("spawn_reviewer") {
+            return Err(SpawnError::Failed {
+                op: "spawn_reviewer",
+                child: None,
+                detail: "mock forced failure".into(),
+            });
+        }
+        self.record(Call::SpawnReviewer {
+            spec_task: spec.task.clone(),
+            step_count: spec.steps.len(),
+        });
+        Ok(spec
+            .name
+            .unwrap_or_else(|| AgentName::new("reviewer-mock".into()).unwrap()))
     }
     async fn fork_wave(&self, specs: Vec<ForkSpec>) -> Vec<Result<AgentName, SpawnError>> {
         self.record(Call::ForkWave { n: specs.len() });

--- a/rust/exo-policy/src/tools/mod.rs
+++ b/rust/exo-policy/src/tools/mod.rs
@@ -5,11 +5,12 @@
 //!
 //! The tools, one file each: `messaging` (notify_parent / send_message), `spawn` (the three
 //! per-op spawn tools), `merge` (the local on-disk fold), `submit` (a leaf's done / ready-to-
-//! merge signal), `tree` (the caller's subtree + parent + liveness). They are wired into
-//! [`role_def`](crate::roles::role_def).
+//! merge signal), `tree` (the caller's subtree + parent + liveness), `verdict` (the reviewer's
+//! approve/deny/changes signal). They are wired into [`role_def`](crate::roles::role_def).
 
 pub mod merge;
 pub mod messaging;
 pub mod spawn;
 pub mod submit;
 pub mod tree;
+pub mod verdict;

--- a/rust/exo-policy/src/tools/submit.rs
+++ b/rust/exo-policy/src/tools/submit.rs
@@ -9,13 +9,20 @@
 //! merges the BRANCH off disk and uncommitted changes would be invisible to that merge.
 
 use exo_caps::{
-    Addressee, Bus, CapError, CapResult, Git, Message, MessageBody, MessageKind, Summary,
+    Addressee, Bus, CapError, CapResult, Git, Message, MessageBody, MessageKind, Process, Summary,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use crate::tool::{ok_json, parse, schema_json, BoxFuture, Tool, ToolOutput};
+
+#[derive(serde::Deserialize)]
+struct CheckResult {
+    pass: bool,
+    #[serde(default)]
+    detail: String,
+}
 
 /// Arguments for `submit_branch`.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -48,19 +55,71 @@ fn committed<C: Git + Sync>(ctx: &C) -> BoxFuture<'_, Result<(), String>> {
     })
 }
 
+/// Run every script in `.exo/checks/pre-merge/*` (relative to the node's worktree). Each must
+/// print a JSON line `{"pass": bool, "detail": "..."}`; any non-pass (or non-zero exit with no
+/// JSON) blocks the submit. Absent dir / no scripts = pass (no gate).
+fn pre_merge_checks<C: Process + Sync>(ctx: &C) -> BoxFuture<'_, Result<(), String>> {
+    Box::pin(async move {
+        let dir = std::path::Path::new(".exo/checks/pre-merge");
+        let mut scripts: Vec<std::path::PathBuf> = match std::fs::read_dir(dir) {
+            Ok(rd) => rd
+                .filter_map(|e| e.ok().map(|e| e.path()))
+                .filter(|p| p.is_file())
+                .collect(),
+            Err(_) => return Ok(()),
+        };
+        scripts.sort();
+        let mut failures = Vec::new();
+        for script in scripts {
+            let path = script.to_string_lossy().to_string();
+            let out = match ctx.run(&path, &[]).await {
+                Ok(o) => o,
+                Err(e) => {
+                    failures.push(format!("{path}: failed to run: {e}"));
+                    continue;
+                }
+            };
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            match serde_json::from_str::<CheckResult>(stdout.trim()) {
+                Ok(r) if r.pass => {}
+                Ok(r) => failures.push(format!("{path}: {}", r.detail)),
+                Err(_) => {
+                    if !out.status.success() {
+                        failures.push(format!("{path}: exited non-zero with no JSON output"));
+                    }
+                }
+            }
+        }
+        if failures.is_empty() {
+            Ok(())
+        } else {
+            Err(format!(
+                "pre-merge checks failed:\n- {}",
+                failures.join("\n- ")
+            ))
+        }
+    })
+}
+
 /// The ordered precondition list. Append here to add a gate.
-fn checks<C: Git + Sync>() -> Vec<Check<C>> {
-    vec![Check {
-        name: "committed",
-        run: committed::<C>,
-    }]
+fn checks<C: Git + Process + Sync>() -> Vec<Check<C>> {
+    vec![
+        Check {
+            name: "committed",
+            run: committed::<C>,
+        },
+        Check {
+            name: "pre_merge_checks",
+            run: pre_merge_checks::<C>,
+        },
+    ]
 }
 
 /// The `submit_branch` tool.
 pub struct SubmitBranch;
 
 impl SubmitBranch {
-    pub async fn run<C: Git + Bus + Sync>(
+    pub async fn run<C: Git + Bus + Process + Sync>(
         ctx: &C,
         args: SubmitBranchArgs,
     ) -> CapResult<ToolOutput> {
@@ -96,7 +155,7 @@ impl SubmitBranch {
 }
 
 #[async_trait::async_trait]
-impl<R: Git + Bus + Send + Sync> Tool<R> for SubmitBranch {
+impl<R: Git + Bus + Process + Send + Sync> Tool<R> for SubmitBranch {
     fn name(&self) -> &str {
         "submit_branch"
     }

--- a/rust/exo-policy/src/tools/submit.rs
+++ b/rust/exo-policy/src/tools/submit.rs
@@ -8,9 +8,7 @@
 //! rewrite. v1 has a single check: the worktree must be clean (work committed), because a parent
 //! merges the BRANCH off disk and uncommitted changes would be invisible to that merge.
 
-use exo_caps::{
-    Addressee, Bus, CapError, CapResult, Git, Message, MessageBody, MessageKind, Process, Summary,
-};
+use exo_caps::{CapError, CapResult, Fs, GeminiSpec, Git, Process, Spawner};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -119,7 +117,7 @@ fn checks<C: Git + Process + Sync>() -> Vec<Check<C>> {
 pub struct SubmitBranch;
 
 impl SubmitBranch {
-    pub async fn run<C: Git + Bus + Process + Sync>(
+    pub async fn run<C: Git + Process + Spawner + Fs + Sync>(
         ctx: &C,
         args: SubmitBranchArgs,
     ) -> CapResult<ToolOutput> {
@@ -135,35 +133,76 @@ impl SubmitBranch {
         }
 
         let branch = ctx.current_branch().await?;
-        let text = format!(
-            "[READY] branch `{}` is committed and ready for review / merge. {}",
-            branch.as_str(),
-            args.note
-        );
-        let msg = Message {
-            text: MessageBody::new(text)?,
-            summary: Summary::new(format!("[READY] {}", branch.as_str()))?,
-            kind: MessageKind::Chat,
+        let sha = ctx.head_sha().await?;
+        // The diff base is the parent branch (this branch minus its last dot-segment).
+        let base = branch
+            .as_str()
+            .rsplit_once('.')
+            .map(|(p, _)| p)
+            .unwrap_or("main")
+            .to_string();
+        // The reviewer's bar: this node's spawn prompt + acceptance criteria, persisted at birth.
+        let acceptance = match ctx.read(std::path::Path::new(".exo/acceptance.md")).await {
+            Ok(bytes) => String::from_utf8_lossy(&bytes).to_string(),
+            Err(_) => "(no acceptance criteria recorded for this branch)".to_string(),
         };
-        ctx.deliver(Addressee::Parent, msg).await?;
+
+        // Spawn a reviewer in its own worktree off this branch. We do NOT deliver `[READY]` here —
+        // the ONLY path that escalates is the sidecar reacting to an approve-verdict for this sha
+        // (see exo-node `handle_system`). That makes the gate structural: the LLM has no tool that
+        // can skip review.
+        let review_task = format!(
+            "You are a code reviewer. Review branch `{branch}` (commit {sha}). Run \
+             `git diff {base}...HEAD` to see exactly what changed; you may build / test / experiment \
+             freely in your own worktree (changes here never touch the reviewed code). Judge the \
+             work against the ACCEPTANCE CRITERIA below and the project's conventions, then call the \
+             `verdict` tool with branch=`{branch}`, sha=`{sha}`, and one of:\n\
+             - approve  (it meets the bar)\n\
+             - deny + message  (what must change)\n\
+             - changes + message + changes_branch=<your own branch>  (you committed a concrete fix \
+             to your own branch for the submitter to merge)\n\n\
+             Note from the submitter: {note}\n\n\
+             ACCEPTANCE CRITERIA\n{acceptance}",
+            branch = branch.as_str(),
+            note = args.note,
+        );
+        let spec = GeminiSpec {
+            name: None,
+            task: review_task,
+            steps: vec![],
+            verify: vec![],
+            done_criteria: vec![],
+            context: None,
+            boundary: vec![],
+            read_first: vec![],
+        };
+        let reviewer = ctx.spawn_reviewer(spec).await?;
 
         Ok(ToolOutput::with_data(
-            format!("submitted branch {} for review/merge", branch.as_str()),
-            json!({ "branch": branch.as_str() }),
+            format!(
+                "Review requested for branch {branch}: reviewer `{reviewer}` spawned. STOP now — do \
+                 nothing further and end your turn. You will be woken automatically: on approval \
+                 your `[READY]` is escalated to your parent with no action from you; on deny / \
+                 changes you'll receive the reviewer's feedback to address.",
+                branch = branch.as_str(),
+                reviewer = reviewer.as_str(),
+            ),
+            json!({ "branch": branch.as_str(), "sha": sha, "reviewer": reviewer.as_str() }),
         ))
     }
 }
 
 #[async_trait::async_trait]
-impl<R: Git + Bus + Process + Send + Sync> Tool<R> for SubmitBranch {
+impl<R: Git + Process + Spawner + Fs + Send + Sync> Tool<R> for SubmitBranch {
     fn name(&self) -> &str {
         "submit_branch"
     }
     fn description(&self) -> &str {
-        "Mark your branch DONE — committed and ready for review / merge. This is how you request \
-         your parent merge your work: the local-merge analogue of filing a PR (there is NO \
-         file_pr, no PR, no remote). Commit everything first — it refuses if your worktree has \
-         uncommitted changes. After calling it, end your turn; your parent reviews and merges."
+        "Request review of your branch. Commit everything first (it refuses on uncommitted changes \
+         or failing `.exo/checks/pre-merge` scripts), then it spawns a reviewer of your work and \
+         returns. Do NOT expect to merge yourself: on approval the sidecar escalates `[READY]` to \
+         your parent automatically; on deny / changes you'll be woken with feedback to address and \
+         re-submit. After calling it, STOP and end your turn."
     }
     fn schema(&self) -> serde_json::Value {
         schema_json(schemars::schema_for!(SubmitBranchArgs))
@@ -179,7 +218,7 @@ mod tests {
     use crate::testing::{Call, MockRuntime};
 
     #[tokio::test]
-    async fn submits_when_clean() {
+    async fn submits_spawns_reviewer_when_clean() {
         let mock = MockRuntime::default(); // is_clean = true, branch = dev.policy-claude
         let out = SubmitBranch::run(
             &mock,
@@ -192,12 +231,12 @@ mod tests {
 
         assert!(out.text.contains("dev.policy-claude"));
         let calls = mock.calls_made();
+        // It spawns a reviewer...
         assert!(calls
             .iter()
-            .any(|c| matches!(c, Call::BusDeliver { to, msg }
-            if *to == Addressee::Parent
-                && msg.summary.as_str().contains("[READY]")
-                && msg.text.as_str().contains("dev.policy-claude"))));
+            .any(|c| matches!(c, Call::SpawnReviewer { .. })));
+        // ...and NEVER delivers [READY] itself — only the sidecar does, on an approve-verdict.
+        assert!(!calls.iter().any(|c| matches!(c, Call::BusDeliver { .. })));
     }
 
     #[tokio::test]

--- a/rust/exo-policy/src/tools/submit.rs
+++ b/rust/exo-policy/src/tools/submit.rs
@@ -64,7 +64,10 @@ fn pre_merge_checks<C: Process + Sync>(ctx: &C) -> BoxFuture<'_, Result<(), Stri
                 .filter_map(|e| e.ok().map(|e| e.path()))
                 .filter(|p| p.is_file())
                 .collect(),
-            Err(_) => return Ok(()),
+            // A missing dir = no gate. Any OTHER error (permissions, IO) must NOT silently
+            // disable the gate — fail the submit.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(e) => return Err(format!("could not read .exo/checks/pre-merge: {e}")),
         };
         scripts.sort();
         let mut failures = Vec::new();
@@ -81,11 +84,12 @@ fn pre_merge_checks<C: Process + Sync>(ctx: &C) -> BoxFuture<'_, Result<(), Stri
             match serde_json::from_str::<CheckResult>(stdout.trim()) {
                 Ok(r) if r.pass => {}
                 Ok(r) => failures.push(format!("{path}: {}", r.detail)),
-                Err(_) => {
-                    if !out.status.success() {
-                        failures.push(format!("{path}: exited non-zero with no JSON output"));
-                    }
-                }
+                // A check that doesn't honour the `{"pass":bool,"detail":...}` contract is
+                // misconfigured/broken — fail closed rather than silently passing the gate.
+                Err(_) => failures.push(format!(
+                    "{path}: did not emit valid {{\"pass\":bool,\"detail\":...}} JSON (exit {})",
+                    out.status
+                )),
             }
         }
         if failures.is_empty() {

--- a/rust/exo-policy/src/tools/verdict.rs
+++ b/rust/exo-policy/src/tools/verdict.rs
@@ -54,12 +54,26 @@ impl Verdict {
                 branch,
                 sha: args.sha.clone(),
             },
-            Decision::Deny => SystemMessage::ReviewDenied {
-                branch,
-                sha: args.sha.clone(),
-                message: args.message.clone(),
-            },
+            Decision::Deny => {
+                if args.message.trim().is_empty() {
+                    return Err(CapError::invalid(
+                        "verdict",
+                        "decision=deny requires a non-empty message explaining what to fix",
+                    ));
+                }
+                SystemMessage::ReviewDenied {
+                    branch,
+                    sha: args.sha.clone(),
+                    message: args.message.clone(),
+                }
+            }
             Decision::Changes => {
+                if args.message.trim().is_empty() {
+                    return Err(CapError::invalid(
+                        "verdict",
+                        "decision=changes requires a non-empty message describing the change",
+                    ));
+                }
                 let changes_branch = match args.changes_branch.clone() {
                     Some(b) => Branch::new(b)?,
                     None => {

--- a/rust/exo-policy/src/tools/verdict.rs
+++ b/rust/exo-policy/src/tools/verdict.rs
@@ -1,0 +1,197 @@
+//! `verdict` — the reviewer's one output. A reviewer (spawned by a submitting node off the
+//! under-review branch) reads the diff against the acceptance criteria, then calls this with
+//! one of three decisions. It packages the decision into a [`SystemMessage`] and delivers it to
+//! its **parent** (the submitter — a real tree edge); the submitter's *sidecar* acts on it
+//! (approve → auto-escalate `[READY]`; deny/changes → wake the LLM). The reviewer then exits.
+
+use exo_caps::{
+    Addressee, Branch, Bus, CapError, CapResult, Message, MessageBody, MessageKind, Summary,
+    SystemMessage,
+};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use crate::tool::{ok_json, parse, schema_json, Tool, ToolOutput};
+
+/// The reviewer's decision.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum Decision {
+    /// The branch meets the bar — the submitter may escalate.
+    Approve,
+    /// The branch does not meet the bar — `message` explains what to fix.
+    Deny,
+    /// You committed improvements to your OWN branch — the submitter should merge `changes_branch`.
+    Changes,
+}
+
+/// Arguments for `verdict`.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct VerdictArgs {
+    /// approve / deny / changes.
+    pub decision: Decision,
+    /// The branch you reviewed (as given in your review task).
+    pub branch: String,
+    /// The commit sha you reviewed (as given in your review task).
+    pub sha: String,
+    /// Feedback for the submitter (required for deny / changes).
+    #[serde(default)]
+    pub message: String,
+    /// For `changes`: your own branch carrying the committed counter-proposal.
+    #[serde(default)]
+    pub changes_branch: Option<String>,
+}
+
+/// The `verdict` tool.
+pub struct Verdict;
+
+impl Verdict {
+    pub async fn run<C: Bus>(ctx: &C, args: VerdictArgs) -> CapResult<ToolOutput> {
+        let branch = Branch::new(args.branch.clone())?;
+        let system = match args.decision {
+            Decision::Approve => SystemMessage::ReviewApproved {
+                branch,
+                sha: args.sha.clone(),
+            },
+            Decision::Deny => SystemMessage::ReviewDenied {
+                branch,
+                sha: args.sha.clone(),
+                message: args.message.clone(),
+            },
+            Decision::Changes => {
+                let changes_branch = match args.changes_branch.clone() {
+                    Some(b) => Branch::new(b)?,
+                    None => {
+                        return Err(CapError::invalid(
+                            "verdict",
+                            "decision=changes requires changes_branch",
+                        ))
+                    }
+                };
+                SystemMessage::ReviewChanges {
+                    branch,
+                    sha: args.sha.clone(),
+                    changes_branch,
+                    message: args.message.clone(),
+                }
+            }
+        };
+
+        // A short human-readable rendering rides text/summary (used in logs, and shown to the
+        // submitter's LLM when the sidecar delivers a deny/changes); the typed payload is in `kind`.
+        let summary = format!("[VERDICT] {} {}", verb(&system), args.branch);
+        let text = render(&system, &args);
+        let msg = Message {
+            text: MessageBody::new(text)?,
+            summary: Summary::new(summary)?,
+            kind: MessageKind::System(system),
+        };
+        ctx.deliver(Addressee::Parent, msg).await?;
+
+        Ok(ToolOutput::with_data(
+            "verdict delivered to parent".to_string(),
+            json!({ "branch": args.branch, "sha": args.sha }),
+        ))
+    }
+}
+
+fn verb(s: &SystemMessage) -> &'static str {
+    match s {
+        SystemMessage::ReviewApproved { .. } => "approve",
+        SystemMessage::ReviewDenied { .. } => "deny",
+        SystemMessage::ReviewChanges { .. } => "changes",
+    }
+}
+
+fn render(s: &SystemMessage, args: &VerdictArgs) -> String {
+    match s {
+        SystemMessage::ReviewApproved { branch, sha } => {
+            format!(
+                "[VERDICT approve] branch `{}` @ {} approved.",
+                branch.as_str(),
+                sha
+            )
+        }
+        SystemMessage::ReviewDenied { branch, .. } => format!(
+            "[VERDICT deny] branch `{}` rejected: {}",
+            branch.as_str(),
+            args.message
+        ),
+        SystemMessage::ReviewChanges {
+            branch,
+            changes_branch,
+            ..
+        } => format!(
+            "[VERDICT changes] branch `{}` — merge `{}` to incorporate: {}",
+            branch.as_str(),
+            changes_branch.as_str(),
+            args.message
+        ),
+    }
+}
+
+#[async_trait::async_trait]
+impl<R: Bus + Send + Sync> Tool<R> for Verdict {
+    fn name(&self) -> &str {
+        "verdict"
+    }
+    fn description(&self) -> &str {
+        "Submit your review verdict on the branch you were spawned to review, then end your turn. \
+         `approve` (meets the bar), `deny` + `message` (what to fix), or `changes` + `changes_branch` \
+         + `message` (you committed a fix to your own branch for the submitter to merge). Pass the \
+         `branch` and `sha` from your review task."
+    }
+    fn schema(&self) -> serde_json::Value {
+        schema_json(schemars::schema_for!(VerdictArgs))
+    }
+    async fn call(&self, ctx: &R, j: serde_json::Value) -> CapResult<serde_json::Value> {
+        ok_json(Self::run(ctx, parse(j)?).await?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testing::{Call, MockRuntime};
+
+    #[tokio::test]
+    async fn approve_delivers_system_message_to_parent() {
+        let mock = MockRuntime::default();
+        Verdict::run(
+            &mock,
+            VerdictArgs {
+                decision: Decision::Approve,
+                branch: "main.dev-0".into(),
+                sha: "abc123".into(),
+                message: String::new(),
+                changes_branch: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let calls = mock.calls_made();
+        assert!(calls.iter().any(|c| matches!(c, Call::BusDeliver { to, msg }
+            if *to == Addressee::Parent
+                && matches!(&msg.kind, MessageKind::System(SystemMessage::ReviewApproved { branch, sha })
+                    if branch.as_str() == "main.dev-0" && sha == "abc123"))));
+    }
+
+    #[tokio::test]
+    async fn changes_requires_changes_branch() {
+        let mock = MockRuntime::default();
+        let res = Verdict::run(
+            &mock,
+            VerdictArgs {
+                decision: Decision::Changes,
+                branch: "main.dev-0".into(),
+                sha: "abc123".into(),
+                message: "fixed the bug".into(),
+                changes_branch: None,
+            },
+        )
+        .await;
+        assert!(res.is_err());
+    }
+}

--- a/rust/exo-runtime/src/git.rs
+++ b/rust/exo-runtime/src/git.rs
@@ -21,6 +21,11 @@ impl Git for Runtime {
         })
     }
 
+    async fn head_sha(&self) -> Result<String, GitError> {
+        let output = self.git(&["rev-parse", "HEAD"]).await?;
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    }
+
     async fn is_clean(&self) -> Result<bool, GitError> {
         let output = self.git(&["status", "--porcelain"]).await?;
         Ok(String::from_utf8_lossy(&output.stdout).trim().is_empty())

--- a/rust/exo-runtime/src/spawner.rs
+++ b/rust/exo-runtime/src/spawner.rs
@@ -354,6 +354,20 @@ impl Runtime {
         })?;
         tokio::fs::write(&papers_path, papers_json).await?;
 
+        // Persist this node's spec (prompt + acceptance criteria) so the reviewer it later spawns
+        // from `submit_branch` can judge against the *original* bar. Worktree children only (an
+        // inline worker shares the parent's `.exo` and never submits). Best-effort — a write
+        // failure must not fail the spawn.
+        if core.kind == ChildKind::Worktree {
+            let acceptance_path = child_dir.join(".exo/acceptance.md");
+            if let Err(e) = tokio::fs::write(&acceptance_path, &core.task).await {
+                tracing::warn!(
+                    "failed to persist .exo/acceptance.md for {}: {e}",
+                    core.name.as_str()
+                );
+            }
+        }
+
         // (f) Launch the agent via exomonad's shared launch builder (reuse over reinvent):
         // the prompt goes in a file (.exo/tmp), never inline — so a multi-line/quote-bearing
         // task can't break shell parsing — and the CLI/flags are the proven ones. The node

--- a/rust/exo-runtime/src/spawner.rs
+++ b/rust/exo-runtime/src/spawner.rs
@@ -515,6 +515,30 @@ impl Spawner for Runtime {
         self.birth(core).await
     }
 
+    async fn spawn_reviewer(&self, spec: GeminiSpec) -> Result<AgentName, SpawnError> {
+        let name = self.resolve_child_name(spec.name, "reviewer").await?;
+        let task = Self::render_spec_prompt(
+            &spec.task,
+            &spec.read_first,
+            &spec.steps,
+            &spec.verify,
+            &spec.boundary,
+            spec.context.as_ref(),
+            &spec.done_criteria,
+        );
+        // Worktree off the CURRENT branch (the under-review code), role=Reviewer. Identical
+        // machinery to `spawn_gemini`; only the role differs (drives papers/tools).
+        let core = BirthCore {
+            kind: ChildKind::Worktree,
+            agent_type: AgentType::Gemini,
+            role: NodeKind::Reviewer,
+            branch: Branch::from_path(&self.node_path().child(&name)),
+            name,
+            task,
+        };
+        self.birth(core).await
+    }
+
     async fn fork_wave(&self, specs: Vec<ForkSpec>) -> Vec<Result<AgentName, SpawnError>> {
         let mut results = Vec::with_capacity(specs.len());
         for spec in specs {


### PR DESCRIPTION
Builds the structural review gate the merge-on-trust smoke called for. A finished node can no longer escalate `[READY]` except through (a) passing automated pre-merge checks and (b) an independent reviewer's approval — and approval rides a new **System message** channel the sidecar acts on without waking the LLM unless it must.

## What's here
- **System messages** (exo-caps): `MessageKind::System(SystemMessage)` — sidecar-consumed, not LLM-rendered. `SystemMessage` is a granular, serde-tagged, extensible enum (`review_approved`/`review_denied`/`review_changes`); a general node-to-node control primitive.
- **The reviewer**: `submit_branch` spawns a full Gemini reviewer in its own worktree branched off the under-review code (no restricted role needed — its blast radius is its own branch), handed the diff + `.exo/acceptance.md` (the node's spawn prompt + `done_criteria`, persisted at birth). It calls the new **`verdict`** tool: approve / deny+msg / changes+branch. New `NodeKind::Reviewer`; `Spawner::spawn_reviewer`; `Git::head_sha`.
- **The structural gate**: `submit_branch` no longer delivers `[READY]` — it runs checks, spawns the reviewer, and returns "STOP & wait." The *only* path that escalates `[READY]` is the sidecar reacting to an approve-verdict whose sha matches HEAD (exo-node `handle_system`): approve → auto-escalate to parent (no LLM turn); deny/changes → wake the LLM to fix / merge + re-submit (new sha → fresh reviewer).
- **Pre-merge checks**: `submit_branch` runs every `.exo/checks/pre-merge/*` script (each emits `{pass, detail}` JSON); any failure blocks the submit.

## How it was built (dogfooded via classic exomonad)
Scaffold (the exo-caps contract + verdict tool + Reviewer role, compiling) committed first; then two parallel Gemini leaves — #933 (pre-merge-check runner) and #934 (sidecar System handler) — merged; then this Wave-2 integration (submit rewiring + acceptance persistence + docs).

## Verification
`cargo build` + `cargo clippy --all-targets` clean; node-mode tests green (exo-caps/policy/runtime/node). Unit tests cover: check-runner skip-on-absent-dir, `verdict` emits the right `SystemMessage`, `submit_branch` spawns a reviewer and never delivers `[READY]` itself. End-to-end (reviewer round-trip) to be exercised in the `smoke/` sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)