### PR TITLE
feat(scry): remove dead resolve_by_pane code path

### DIFF
--- a/rust/exo-scry/CLAUDE.md
+++ b/rust/exo-scry/CLAUDE.md
@@ -18,7 +18,6 @@ CC's own teammate bookkeeping desyncs — we observed phantom teammates, stale `
 | `resolve_active_team(target)` | inotify, Linux | Same, for an arbitrary `ProbeTarget` (pid / tmux pane / self). The only way to resolve a *third party's* team. |
 | `resolve_by_session(uuid)` | config scan, portable | Match a known session UUID against team configs' `leadSessionId`. For self/sidecar contexts where CC hands the process its own `session_id`; works off-Linux. |
 | `resolve_via_transcript(target)` | cwd→transcript, portable-ish | Find the session's newest transcript in its cwd's project dir → UUID → team. Fails loud (`AmbiguousCwd`) if multiple live Claudes share the cwd. |
-| `resolve_by_pane(pane)` | config scan by `tmuxPaneId` | Match a pane against members' `tmuxPaneId`. **See gap — CC omits this field for the lead.** |
 
 `ActiveTeam { team, tasks_dir, lead_inbox, lead_session_id, me, claude_pid }` is the resolved result; `lead_inbox` is the routing target `dispatch` writes.
 
@@ -30,12 +29,11 @@ CC's own teammate bookkeeping desyncs — we observed phantom teammates, stale `
 | `signal` | `ActiveTeamSignal` strategy trait + `InotifyWatchSignal`. |
 | `proc` (Linux) | Process-tree walking (`find_claude_ancestor`/`_descendant`, `self_pid`, cwd reads via `/proc`). |
 | `inotify` / `pathmap` (Linux) | Read `/proc/{pid}/fdinfo` inotify watches → watched paths. |
-| `teams` | On-disk team config discovery/loading (`tasks_root`, `find_team_by_session`, `find_member_by_pane`). |
+| `teams` | On-disk team config discovery/loading (`tasks_root`, `find_team_by_session`). |
 | `inbox` | `send_message(team, to, from, text, summary)` — write a CC Teams inbox line (the native-delivery write). |
 | `transcript` | cwd → project dir → newest session UUID. |
 | `identity` `target` `tmux` `error` | `ActiveTeam`/`Pid`/`TeamName`; `ProbeTarget`; pane→pid; `ScryError`. |
 
 ## Gaps / not-yet
 
-- **`resolve_by_pane` is effectively dead for the lead case** — CC does not write `tmuxPaneId` into team config, so a sidecar can't find *its own* team by pane. `dispatch` uses `resolve_self` for exactly this reason. The fn remains for member resolution; treat as suspect / a cut candidate.
 - The inotify path is **Linux-only**; the portable fallbacks (`resolve_by_session`, `resolve_via_transcript`) exist but the node's `dispatch` only wires `resolve_self` (Linux), so non-Linux native delivery is untested.

--- a/rust/exo-scry/src/bin/exo-scry.rs
+++ b/rust/exo-scry/src/bin/exo-scry.rs
@@ -1,9 +1,9 @@
 //! exo-scry CLI — thin clap shell over the library.
 
 use clap::{Args, Parser, Subcommand};
-use exo_scry::{ActiveTeam, Result};
 #[allow(unused_imports)]
 use exo_scry::ProbeTarget;
+use exo_scry::{ActiveTeam, Result};
 
 #[derive(Parser)]
 #[command(
@@ -61,15 +61,6 @@ fn probe_team(args: ProbeArgs) -> std::process::ExitCode {
 
 #[cfg(target_os = "linux")]
 fn probe_by_target(args: &ProbeArgs) -> std::process::ExitCode {
-    // A pane id is a member's durable self-key: try matching it against
-    // members' tmuxPaneId first; fall back to walking the pane to its session.
-    if let Some(pane) = &args.pane {
-        match exo_scry::resolve_by_pane(pane) {
-            Ok(Some(team)) => return print_result(Ok(Some(team)), args.json),
-            Ok(None) => {} // not a recorded member — fall through to the watch path
-            Err(e) => return print_result(Err(e), args.json),
-        }
-    }
     let target = if let Some(pane) = &args.pane {
         ProbeTarget::TmuxPane(pane.clone())
     } else if let Some(pid) = args.pid {
@@ -98,7 +89,10 @@ fn print_result(res: Result<Option<ActiveTeam>>, json: bool) -> std::process::Ex
     match res {
         Ok(Some(team)) => {
             if json {
-                println!("{}", serde_json::to_string_pretty(&team).unwrap_or_default());
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&team).unwrap_or_default()
+                );
             } else {
                 println!("active team: {}", team.team);
                 if let Some(me) = &team.me {

--- a/rust/exo-scry/src/error.rs
+++ b/rust/exo-scry/src/error.rs
@@ -22,7 +22,9 @@ pub enum ScryError {
     PermissionDenied(i32),
 
     /// No Claude Code process found in the requested direction of `start`.
-    #[error("no Claude Code process found in the {direction} of pid {start} (walked {walked} hops)")]
+    #[error(
+        "no Claude Code process found in the {direction} of pid {start} (walked {walked} hops)"
+    )]
     NoClaudeProcess {
         start: i32,
         direction: &'static str,
@@ -46,7 +48,10 @@ pub enum ScryError {
 
     /// A team's `config.json` could not be read.
     #[error("failed to read team config {}: {source}", path.display())]
-    TeamConfigRead { path: PathBuf, source: std::io::Error },
+    TeamConfigRead {
+        path: PathBuf,
+        source: std::io::Error,
+    },
 
     /// A team's `config.json` was malformed.
     #[error("malformed team config {}: {source}", path.display())]

--- a/rust/exo-scry/src/inotify.rs
+++ b/rust/exo-scry/src/inotify.rs
@@ -16,7 +16,9 @@ pub fn watched_inodes(pid: i32) -> Result<HashSet<u64>> {
     let dir = format!("/proc/{pid}/fdinfo");
     let entries = match std::fs::read_dir(&dir) {
         Ok(e) => e,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Err(ScryError::ProcessGone(pid)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Err(ScryError::ProcessGone(pid))
+        }
         Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
             return Err(ScryError::PermissionDenied(pid))
         }
@@ -44,7 +46,9 @@ pub fn watched_inodes(pid: i32) -> Result<HashSet<u64>> {
 /// `inotify wd:1 ino:abcd sdev:800012 mask:... ...`  (`ino` is hex).
 fn parse_inotify_inode(line: &str) -> Option<u64> {
     let rest = line.strip_prefix("inotify ")?;
-    let tok = rest.split_whitespace().find_map(|t| t.strip_prefix("ino:"))?;
+    let tok = rest
+        .split_whitespace()
+        .find_map(|t| t.strip_prefix("ino:"))?;
     u64::from_str_radix(tok, 16).ok()
 }
 

--- a/rust/exo-scry/src/lib.rs
+++ b/rust/exo-scry/src/lib.rs
@@ -72,28 +72,6 @@ pub fn resolve_by_session(session_id: &str) -> Result<Option<ActiveTeam>> {
     }))
 }
 
-/// Resolve the active team from a tmux pane id, by matching it against members'
-/// `tmuxPaneId`. This is the durable, **portable** self-key for a tmux-backed
-/// teammate (the sidecar reads its own `$TMUX_PANE`): pane ids are unique per
-/// session and survive the session-id churn that makes `CLAUDE_CODE_SESSION_ID`
-/// unreliable. Resolves *members*; the human lead isn't pane-indexed (use
-/// [`resolve_self`] / the watch for it). The result's `me` carries the matched
-/// member identity.
-pub fn resolve_by_pane(pane: &str) -> Result<Option<ActiveTeam>> {
-    let Some((team, me)) = teams::find_member_by_pane(pane)? else {
-        return Ok(None);
-    };
-    let tasks_dir = teams::tasks_root()?.join(&team.name);
-    Ok(Some(ActiveTeam {
-        claude_pid: None,
-        team: TeamName(team.name.clone()),
-        tasks_dir,
-        lead_inbox: team.lead_inbox().map(str::to_string),
-        lead_session_id: team.lead_session_id().map(str::to_string),
-        me: Some(me),
-    }))
-}
-
 /// Resolve **this process's own** active team — the entry point for a sidecar /
 /// MCP server that wants its identity without choosing a strategy. Resolve
 /// lazily per call (never cache): the process may have started before any team

--- a/rust/exo-scry/src/resolve.rs
+++ b/rust/exo-scry/src/resolve.rs
@@ -4,7 +4,7 @@ use crate::error::{Result, ScryError};
 use crate::identity::{ActiveTeam, Pid, TeamName};
 use crate::signal::ActiveTeamSignal;
 use crate::target::ProbeTarget;
-use crate::{proc, teams, transcript, tmux};
+use crate::{proc, teams, tmux, transcript};
 
 /// Resolve the Claude Code process id for a target.
 fn claude_pid_for(target: &ProbeTarget) -> Result<Pid> {
@@ -33,7 +33,10 @@ pub fn resolve_via_transcript(target: ProbeTarget) -> Result<Option<ActiveTeam>>
 
     let siblings = proc::claude_pids_with_cwd(&cwd)?;
     if siblings.len() > 1 {
-        return Err(ScryError::AmbiguousCwd { cwd, pids: siblings });
+        return Err(ScryError::AmbiguousCwd {
+            cwd,
+            pids: siblings,
+        });
     }
 
     let project_dir = transcript::project_dir(&teams::projects_root()?, &cwd);
@@ -69,7 +72,9 @@ pub fn resolve_with<S: ActiveTeamSignal>(
         claude_pid: Some(claude_pid),
         team: TeamName(team_name),
         tasks_dir: dir,
-        lead_inbox: cfg.as_ref().and_then(|c| c.lead_inbox().map(str::to_string)),
+        lead_inbox: cfg
+            .as_ref()
+            .and_then(|c| c.lead_inbox().map(str::to_string)),
         lead_session_id: cfg.and_then(|c| c.lead_session_id().map(str::to_string)),
         me: None,
     }))

--- a/rust/exo-scry/src/teams.rs
+++ b/rust/exo-scry/src/teams.rs
@@ -111,43 +111,6 @@ pub fn find_team_by_session(session_id: &str) -> Result<Option<String>> {
     find_team_by_session_in(&teams_root()?, session_id)
 }
 
-/// Find the `(team, member)` whose member `tmuxPaneId` equals `pane`.
-///
-/// The durable, unambiguous self-key for a tmux-backed teammate: pane ids are
-/// unique per session (so they disambiguate multiple sessions in one cwd) and
-/// survive session-id churn (unlike the spawn-frozen `CLAUDE_CODE_SESSION_ID`).
-/// The human lead is *not* found here — its member entry has no pane; resolve it
-/// via the live watch instead.
-pub fn find_member_by_pane(pane: &str) -> Result<Option<(Team, Teammate)>> {
-    find_member_by_pane_in(&teams_root()?, pane)
-}
-
-fn find_member_by_pane_in(teams_root: &Path, pane: &str) -> Result<Option<(Team, Teammate)>> {
-    if pane.is_empty() {
-        return Ok(None);
-    }
-    let entries = match std::fs::read_dir(teams_root) {
-        Ok(e) => e,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(e) => return Err(ScryError::Io(e)),
-    };
-    for entry in entries {
-        let Ok(entry) = entry else { continue };
-        let Ok(team) = load_team_at(&entry.path().join("config.json")) else {
-            continue;
-        };
-        if let Some(m) = team
-            .members
-            .iter()
-            .find(|m| !m.tmux_pane_id.is_empty() && m.tmux_pane_id == pane)
-        {
-            let me = m.clone();
-            return Ok(Some((team, me)));
-        }
-    }
-    Ok(None)
-}
-
 fn find_team_by_session_in(teams_root: &Path, session_id: &str) -> Result<Option<String>> {
     let entries = match std::fs::read_dir(teams_root) {
         Ok(e) => e,
@@ -158,7 +121,9 @@ fn find_team_by_session_in(teams_root: &Path, session_id: &str) -> Result<Option
         let Ok(entry) = entry else { continue };
         let cfg = entry.path().join("config.json");
         // A malformed/half-written sibling config must not abort the scan.
-        let Ok(team) = load_team_at(&cfg) else { continue };
+        let Ok(team) = load_team_at(&cfg) else {
+            continue;
+        };
         if team.lead_session_id() == Some(session_id) {
             if let Some(name) = entry.file_name().to_str() {
                 return Ok(Some(name.to_string()));
@@ -192,7 +157,9 @@ mod tests {
         write_team(&root, "alpha", "uuid-aaa");
         write_team(&root, "beta", "uuid-bbb");
         assert_eq!(
-            find_team_by_session_in(&root, "uuid-bbb").unwrap().as_deref(),
+            find_team_by_session_in(&root, "uuid-bbb")
+                .unwrap()
+                .as_deref(),
             Some("beta")
         );
         assert_eq!(find_team_by_session_in(&root, "uuid-zzz").unwrap(), None);
@@ -204,28 +171,6 @@ mod tests {
         let root = std::env::temp_dir().join("exo-scry-teams-nonexistent-xyzzy");
         let _ = std::fs::remove_dir_all(&root);
         assert_eq!(find_team_by_session_in(&root, "any").unwrap(), None);
-    }
-
-    #[test]
-    fn finds_member_by_pane() {
-        let root = std::env::temp_dir().join(format!("exo-scry-pane-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&root);
-        std::fs::create_dir_all(root.join("alpha")).unwrap();
-        std::fs::write(
-            root.join("alpha").join("config.json"),
-            r#"{"name":"alpha","leadAgentId":"lead@alpha","members":[
-                {"agentId":"lead@alpha","name":"team-lead","tmuxPaneId":""},
-                {"agentId":"scout@alpha","name":"scout","tmuxPaneId":"%312","isActive":false}
-            ]}"#,
-        )
-        .unwrap();
-        let (team, me) = find_member_by_pane_in(&root, "%312").unwrap().unwrap();
-        assert_eq!(team.name, "alpha");
-        assert_eq!(me.name, "scout");
-        // Empty pane must never match the lead's empty tmuxPaneId.
-        assert!(find_member_by_pane_in(&root, "").unwrap().is_none());
-        assert!(find_member_by_pane_in(&root, "%999").unwrap().is_none());
-        std::fs::remove_dir_all(&root).unwrap();
     }
 
     #[test]

--- a/rust/exo-scry/src/transcript.rs
+++ b/rust/exo-scry/src/transcript.rs
@@ -67,7 +67,9 @@ mod tests {
             "-home-inanna-dev-exomonad"
         );
         assert_eq!(
-            escape_cwd(Path::new("/home/inanna/dev/exomonad/.exo/worktrees/address-type")),
+            escape_cwd(Path::new(
+                "/home/inanna/dev/exomonad/.exo/worktrees/address-type"
+            )),
             "-home-inanna-dev-exomonad--exo-worktrees-address-type"
         );
     }
@@ -79,10 +81,18 @@ mod tests {
         let _ = std::fs::remove_dir_all(&root);
         std::fs::create_dir_all(&root).unwrap();
         // Deterministic mtimes (no sleep): beta newer than alpha; ignore non-jsonl.
-        for (name, secs) in [("alpha.jsonl", 1000), ("beta.jsonl", 2000), ("notes.txt", 9000)] {
+        for (name, secs) in [
+            ("alpha.jsonl", 1000),
+            ("beta.jsonl", 2000),
+            ("notes.txt", 9000),
+        ] {
             std::fs::write(root.join(name), b"{}").unwrap();
-            let f = std::fs::File::options().write(true).open(root.join(name)).unwrap();
-            f.set_modified(SystemTime::UNIX_EPOCH + Duration::from_secs(secs)).unwrap();
+            let f = std::fs::File::options()
+                .write(true)
+                .open(root.join(name))
+                .unwrap();
+            f.set_modified(SystemTime::UNIX_EPOCH + Duration::from_secs(secs))
+                .unwrap();
         }
         assert_eq!(newest_session(&root).unwrap().as_deref(), Some("beta"));
         std::fs::remove_dir_all(&root).unwrap();


### PR DESCRIPTION
This PR removes the dead `resolve_by_pane` code path from the `exo-scry` crate.
It was documented as dead code because Claude Code omits `tmuxPaneId` for the team lead, and the node sidecar uses `resolve_self` instead.

Changes:
- Deleted `resolve_by_pane` from `rust/exo-scry/src/lib.rs`.
- Deleted `find_member_by_pane`, `find_member_by_pane_in`, and associated tests from `rust/exo-scry/src/teams.rs`.
- Removed the `resolve_by_pane` fallback from the `exo-scry` CLI in `rust/exo-scry/src/bin/exo-scry.rs`.
- Updated `rust/exo-scry/CLAUDE.md` to reflect the removal.
- Formatted the `exo-scry` crate with `cargo fmt`.

Verified with `cargo build`, `cargo test`, `cargo clippy`, and `rg`.