### PR TITLE
feat(policy): stop hook notifies parent on turn-end; stop_notify for Gemini leaves

### DIFF
--- a/rust/exo-policy/src/hooks.rs
+++ b/rust/exo-policy/src/hooks.rs
@@ -12,7 +12,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::tool::BoxFuture;
-use exo_caps::{Git, Log};
+use exo_caps::{
+    Addressee, Bus, CapResult, Git, Log, Message, MessageBody, MessageKind, Summary, SystemMessage,
+};
 
 /// A `PreToolUse` verdict. `Modify` rewrites the tool input in place (the PII-rewrite path).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -87,14 +89,49 @@ pub fn pre_tool_use<'a, R: Send + Sync>(
     })
 }
 
-/// The local convergence gate (v2 — no GitHub). A parent folds a child by merging its
-/// **branch** off disk, so uncommitted work is invisible to that merge. Block exit while the
-/// worktree is dirty — the agent must commit (or discard) before it stops. Fail OPEN on any
-/// error: a hook must never wedge an agent in its turn-loop (that bricks the session).
-pub fn stop<'a, R: Git + Log + Send + Sync>(ctx: &'a R) -> BoxFuture<'a, StopDecision> {
+/// Build the [`ChildIdle`](SystemMessage::ChildIdle) a non-root node delivers to its parent at
+/// turn-end. Minimal by design (v1): a fixed human-readable summary the parent's `handle_system`
+/// renders. Refinement (dedupe, richer state from the hook payload) lands parent-side later, not
+/// by growing this message.
+fn child_idle_message() -> CapResult<Message> {
+    let summary = "finished a turn and is yielding control";
+    Ok(Message {
+        text: MessageBody::new(format!("[idle] {summary}"))?,
+        summary: Summary::new(summary.into())?,
+        kind: MessageKind::System(SystemMessage::ChildIdle {
+            summary: summary.into(),
+        }),
+    })
+}
+
+/// Best-effort turn-end signal: deliver a `ChildIdle` to the parent. Logs and swallows any error
+/// — a stop hook must never fail an agent's exit over a missed notification. Root has no parent,
+/// so it never calls this (it uses `stop_allow`).
+async fn notify_parent_idle<R: Bus + Log>(ctx: &R) {
+    match child_idle_message() {
+        Ok(msg) => {
+            if let Err(e) = ctx.deliver(Addressee::Parent, msg).await {
+                ctx.error(&format!("stop hook: failed to notify parent of idle: {e}"));
+            }
+        }
+        Err(e) => ctx.error(&format!(
+            "stop hook: could not build ChildIdle message: {e}"
+        )),
+    }
+}
+
+/// The local convergence gate for a spawned TL (v2 — no GitHub). A parent folds a child by
+/// merging its **branch** off disk, so uncommitted work is invisible to that merge: block exit
+/// while the worktree is dirty (commit or discard first). On a clean exit the node is yielding
+/// control, so notify the parent it went idle. Fails OPEN on any git error — a hook must never
+/// wedge an agent in its turn-loop (that bricks the session).
+pub fn stop<'a, R: Git + Log + Bus + Send + Sync>(ctx: &'a R) -> BoxFuture<'a, StopDecision> {
     Box::pin(async move {
         match ctx.is_clean().await {
-            Ok(true) => StopDecision::Allow,
+            Ok(true) => {
+                notify_parent_idle(ctx).await;
+                StopDecision::Allow
+            }
             Ok(false) => StopDecision::Block {
                 reason: "Uncommitted changes in your worktree. Commit your work (a parent merges \
                          your branch off disk — uncommitted changes are invisible to that merge), \
@@ -118,6 +155,18 @@ pub fn stop_allow<R: Send + Sync>(_ctx: &R) -> BoxFuture<'_, StopDecision> {
     Box::pin(async move { StopDecision::Allow })
 }
 
+/// Stop hook for Gemini leaves (dev, worker): notify the parent this node yielded control, then
+/// ALWAYS allow exit. It NEVER blocks — Gemini's `AfterAgent` `deny` can infinite-loop
+/// (gemini-cli #20426), so a Gemini role must not block at stop. The committed-before-fold
+/// guarantee for a dev is enforced by `submit_branch`'s committed-check, not here; a worker is
+/// inline with no branch to fold.
+pub fn stop_notify<'a, R: Bus + Log + Send + Sync>(ctx: &'a R) -> BoxFuture<'a, StopDecision> {
+    Box::pin(async move {
+        notify_parent_idle(ctx).await;
+        StopDecision::Allow
+    })
+}
+
 pub fn session_start<'a, R: Send + Sync>(_ctx: &'a R) -> BoxFuture<'a, SessionStartOutput> {
     Box::pin(async move {
         // Root identity bootstrap context injection goes here (additional_context).
@@ -128,8 +177,55 @@ pub fn session_start<'a, R: Send + Sync>(_ctx: &'a R) -> BoxFuture<'a, SessionSt
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::testing::MockRuntime;
+    use crate::testing::{Call, MockRuntime};
     use serde_json::json;
+
+    fn delivered_child_idle_to_parent(calls: &[Call]) -> bool {
+        calls.iter().any(|c| {
+            matches!(
+                c,
+                Call::BusDeliver { to: Addressee::Parent, msg }
+                    if matches!(msg.kind, MessageKind::System(SystemMessage::ChildIdle { .. }))
+            )
+        })
+    }
+
+    #[tokio::test]
+    async fn test_stop_notifies_parent_on_clean_allow() {
+        let ctx = MockRuntime::default(); // is_clean = true
+        assert_eq!(stop(&ctx).await, StopDecision::Allow);
+        assert!(
+            delivered_child_idle_to_parent(&ctx.calls_made()),
+            "clean stop should notify parent of idle"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_stop_block_when_dirty_does_not_notify() {
+        let ctx = MockRuntime {
+            is_clean: false,
+            ..Default::default()
+        };
+        assert!(matches!(stop(&ctx).await, StopDecision::Block { .. }));
+        assert!(
+            !delivered_child_idle_to_parent(&ctx.calls_made()),
+            "a blocked (still-working) node must not notify idle"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_stop_notify_allows_and_notifies() {
+        let ctx = MockRuntime::default();
+        assert_eq!(stop_notify(&ctx).await, StopDecision::Allow);
+        assert!(delivered_child_idle_to_parent(&ctx.calls_made()));
+    }
+
+    #[tokio::test]
+    async fn test_stop_notify_never_blocks_even_if_deliver_fails() {
+        let ctx = MockRuntime::failing("deliver");
+        // Even when the bus delivery errors, a Gemini stop must allow exit (never block).
+        assert_eq!(stop_notify(&ctx).await, StopDecision::Allow);
+    }
 
     #[test]
     fn hook_decision_serde_is_tagged() {

--- a/rust/exo-policy/src/roles.rs
+++ b/rust/exo-policy/src/roles.rs
@@ -11,8 +11,8 @@
 
 use crate::caps::PolicyCaps;
 use crate::hooks::{
-    pre_tool_use, session_start, stop, stop_allow, HookDecision, HookInput, SessionStartOutput,
-    StopDecision,
+    pre_tool_use, session_start, stop, stop_allow, stop_notify, HookDecision, HookInput,
+    SessionStartOutput, StopDecision,
 };
 use crate::tool::{BoxFuture, Tool};
 use crate::tools::merge::Merge;
@@ -79,20 +79,20 @@ pub fn role_def<R: PolicyCaps>(kind: NodeKind) -> RoleDef<R> {
             stop,
             session_start,
         },
-        // A dev leaf works on its own branch and submits it for the parent to merge.
+        // A dev leaf works on its own branch and submits it for the parent to merge. It NEVER blocks at
+        // stop (Gemini #20426); the committed-before-fold guarantee is enforced by submit_branch.
         NodeKind::Dev => RoleDef {
             tools: vec![Box::new(NotifyParent), Box::new(SubmitBranch)],
             pre_tool_use,
-            stop,
+            stop: stop_notify,
             session_start,
         },
-        // A worker is an inline child sharing the parent's worktree — it has no own branch to
-        // submit, so it only reports back.
+        // A worker is an inline child sharing the parent's worktree — no own branch to submit, so it
+        // only reports back, but it still signals the parent when it yields control.
         NodeKind::Worker => RoleDef {
             tools: vec![Box::new(NotifyParent)],
             pre_tool_use,
-            // Workers are ephemeral and commit nothing to fold — nothing to gate on.
-            stop: stop_allow,
+            stop: stop_notify,
             session_start,
         },
         // A reviewer reads the under-review branch and emits a `verdict`, then exits. It does not
@@ -129,12 +129,16 @@ mod tests {
                 rd.pre_tool_use as usize,
                 pre_tool_use::<MockRuntime> as *const () as usize
             );
-            // Root/Worker never file a PR → no gate (stop_allow); Tl/Dev gate via `stop`.
+            // Root/Reviewer never yield work to fold → stop_allow. Dev/Worker (Gemini) notify the
+            // parent then allow (never block). Tl keeps the dirty-gate (stop).
             let expected_stop = match kind {
-                NodeKind::Root | NodeKind::Worker | NodeKind::Reviewer => {
+                NodeKind::Root | NodeKind::Reviewer => {
                     stop_allow::<MockRuntime> as *const () as usize
                 }
-                NodeKind::Tl | NodeKind::Dev => stop::<MockRuntime> as *const () as usize,
+                NodeKind::Dev | NodeKind::Worker => {
+                    stop_notify::<MockRuntime> as *const () as usize
+                }
+                NodeKind::Tl => stop::<MockRuntime> as *const () as usize,
             };
             assert_eq!(rd.stop as usize, expected_stop, "Role {:?} stop fn", kind);
             assert_eq!(
@@ -146,7 +150,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_role_stop_gate_blocks_when_dirty() {
-        let rd = role_def::<MockRuntime>(NodeKind::Dev);
+        let rd = role_def::<MockRuntime>(NodeKind::Tl);
         let ctx = MockRuntime {
             is_clean: false,
             ..Default::default()


### PR DESCRIPTION
This PR wires the per-role `Stop` hook to notify the parent on turn-end (v2 node-mode).

Changes:
- Added `stop_notify` hook for Gemini leaves (dev, worker) which always allows exit but notifies the parent.
- Updated the existing `stop` hook (used by `tl`) to notify the parent when it allows a clean exit.
- Updated the role table: `dev` and `worker` now use `stop_notify`.
- Added tests to verify the notification behavior.
- Root and Reviewer continue to use `stop_allow` (no notification needed/already handled).

This implements the v2 turn-end signal where a node delivers a `SystemMessage::ChildIdle` to its parent.