### PR TITLE
feat(exo-node): implement per-agent hooksock server (N5)

### DIFF
--- a/rust/exo-node/CLAUDE.md
+++ b/rust/exo-node/CLAUDE.md
@@ -12,6 +12,7 @@ Assembles `exo-runtime` (all caps) + `exo-policy` (tools/hooks/roles) into a run
 |--------|------|------|
 | `outbound` (N1) | serve | Serve `role_def(kind).tools` as MCP over stdio (`tools/list` emits each tool's `name`/`description`/`inputSchema`, so the toolset is self-documenting). **Owns stdin/stdout → the node's lifetime anchor** (when it closes, the node ends). |
 | `inbound` (N2b) | watch | Watch the node's own ingestion inbox (byte-offset cursor + `notify` watch), route each new entry. |
+| `hooksock` (N5) | serve | Per-agent UDS hook-RPC channel — runs the role hook fn on the live runtime and shapes the verdict per agent_type (never a Gemini Stop deny). |
 | `dispatch` (N2a) | — | The **last hop**: deliver one entry into the agent's native interface (Teams inbox or tmux paste). |
 | `hook` (N4) | one-shot | `exomonad experimental hook <event>` → bootstrap from papers → run the role's `pre_tool_use`/`stop`/`session_start` → print the verdict. No server. |
 | `bootstrap` | — | Self-ID: read `--papers` → `NodePapers`, enrich with ambient env (`$TMUX_PANE`, `EXOMONAD_SWARM_RUN_ID`, `EXOMONAD_TMUX_SESSION`, `$HOME`), build `NodeContext { runtime, kind, own_inbox, parent_inbox, ... }`. |

--- a/rust/exo-node/src/hooksock/server.rs
+++ b/rust/exo-node/src/hooksock/server.rs
@@ -1,22 +1,178 @@
 //! Hook-RPC server (N5) — runs in the sidecar, sharing `ctx.runtime` with the other loops.
 
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
 use std::sync::Arc;
 
+use exo_caps::{AgentType, HookEvent, HookRequest, HookVerdict};
+use exo_policy::{role_def, HookDecision, HookInput, RoleDef, StopDecision};
+use serde_json::json;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{UnixListener, UnixStream};
+use tracing::{info, warn};
+
 use crate::bootstrap::NodeContext;
-use crate::error::NodeResult;
+use crate::error::{NodeError, NodeResult};
 
 /// Serve the per-agent hook-RPC socket. Binds `paths::hook_sock(home, run_id, own_pane)`
 /// (remove-before-bind to clear a stale socket, then `0o600`), accepts connections, and for each
 /// [`HookRequest`](exo_caps::HookRequest) runs the role's hook fn against the **live**
-/// `ctx.runtime` (NOT a fresh `bootstrap()` Runtime — sharing the live one is the whole point),
-/// then replies with a [`HookVerdict`](exo_caps::HookVerdict) whose `stdout` is already shaped
-/// for the node's `agent_type` (Claude vs Gemini; **never a Gemini Stop `deny`** — Gemini
-/// `AfterAgent` deny can infinite-loop, gemini-cli #20426).
+/// `ctx.runtime` (NOT a fresh `bootstrap()` Runtime), then replies with a
+/// [`HookVerdict`](exo_caps::HookVerdict) shaped for the node's `agent_type` — **never a Gemini
+/// Stop `deny`** (gemini-cli #20426 can infinite-loop on `AfterAgent` deny).
 ///
 /// Spawned as a background task by [`run_node`](crate::run_node) and aborted when the outbound
-/// serve loop (the lifetime anchor) returns; an error here is logged, never fatal.
-///
-/// **Status: Wave-0 stub.** Body lands in leaf A1 (reuse the `serve.rs` `UnixListener` pattern).
-pub async fn serve(_ctx: Arc<NodeContext>) -> NodeResult<()> {
-    todo!("A1: remove-before-bind hook_sock + 0o600; accept loop; per-conn read HookRequest, run role_def(ctx.kind).<event> on ctx.runtime, shape verdict per agent_type, write HookVerdict")
+/// serve loop returns; an error here is logged, never fatal.
+pub async fn serve(ctx: Arc<NodeContext>) -> NodeResult<()> {
+    let home = std::env::var("HOME").map_err(|_| NodeError::MissingContext("HOME"))?;
+    let sock = exo_caps::paths::hook_sock(Path::new(&home), &ctx.run_id, &ctx.own_pane);
+
+    if let Some(parent) = sock.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    // Remove a stale socket so bind() can't fail with EADDRINUSE. NotFound is fine.
+    match std::fs::remove_file(&sock) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => return Err(e.into()),
+    }
+
+    let listener = UnixListener::bind(&sock)?;
+    std::fs::set_permissions(&sock, std::fs::Permissions::from_mode(0o600))?;
+    info!(socket = %sock.display(), "hooksock: listening");
+
+    loop {
+        let (stream, _addr) = listener.accept().await?;
+        let ctx = ctx.clone();
+        tokio::spawn(async move {
+            if let Err(e) = handle_conn(ctx, stream).await {
+                warn!("hooksock: connection handler error: {e}");
+            }
+        });
+    }
+}
+
+/// One request/response cycle. The client writes a `HookRequest` then half-closes its write side;
+/// we read to EOF, run the hook, write the `HookVerdict`, and close.
+async fn handle_conn(ctx: Arc<NodeContext>, mut stream: UnixStream) -> NodeResult<()> {
+    let mut buf = Vec::new();
+    stream.read_to_end(&mut buf).await?;
+    let req: HookRequest = serde_json::from_slice(&buf).map_err(|e| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("hooksock: bad HookRequest: {e}"),
+        )
+    })?;
+
+    let verdict = run(&ctx, &req).await;
+    let out = serde_json::to_vec(&verdict)
+        .map_err(|e| std::io::Error::other(format!("hooksock: encode HookVerdict: {e}")))?;
+    stream.write_all(&out).await?;
+    stream.shutdown().await?;
+    Ok(())
+}
+
+/// Run the role's hook fn on the LIVE runtime, then shape stdout for the node's agent_type.
+async fn run(ctx: &NodeContext, req: &HookRequest) -> HookVerdict {
+    let rd = role_def::<exo_runtime::Runtime>(ctx.kind);
+    let agent_type = ctx.kind.agent_type();
+    let stdout = match req.event {
+        HookEvent::PreToolUse => {
+            shape_pre_tool_use(&rd, &ctx.runtime, &req.stdin_json, agent_type).await
+        }
+        HookEvent::Stop => shape_stop(&rd, &ctx.runtime, agent_type).await,
+        HookEvent::SessionStart => {
+            // SessionStart is handled one-shot by the client, never over the socket. A hook must
+            // never wedge an agent, so be defensive and fail-safe allow if one ever arrives.
+            warn!("hooksock: unexpected SessionStart over socket; returning allow");
+            allow_json(agent_type)
+        }
+    };
+    HookVerdict { stdout }
+}
+
+async fn shape_pre_tool_use(
+    rd: &RoleDef<exo_runtime::Runtime>,
+    rt: &exo_runtime::Runtime,
+    stdin_json: &str,
+    agent_type: AgentType,
+) -> String {
+    let input: HookInput = match serde_json::from_str(stdin_json) {
+        Ok(i) => i,
+        Err(e) => {
+            warn!("hooksock: bad PreToolUse stdin ({e}); allowing");
+            return allow_json(agent_type);
+        }
+    };
+    let decision = (rd.pre_tool_use)(rt, &input).await;
+    match agent_type {
+        AgentType::Claude | AgentType::Shoal => match decision {
+            HookDecision::Allow => json!({"continue": true}).to_string(),
+            HookDecision::Deny { reason } => {
+                json!({"continue": true, "systemMessage": reason}).to_string()
+            }
+            HookDecision::Modify { input } => json!({
+                "continue": true,
+                "hookSpecificOutput": {"hookEventName": "PreToolUse", "toolInput": input}
+            })
+            .to_string(),
+        },
+        AgentType::Gemini => match decision {
+            HookDecision::Allow => json!({}).to_string(),
+            // BeforeTool deny is safe (delivered as a tool error, no retry loop).
+            HookDecision::Deny { reason } => {
+                json!({"decision": "deny", "reason": reason}).to_string()
+            }
+            // Gemini BeforeTool has no tool-input rewrite shape; surface nothing and allow.
+            HookDecision::Modify { .. } => {
+                warn!("hooksock: dropping Gemini PreToolUse Modify (no BeforeTool rewrite shape)");
+                json!({}).to_string()
+            }
+        },
+    }
+}
+
+async fn shape_stop(
+    rd: &RoleDef<exo_runtime::Runtime>,
+    rt: &exo_runtime::Runtime,
+    agent_type: AgentType,
+) -> String {
+    let decision = (rd.stop)(rt).await;
+    match agent_type {
+        AgentType::Claude | AgentType::Shoal => match decision {
+            StopDecision::Allow => json!({"continue": true}).to_string(),
+            StopDecision::Block { reason } => {
+                json!({"decision": "block", "reason": reason}).to_string()
+            }
+        },
+        // SAFETY NET: never emit a Gemini Stop deny. `AfterAgent` deny can infinite-loop
+        // (gemini-cli #20426). Policy already must not block Gemini at stop; this downgrade is
+        // defence in depth.
+        AgentType::Gemini => match decision {
+            StopDecision::Allow => json!({}).to_string(),
+            StopDecision::Block { reason } => {
+                warn!("hooksock: downgrading Gemini Stop block to allow (gemini-cli #20426): {reason}");
+                json!({}).to_string()
+            }
+        },
+    }
+}
+
+fn allow_json(agent_type: AgentType) -> String {
+    match agent_type {
+        AgentType::Claude | AgentType::Shoal => json!({"continue": true}).to_string(),
+        AgentType::Gemini => json!({}).to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::allow_json;
+    use exo_caps::AgentType;
+
+    #[test]
+    fn allow_shape_per_agent_type() {
+        assert_eq!(allow_json(AgentType::Claude), r#"{"continue":true}"#);
+        assert_eq!(allow_json(AgentType::Gemini), "{}");
+    }
 }

--- a/rust/exo-node/src/hooksock/server.rs
+++ b/rust/exo-node/src/hooksock/server.rs
@@ -54,9 +54,21 @@ pub async fn serve(ctx: Arc<NodeContext>) -> NodeResult<()> {
 
 /// One request/response cycle. The client writes a `HookRequest` then half-closes its write side;
 /// we read to EOF, run the hook, write the `HookVerdict`, and close.
-async fn handle_conn(ctx: Arc<NodeContext>, mut stream: UnixStream) -> NodeResult<()> {
+async fn handle_conn(ctx: Arc<NodeContext>, stream: UnixStream) -> NodeResult<()> {
     let mut buf = Vec::new();
-    stream.read_to_end(&mut buf).await?;
+    // Read up to 64KB with a 2-second timeout to prevent memory exhaustion and deadlocks.
+    // The client MUST half-close its write side for us to see EOF.
+    let mut limited = stream.take(64 * 1024);
+    let read_fut = limited.read_to_end(&mut buf);
+    match tokio::time::timeout(std::time::Duration::from_secs(2), read_fut).await {
+        Ok(Ok(_)) => {}
+        Ok(Err(e)) => return Err(e.into()),
+        Err(_) => {
+            return Err(std::io::Error::new(std::io::ErrorKind::TimedOut, "hooksock: request timeout").into())
+        }
+    }
+    let mut stream = limited.into_inner();
+
     let req: HookRequest = serde_json::from_slice(&buf).map_err(|e| {
         std::io::Error::new(
             std::io::ErrorKind::InvalidData,
@@ -173,6 +185,7 @@ mod tests {
     #[test]
     fn allow_shape_per_agent_type() {
         assert_eq!(allow_json(AgentType::Claude), r#"{"continue":true}"#);
+        assert_eq!(allow_json(AgentType::Shoal), r#"{"continue":true}"#);
         assert_eq!(allow_json(AgentType::Gemini), "{}");
     }
 }

--- a/rust/exo-node/src/lib.rs
+++ b/rust/exo-node/src/lib.rs
@@ -31,15 +31,16 @@ pub use hook::{handle as handle_hook, HookEvent};
 
 use std::sync::Arc;
 
-/// Run the node's two concurrent stimuli in one process (outbound serve + inbound watch):
+/// Run the node's three concurrent stimuli in one process (outbound serve + inbound watch + hooksock):
 /// - **outbound** ([`outbound::serve`]) — serve the role's MCP tools over stdio. This owns
 ///   stdin/stdout and returns when the stream closes (agent gone), so it is the node's
 ///   **lifetime anchor**: when it ends, the node ends.
 /// - **inbound** ([`inbound::watch`]) — watch the ingestion inbox (cursor + notify) and route
 ///   each entry; ends on a `Control(Shutdown)`.
+/// - **hooksock** ([`hooksock::serve`]) — background hook-RPC socket (N5); also aborted when serve returns.
 ///
-/// The inbound loop is aborted when `serve` returns. `Arc<NodeContext>` satisfies the
-/// `R: Send + Sync + 'static` dispatch boundary. The background loop erroring is logged but does
+/// The background loops are aborted when `serve` returns. `Arc<NodeContext>` satisfies the
+/// `R: Send + Sync + 'static` dispatch boundary. A background loop erroring is logged but does
 /// not tear down the node — only the outbound anchor closing (or a shutdown) ends it.
 pub async fn run_node(ctx: Arc<NodeContext>) -> NodeResult<()> {
     let inbound = tokio::spawn({
@@ -51,11 +52,22 @@ pub async fn run_node(ctx: Arc<NodeContext>) -> NodeResult<()> {
         }
     });
 
+    // N5 — per-agent hook-RPC socket. Background like inbound; an error is logged, not fatal.
+    let hooksock = tokio::spawn({
+        let ctx = ctx.clone();
+        async move {
+            if let Err(e) = hooksock::serve(ctx).await {
+                tracing::error!("hooksock loop exited with error: {e}");
+            }
+        }
+    });
+
     // The outbound serve owns stdio and runs for the node's lifetime.
     let result = outbound::serve(ctx).await;
 
-    // Agent stream closed (or serve errored) → reap the background loop.
+    // Agent stream closed (or serve errored) → reap the background loops.
     inbound.abort();
+    hooksock.abort();
 
     result
 }


### PR DESCRIPTION
This PR implements the per-agent hook-RPC UNIX-socket server (N5) in `exo-node`.

Key changes:
- Implemented `serve()` in `rust/exo-node/src/hooksock/server.rs` using a raw `tokio::net::UnixListener`.
- Wired the `hooksock` server as a third background loop in `run_node` in `rust/exo-node/src/lib.rs`.
- Added a safety net to ensure Gemini `Stop` verdicts are never denied (downgraded to allow), preventing infinite loops (gemini-cli #20426).
- Added unit tests for agent-type shaping.
- Updated `CLAUDE.md` to document the new loop.

**Fixes after Copilot review:**
- Added 64KB size limit to `handle_conn` read to prevent memory exhaustion.
- Added 2-second timeout to `handle_conn` read to prevent deadlocks if client doesn't half-close.
- Added `AgentType::Shoal` assertion to unit tests.

Verification:
- `cargo build -p exo-node` passes.
- `cargo clippy -p exo-node` passes.
- `cargo test -p exo-node` passes (21 tests).
- `cargo fmt -p exo-node` applied.
- Manual check: `Shoal` agent type handled alongside `Claude`.