### PR TITLE
feat: wire Gemini-agent hook configuration

### DIFF
--- a/rust/exo-caps/src/invocation.rs
+++ b/rust/exo-caps/src/invocation.rs
@@ -20,6 +20,15 @@ pub const PRE_TOOL_USE: &str = "pre-tool-use";
 pub const STOP: &str = "stop";
 pub const SESSION_START: &str = "session-start";
 
+/// Gemini CLI `settings.json` hook KEYS — the harness event names, distinct from the CLI event
+/// args above ([`PRE_TOOL_USE`]/[`STOP`]/[`SESSION_START`]). `AfterAgent` is Gemini's turn-end
+/// (the `Stop` equivalent); `BeforeTool` is its pre-tool event; `SessionStart` mirrors Claude.
+/// A Gemini hook entry maps one of these keys to the same `exomonad experimental hook <arg>`
+/// command — so `AfterAgent` runs `... hook stop`, `BeforeTool` runs `... hook pre-tool-use`.
+pub const GEMINI_AFTER_AGENT: &str = "AfterAgent";
+pub const GEMINI_BEFORE_TOOL: &str = "BeforeTool";
+pub const GEMINI_SESSION_START: &str = "SessionStart";
+
 /// MCP sidecar args for a child's `.mcp.json` (the `"command"` is [`BIN`]):
 /// `exomonad experimental node --papers <papers>`.
 pub fn node_args(papers: &str) -> [String; 4] {

--- a/rust/exo-runtime/CLAUDE.md
+++ b/rust/exo-runtime/CLAUDE.md
@@ -15,9 +15,10 @@ The single concrete `Runtime` struct that implements **every** `exo-caps` trait.
 | `bus` | `impl Bus` — **the genuinely-new piece.** Append a line to the target's jsonl inbox; resolve `Addressee`→`InboxPath` (Parent = papers pointer; child = fold `children.jsonl`); stamp the envelope; assert line ≤ `PIPE_BUF` (4096) and **never spill**; append + flush, no fsync. |
 | `spawner` | `impl Spawner` — the recursion (birth + teardown). See below. |
 | `tmux` | `impl Tmux` — delegates to exomonad-core `TmuxIpc::inject_input` (hardened buffer-paste). |
-| `fs` `kv` `log` `process` | The remaining cap impls. |
-| `node_config` | `write_node_agent_config` — writes a Claude child's `.mcp.json` + `.claude/settings.local.json` (PreToolUse/Stop/SessionStart hooks via `exo_caps::invocation`). |
+| `process` | The remaining cap impls. |
+| `node_config` | `write_node_agent_config` — writes a Claude child's `.mcp.json` + `.claude/settings.local.json` (PreToolUse/Stop/SessionStart hooks via `exo_caps::invocation`). (Gemini equivalent BeforeTool/AfterAgent/SessionStart hooks are written inline in `spawner.rs`'s Gemini arm.) |
 | `session_boot` | `boot_root_session` — creates the detached `{session}` tmux window for the root, returns its pane. |
+
 
 ## Spawn: `birth` and record-first ordering (read before editing `spawner.rs`)
 

--- a/rust/exo-runtime/CLAUDE.md
+++ b/rust/exo-runtime/CLAUDE.md
@@ -15,8 +15,8 @@ The single concrete `Runtime` struct that implements **every** `exo-caps` trait.
 | `bus` | `impl Bus` — **the genuinely-new piece.** Append a line to the target's jsonl inbox; resolve `Addressee`→`InboxPath` (Parent = papers pointer; child = fold `children.jsonl`); stamp the envelope; assert line ≤ `PIPE_BUF` (4096) and **never spill**; append + flush, no fsync. |
 | `spawner` | `impl Spawner` — the recursion (birth + teardown). See below. |
 | `tmux` | `impl Tmux` — delegates to exomonad-core `TmuxIpc::inject_input` (hardened buffer-paste). |
-| `process` | The remaining cap impls. |
-| `node_config` | `write_node_agent_config` — writes a Claude child's `.mcp.json` + `.claude/settings.local.json` (PreToolUse/Stop/SessionStart hooks via `exo_caps::invocation`). (Gemini equivalent BeforeTool/AfterAgent/SessionStart hooks are written inline in `spawner.rs`'s Gemini arm.) |
+| `fs` `kv` `log` `process` | The remaining cap impls. |
+| `node_config` | `write_node_agent_config` / `write_gemini_node_config` — writes child agent config (MCP + hooks). |
 | `session_boot` | `boot_root_session` — creates the detached `{session}` tmux window for the root, returns its pane. |
 
 

--- a/rust/exo-runtime/src/node_config.rs
+++ b/rust/exo-runtime/src/node_config.rs
@@ -35,7 +35,7 @@ pub async fn write_node_agent_config(agent_dir: &Path, papers_path: &Path) -> st
     // The Stop hook is a local convergence gate (reads `git status`); no GitHub token needed.
     // PreToolUse + Stop route to the sidecar's hook socket via the thin client; SessionStart
     // stays one-shot in-process. (Gemini gets the equivalent BeforeTool/AfterAgent wiring in
-    // spawner.rs.)
+    // `write_gemini_node_config` below.)
     let settings = serde_json::json!({
         "hooks": {
             "PreToolUse": [{

--- a/rust/exo-runtime/src/node_config.rs
+++ b/rust/exo-runtime/src/node_config.rs
@@ -33,6 +33,9 @@ pub async fn write_node_agent_config(agent_dir: &Path, papers_path: &Path) -> st
     let p_str = esc(&papers_path.to_string_lossy());
     use exo_caps::invocation::{hook_command, PRE_TOOL_USE, SESSION_START, STOP};
     // The Stop hook is a local convergence gate (reads `git status`); no GitHub token needed.
+    // PreToolUse + Stop route to the sidecar's hook socket via the thin client; SessionStart
+    // stays one-shot in-process. (Gemini gets the equivalent BeforeTool/AfterAgent wiring in
+    // spawner.rs.)
     let settings = serde_json::json!({
         "hooks": {
             "PreToolUse": [{

--- a/rust/exo-runtime/src/node_config.rs
+++ b/rust/exo-runtime/src/node_config.rs
@@ -62,3 +62,94 @@ pub async fn write_node_agent_config(agent_dir: &Path, papers_path: &Path) -> st
 
     Ok(())
 }
+
+/// Write the Gemini-specific `settings.json` (MCP + hooks) to the given agent directory.
+pub async fn write_gemini_node_config(agent_dir: &Path, papers_path: &Path) -> std::io::Result<()> {
+    let p_raw = papers_path.to_string_lossy();
+    let p_esc = shell_escape::escape(p_raw.clone().into_owned().into()).into_owned();
+
+    let settings = gemini_settings_json(&p_raw, &p_esc);
+    let settings_json = serde_json::to_vec_pretty(&settings).map_err(|e| {
+        std::io::Error::other(format!("gemini settings encode: {e}"))
+    })?;
+
+    // Gemini settings live in the agent root (unlike Claude's .claude/ subfolder),
+    // pointed to by GEMINI_CLI_SYSTEM_SETTINGS_PATH.
+    let settings_path = agent_dir.join("settings.json");
+    let mut f = tokio::fs::File::create(&settings_path).await?;
+    f.write_all(&settings_json).await?;
+    f.sync_all().await?;
+
+    Ok(())
+}
+
+pub(crate) fn gemini_settings_json(papers_path: &str, p_str_escaped: &str) -> serde_json::Value {
+    use exo_caps::invocation::{
+        hook_command, GEMINI_AFTER_AGENT, GEMINI_BEFORE_TOOL, GEMINI_SESSION_START,
+        PRE_TOOL_USE, SESSION_START, STOP,
+    };
+
+    let mut hooks = serde_json::Map::new();
+    hooks.insert(
+        GEMINI_BEFORE_TOOL.to_string(),
+        serde_json::json!([{
+            "matcher": "*",
+            "hooks": [{"type": "command", "command": hook_command(PRE_TOOL_USE, p_str_escaped)}]
+        }]),
+    );
+    hooks.insert(
+        GEMINI_AFTER_AGENT.to_string(),
+        serde_json::json!([{
+            "matcher": "*",
+            "hooks": [{"type": "command", "command": hook_command(STOP, p_str_escaped)}]
+        }]),
+    );
+    hooks.insert(
+        GEMINI_SESSION_START.to_string(),
+        serde_json::json!([{
+            "matcher": "*",
+            "hooks": [{"type": "command", "command": hook_command(SESSION_START, p_str_escaped)}]
+        }]),
+    );
+
+    serde_json::json!({
+        "mcpServers": {
+            "exomonad": {
+                "type": "stdio",
+                "command": "exomonad",
+                "args": exo_caps::invocation::node_args(papers_path)
+            }
+        },
+        "hooks": hooks
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use exo_caps::invocation::{GEMINI_AFTER_AGENT, GEMINI_BEFORE_TOOL, GEMINI_SESSION_START};
+
+    #[test]
+    fn test_gemini_settings_shape() {
+        let papers = "/tmp/node.json";
+        let escaped = "'/tmp/node.json'";
+        let json = gemini_settings_json(papers, escaped);
+
+        // 1. MCP server args
+        let args = &json["mcpServers"]["exomonad"]["args"];
+        assert_eq!(args[3], papers);
+
+        // 2. Hook keys and matchers (must be "*")
+        let hooks = &json["hooks"];
+        assert_eq!(hooks[GEMINI_BEFORE_TOOL][0]["matcher"], "*");
+        assert_eq!(hooks[GEMINI_AFTER_AGENT][0]["matcher"], "*");
+        assert_eq!(hooks[GEMINI_SESSION_START][0]["matcher"], "*");
+
+        // 3. Command wiring
+        let cmd = hooks[GEMINI_BEFORE_TOOL][0]["hooks"][0]["command"]
+            .as_str()
+            .unwrap();
+        assert!(cmd.contains("pre-tool-use"));
+        assert!(cmd.contains(escaped));
+    }
+}

--- a/rust/exo-runtime/src/node_config.rs
+++ b/rust/exo-runtime/src/node_config.rs
@@ -93,21 +93,21 @@ pub(crate) fn gemini_settings_json(papers_path: &str, p_str_escaped: &str) -> se
     hooks.insert(
         GEMINI_BEFORE_TOOL.to_string(),
         serde_json::json!([{
-            "matcher": "*",
+            "matcher": ".*",
             "hooks": [{"type": "command", "command": hook_command(PRE_TOOL_USE, p_str_escaped)}]
         }]),
     );
     hooks.insert(
         GEMINI_AFTER_AGENT.to_string(),
         serde_json::json!([{
-            "matcher": "*",
+            "matcher": "",
             "hooks": [{"type": "command", "command": hook_command(STOP, p_str_escaped)}]
         }]),
     );
     hooks.insert(
         GEMINI_SESSION_START.to_string(),
         serde_json::json!([{
-            "matcher": "*",
+            "matcher": "",
             "hooks": [{"type": "command", "command": hook_command(SESSION_START, p_str_escaped)}]
         }]),
     );
@@ -139,11 +139,11 @@ mod tests {
         let args = &json["mcpServers"]["exomonad"]["args"];
         assert_eq!(args[3], papers);
 
-        // 2. Hook keys and matchers (must be "*")
+        // 2. Hook keys and matchers (BeforeTool = regex (.*), lifecycle events = exact-string (""))
         let hooks = &json["hooks"];
-        assert_eq!(hooks[GEMINI_BEFORE_TOOL][0]["matcher"], "*");
-        assert_eq!(hooks[GEMINI_AFTER_AGENT][0]["matcher"], "*");
-        assert_eq!(hooks[GEMINI_SESSION_START][0]["matcher"], "*");
+        assert_eq!(hooks[GEMINI_BEFORE_TOOL][0]["matcher"], ".*");
+        assert_eq!(hooks[GEMINI_AFTER_AGENT][0]["matcher"], "");
+        assert_eq!(hooks[GEMINI_SESSION_START][0]["matcher"], "");
 
         // 3. Command wiring
         let cmd = hooks[GEMINI_BEFORE_TOOL][0]["hooks"][0]["command"]

--- a/rust/exo-runtime/src/spawner.rs
+++ b/rust/exo-runtime/src/spawner.rs
@@ -396,62 +396,21 @@ impl Runtime {
             AgentType::Gemini => {
                 // Gemini discovers the node MCP server via GEMINI_CLI_SYSTEM_SETTINGS_PATH, and
                 // fires hooks through the same `exomonad experimental hook` thin client as Claude.
-                // AfterAgent = turn-end (Stop equiv); BeforeTool = pre-tool. NEVER block Gemini at
-                // AfterAgent (the sidecar downgrades any Stop block to allow — gemini-cli #20426).
-                let p_str = shell_escape::escape(papers_path.to_string_lossy().into_owned().into())
-                    .into_owned();
-                use exo_caps::invocation::{
-                    hook_command, GEMINI_AFTER_AGENT, GEMINI_BEFORE_TOOL, GEMINI_SESSION_START,
-                    PRE_TOOL_USE, SESSION_START, STOP,
-                };
-                let mut hooks = serde_json::Map::new();
-                hooks.insert(
-                    GEMINI_BEFORE_TOOL.to_string(),
-                    serde_json::json!([{
-                        "matcher": ".*",
-                        "hooks": [{"type": "command", "command": hook_command(PRE_TOOL_USE, &p_str)}]
-                    }]),
-                );
-                hooks.insert(
-                    GEMINI_AFTER_AGENT.to_string(),
-                    serde_json::json!([{
-                        "matcher": "",
-                        "hooks": [{"type": "command", "command": hook_command(STOP, &p_str)}]
-                    }]),
-                );
-                hooks.insert(
-                    GEMINI_SESSION_START.to_string(),
-                    serde_json::json!([{
-                        "matcher": "",
-                        "hooks": [{"type": "command", "command": hook_command(SESSION_START, &p_str)}]
-                    }]),
-                );
-                let mcp_config = serde_json::json!({
-                    "mcpServers": {
-                        "exomonad": {
-                            "type": "stdio",
-                            "command": "exomonad",
-                            "args": exo_caps::invocation::node_args(&papers_path.to_string_lossy())
-                        }
-                    },
-                    "hooks": hooks
-                });
-                let settings_path = papers_path.with_file_name("settings.json");
-                tokio::fs::write(
-                    &settings_path,
-                    serde_json::to_vec_pretty(&mcp_config).map_err(|e| SpawnError::Failed {
-                        op: "write_gemini_settings",
+                crate::node_config::write_gemini_node_config(child_dir, &papers_path)
+                    .await
+                    .map_err(|e| SpawnError::Failed {
+                        op: "write_gemini_node_config",
                         child: Some(core.name.clone()),
                         detail: e.to_string(),
-                    })?,
-                )
-                .await?;
+                    })?;
+                let settings_path = child_dir.join("settings.json");
                 env_vars.insert(
                     "GEMINI_CLI_SYSTEM_SETTINGS_PATH".into(),
                     settings_path.to_string_lossy().into_owned(),
                 );
                 exomonad_core::services::agent_control::AgentType::Gemini
             }
+
             AgentType::Shoal => {
                 return Err(SpawnError::Failed {
                     op: "launch",

--- a/rust/exo-runtime/src/spawner.rs
+++ b/rust/exo-runtime/src/spawner.rs
@@ -394,7 +394,38 @@ impl Runtime {
                 exomonad_core::services::agent_control::AgentType::Claude
             }
             AgentType::Gemini => {
-                // Gemini discovers the node MCP server via GEMINI_CLI_SYSTEM_SETTINGS_PATH.
+                // Gemini discovers the node MCP server via GEMINI_CLI_SYSTEM_SETTINGS_PATH, and
+                // fires hooks through the same `exomonad experimental hook` thin client as Claude.
+                // AfterAgent = turn-end (Stop equiv); BeforeTool = pre-tool. NEVER block Gemini at
+                // AfterAgent (the sidecar downgrades any Stop block to allow — gemini-cli #20426).
+                let p_str = shell_escape::escape(papers_path.to_string_lossy().into_owned().into())
+                    .into_owned();
+                use exo_caps::invocation::{
+                    hook_command, GEMINI_AFTER_AGENT, GEMINI_BEFORE_TOOL, GEMINI_SESSION_START,
+                    PRE_TOOL_USE, SESSION_START, STOP,
+                };
+                let mut hooks = serde_json::Map::new();
+                hooks.insert(
+                    GEMINI_BEFORE_TOOL.to_string(),
+                    serde_json::json!([{
+                        "matcher": ".*",
+                        "hooks": [{"type": "command", "command": hook_command(PRE_TOOL_USE, &p_str)}]
+                    }]),
+                );
+                hooks.insert(
+                    GEMINI_AFTER_AGENT.to_string(),
+                    serde_json::json!([{
+                        "matcher": "",
+                        "hooks": [{"type": "command", "command": hook_command(STOP, &p_str)}]
+                    }]),
+                );
+                hooks.insert(
+                    GEMINI_SESSION_START.to_string(),
+                    serde_json::json!([{
+                        "matcher": "",
+                        "hooks": [{"type": "command", "command": hook_command(SESSION_START, &p_str)}]
+                    }]),
+                );
                 let mcp_config = serde_json::json!({
                     "mcpServers": {
                         "exomonad": {
@@ -402,7 +433,8 @@ impl Runtime {
                             "command": "exomonad",
                             "args": exo_caps::invocation::node_args(&papers_path.to_string_lossy())
                         }
-                    }
+                    },
+                    "hooks": hooks
                 });
                 let settings_path = papers_path.with_file_name("settings.json");
                 tokio::fs::write(


### PR DESCRIPTION
This PR wires the Gemini-agent hook configuration so spawned Gemini node-children fire `BeforeTool` and `AfterAgent` hooks through the `exomonad experimental hook` command.

Refactored to extraction `gemini_settings_json` helper and addressed Gemini-specific matcher requirements:
- `BeforeTool` matcher is `".*"` (regex match-all).
- `AfterAgent` and `SessionStart` matchers are `""` (exact-string lifecycle matchers).

Verified with unit tests in `rust/exo-runtime/src/node_config.rs`.