### PR TITLE
feat: hook-RPC client and CLI rewiring (final corrections)

### DIFF
--- a/rust/exo-node/src/hooksock/client.rs
+++ b/rust/exo-node/src/hooksock/client.rs
@@ -1,10 +1,12 @@
 //! Hook-RPC client — the short-lived `exomonad experimental hook` process.
 
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use exo_caps::{HookRequest, HookVerdict, NodePapers};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::UnixStream;
+use tokio::time::timeout;
 
 use crate::error::{NodeError, NodeResult};
 
@@ -15,20 +17,31 @@ use crate::error::{NodeError, NodeResult};
 /// Framing: write the request JSON, half-close the write side (EOF signals end-of-request to the
 /// server), then read the response JSON to EOF.
 pub async fn client_request(sock: &Path, req: &HookRequest) -> NodeResult<HookVerdict> {
-    let mut stream = UnixStream::connect(sock).await?;
-    let bytes = serde_json::to_vec(req)
-        .map_err(|e| std::io::Error::other(format!("encode HookRequest: {e}")))?;
-    stream.write_all(&bytes).await?;
-    stream.shutdown().await?;
+    let verdict = timeout(Duration::from_secs(5), async {
+        let mut stream = UnixStream::connect(sock).await?;
+        let bytes = serde_json::to_vec(req)
+            .map_err(|e| std::io::Error::other(format!("encode HookRequest: {e}")))?;
+        stream.write_all(&bytes).await?;
+        stream.shutdown().await?;
 
-    let mut resp = Vec::new();
-    stream.read_to_end(&mut resp).await?;
-    let verdict: HookVerdict = serde_json::from_slice(&resp).map_err(|e| {
+        let mut resp = Vec::new();
+        stream.read_to_end(&mut resp).await?;
+        let verdict: HookVerdict = serde_json::from_slice(&resp).map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("decode HookVerdict: {e}"),
+            )
+        })?;
+        Ok::<HookVerdict, NodeError>(verdict)
+    })
+    .await
+    .map_err(|_| {
         std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
-            format!("decode HookVerdict: {e}"),
+            std::io::ErrorKind::TimedOut,
+            format!("hook socket RPC timed out for {}", sock.display()),
         )
-    })?;
+    })??;
+
     Ok(verdict)
 }
 

--- a/rust/exo-node/src/hooksock/client.rs
+++ b/rust/exo-node/src/hooksock/client.rs
@@ -1,18 +1,54 @@
 //! Hook-RPC client — the short-lived `exomonad experimental hook` process.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
-use exo_caps::{HookRequest, HookVerdict};
+use exo_caps::{HookRequest, HookVerdict, NodePapers};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::UnixStream;
 
-use crate::error::NodeResult;
+use crate::error::{NodeError, NodeResult};
 
 /// Connect to a node's hook socket, send one [`HookRequest`], return the [`HookVerdict`]. The
-/// caller (`exomonad experimental hook`) prints `verdict.stdout` verbatim and exits 0. On a
-/// connect failure the caller must **fail open** (print the allow-shape for its agent type and
-/// exit 0) — the sidecar being down means there are no tools to gate anyway.
+/// caller prints `verdict.stdout` verbatim and exits 0. On any failure the caller must **fail
+/// open** — the sidecar being down means there are no tools to gate anyway.
 ///
-/// **Status: Wave-0 stub.** Body lands in leaf A2 (reuse the `uds_client.rs` hyper-over-UnixStream
-/// pattern; this is a tiny JSON request/response).
-pub async fn client_request(_sock: &Path, _req: &HookRequest) -> NodeResult<HookVerdict> {
-    todo!("A2: connect UDS, send HookRequest JSON, read HookVerdict JSON")
+/// Framing: write the request JSON, half-close the write side (EOF signals end-of-request to the
+/// server), then read the response JSON to EOF.
+pub async fn client_request(sock: &Path, req: &HookRequest) -> NodeResult<HookVerdict> {
+    let mut stream = UnixStream::connect(sock).await?;
+    let bytes = serde_json::to_vec(req)
+        .map_err(|e| std::io::Error::other(format!("encode HookRequest: {e}")))?;
+    stream.write_all(&bytes).await?;
+    stream.shutdown().await?;
+
+    let mut resp = Vec::new();
+    stream.read_to_end(&mut resp).await?;
+    let verdict: HookVerdict = serde_json::from_slice(&resp).map_err(|e| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("decode HookVerdict: {e}"),
+        )
+    })?;
+    Ok(verdict)
+}
+
+/// Resolve this node's hook socket path from its papers + ambient run env, identically to how the
+/// sidecar's server binds it (both go through [`exo_caps::paths::hook_sock`], so they always
+/// agree). The pane comes from papers; the run-id and home from the env the parent set at spawn.
+pub fn resolve_hook_sock(papers_path: &Path) -> NodeResult<PathBuf> {
+    let bytes = std::fs::read(papers_path)?;
+    let papers: NodePapers = serde_json::from_slice(&bytes).map_err(|e| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("parse papers {}: {e}", papers_path.display()),
+        )
+    })?;
+    let run_id = std::env::var("EXOMONAD_SWARM_RUN_ID")
+        .map_err(|_| NodeError::MissingContext("EXOMONAD_SWARM_RUN_ID"))?;
+    let home = std::env::var("HOME").map_err(|_| NodeError::MissingContext("HOME"))?;
+    Ok(exo_caps::paths::hook_sock(
+        Path::new(&home),
+        &run_id,
+        &papers.pane,
+    ))
 }

--- a/rust/exo-node/tests/converge.rs
+++ b/rust/exo-node/tests/converge.rs
@@ -9,7 +9,7 @@
 use std::sync::Arc;
 
 use exo_caps::{
-    Addressee, AgentName, Branch, Bus, IngestionEntry, InboxPath, Message, MessageBody,
+    Addressee, AgentName, Branch, Bus, InboxPath, IngestionEntry, Message, MessageBody,
     MessageKind, NodePath, PaneId, Persona, Summary,
 };
 use exo_runtime::Runtime;

--- a/rust/exomonad/src/main.rs
+++ b/rust/exomonad/src/main.rs
@@ -37,7 +37,7 @@ fn fail_open_shape(papers_path: &std::path::Path) -> &'static str {
         .and_then(|b| serde_json::from_slice::<exo_caps::NodePapers>(&b).ok())
         .map(|p| p.role.agent_type());
     match agent_type {
-        Some(exo_caps::AgentType::Gemini) => r#"{"decision":"allow"}"#,
+        Some(exo_caps::AgentType::Gemini) => "{}",
         _ => r#"{"continue":true}"#,
     }
 }
@@ -242,35 +242,27 @@ async fn main() -> Result<()> {
 
                 let req = exo_caps::HookRequest {
                     event: hook_event,
-                    stdin_json: body.clone(),
+                    stdin_json: body,
                 };
 
-                // Route to socket, fallback to in-process if unreachable or times out.
-                let result = match exo_node::hooksock::client::resolve_hook_sock(&papers) {
-                    Ok(sock) => exo_node::hooksock::client::client_request(&sock, &req).await,
-                    Err(e) => Err(e),
-                };
-
-                match result {
-                    Ok(verdict) => print!("{}", verdict.stdout),
+                // Fail-open on ANY error: if the sidecar is unreachable there are no tools to
+                // gate, so never wedge the agent. Shape the allow per agent_type.
+                match exo_node::hooksock::client::resolve_hook_sock(&papers) {
+                    Ok(sock) => match exo_node::hooksock::client::client_request(&sock, &req).await
+                    {
+                        Ok(verdict) => print!("{}", verdict.stdout),
+                        Err(e) => {
+                            eprintln!(
+                                "[exomonad] node hook: socket RPC failed ({e}); failing open"
+                            );
+                            print!("{}", fail_open_shape(&papers));
+                        }
+                    },
                     Err(e) => {
                         eprintln!(
-                            "[exomonad] node hook: socket RPC failed ({e}); falling back to in-process policy"
+                            "[exomonad] node hook: cannot resolve hook socket ({e}); failing open"
                         );
-                        let node_event = match hook_event {
-                            exo_caps::HookEvent::PreToolUse => exo_node::HookEvent::PreToolUse,
-                            exo_caps::HookEvent::Stop => exo_node::HookEvent::Stop,
-                            _ => unreachable!(),
-                        };
-                        match exo_node::handle_hook(node_event, &papers, &body).await {
-                            Ok(verdict) => println!("{verdict}"),
-                            Err(fallback_e) => {
-                                eprintln!(
-                                    "[exomonad] node hook: in-process fallback also failed ({fallback_e}); failing open"
-                                );
-                                print!("{}", fail_open_shape(&papers));
-                            }
-                        }
+                        print!("{}", fail_open_shape(&papers));
                     }
                 }
                 return Ok(());

--- a/rust/exomonad/src/main.rs
+++ b/rust/exomonad/src/main.rs
@@ -28,6 +28,20 @@ use tokio::io::AsyncWriteExt;
 use tokio::net::UnixStream;
 use tracing::warn;
 
+/// The allow-shaped hook stdout for a node, by its agent type. Used to fail open when the sidecar
+/// socket is unreachable. Defaults to the Claude allow if papers can't be read (exit 0 is allow
+/// for both harnesses anyway, so this only affects the printed JSON).
+fn fail_open_shape(papers_path: &std::path::Path) -> &'static str {
+    let agent_type = std::fs::read(papers_path)
+        .ok()
+        .and_then(|b| serde_json::from_slice::<exo_caps::NodePapers>(&b).ok())
+        .map(|p| p.role.agent_type());
+    match agent_type {
+        Some(exo_caps::AgentType::Gemini) => "{}",
+        _ => r#"{"continue":true}"#,
+    }
+}
+
 // ============================================================================
 // CLI Types
 // ============================================================================
@@ -198,10 +212,25 @@ async fn main() -> Result<()> {
                 runtime: _,
                 papers,
             } => {
-                let node_event = match event {
-                    HookEventType::PreToolUse => exo_node::HookEvent::PreToolUse,
-                    HookEventType::Stop => exo_node::HookEvent::Stop,
-                    HookEventType::SessionStart => exo_node::HookEvent::SessionStart,
+                use std::io::Read;
+                let mut body = String::new();
+                std::io::stdin().read_to_string(&mut body)?;
+
+                // SessionStart stays one-shot in-process: it needs no live state and must survive
+                // a cold-start race before the sidecar socket is listening.
+                if event == HookEventType::SessionStart {
+                    let verdict =
+                        exo_node::handle_hook(exo_node::HookEvent::SessionStart, &papers, &body)
+                            .await
+                            .context("node session-start hook")?;
+                    println!("{verdict}");
+                    return Ok(());
+                }
+
+                // All other hooks route to the sidecar over its per-agent socket.
+                let hook_event = match event {
+                    HookEventType::PreToolUse => exo_caps::HookEvent::PreToolUse,
+                    HookEventType::Stop => exo_caps::HookEvent::Stop,
                     other => {
                         eprintln!(
                             "[exomonad] node hook: unhandled event {other:?}, passing through"
@@ -210,13 +239,31 @@ async fn main() -> Result<()> {
                         return Ok(());
                     }
                 };
-                let mut body = String::new();
-                use std::io::Read;
-                std::io::stdin().read_to_string(&mut body)?;
-                let verdict = exo_node::handle_hook(node_event, &papers, &body)
-                    .await
-                    .context("node hook")?;
-                println!("{verdict}");
+                let req = exo_caps::HookRequest {
+                    event: hook_event,
+                    stdin_json: body,
+                };
+
+                // Fail-open on ANY error: if the sidecar is unreachable there are no tools to
+                // gate, so never wedge the agent. Shape the allow per agent_type.
+                match exo_node::hooksock::client::resolve_hook_sock(&papers) {
+                    Ok(sock) => match exo_node::hooksock::client::client_request(&sock, &req).await
+                    {
+                        Ok(verdict) => print!("{}", verdict.stdout),
+                        Err(e) => {
+                            eprintln!(
+                                "[exomonad] node hook: socket RPC failed ({e}); failing open"
+                            );
+                            print!("{}", fail_open_shape(&papers));
+                        }
+                    },
+                    Err(e) => {
+                        eprintln!(
+                            "[exomonad] node hook: cannot resolve hook socket ({e}); failing open"
+                        );
+                        print!("{}", fail_open_shape(&papers));
+                    }
+                }
                 return Ok(());
             }
         },

--- a/rust/exomonad/src/main.rs
+++ b/rust/exomonad/src/main.rs
@@ -37,7 +37,7 @@ fn fail_open_shape(papers_path: &std::path::Path) -> &'static str {
         .and_then(|b| serde_json::from_slice::<exo_caps::NodePapers>(&b).ok())
         .map(|p| p.role.agent_type());
     match agent_type {
-        Some(exo_caps::AgentType::Gemini) => "{}",
+        Some(exo_caps::AgentType::Gemini) => r#"{"decision":"allow"}"#,
         _ => r#"{"continue":true}"#,
     }
 }
@@ -235,33 +235,42 @@ async fn main() -> Result<()> {
                         eprintln!(
                             "[exomonad] node hook: unhandled event {other:?}, passing through"
                         );
-                        println!("{{\"continue\": true}}");
+                        print!("{}", fail_open_shape(&papers));
                         return Ok(());
                     }
                 };
+
                 let req = exo_caps::HookRequest {
                     event: hook_event,
-                    stdin_json: body,
+                    stdin_json: body.clone(),
                 };
 
-                // Fail-open on ANY error: if the sidecar is unreachable there are no tools to
-                // gate, so never wedge the agent. Shape the allow per agent_type.
-                match exo_node::hooksock::client::resolve_hook_sock(&papers) {
-                    Ok(sock) => match exo_node::hooksock::client::client_request(&sock, &req).await
-                    {
-                        Ok(verdict) => print!("{}", verdict.stdout),
-                        Err(e) => {
-                            eprintln!(
-                                "[exomonad] node hook: socket RPC failed ({e}); failing open"
-                            );
-                            print!("{}", fail_open_shape(&papers));
-                        }
-                    },
+                // Route to socket, fallback to in-process if unreachable or times out.
+                let result = match exo_node::hooksock::client::resolve_hook_sock(&papers) {
+                    Ok(sock) => exo_node::hooksock::client::client_request(&sock, &req).await,
+                    Err(e) => Err(e),
+                };
+
+                match result {
+                    Ok(verdict) => print!("{}", verdict.stdout),
                     Err(e) => {
                         eprintln!(
-                            "[exomonad] node hook: cannot resolve hook socket ({e}); failing open"
+                            "[exomonad] node hook: socket RPC failed ({e}); falling back to in-process policy"
                         );
-                        print!("{}", fail_open_shape(&papers));
+                        let node_event = match hook_event {
+                            exo_caps::HookEvent::PreToolUse => exo_node::HookEvent::PreToolUse,
+                            exo_caps::HookEvent::Stop => exo_node::HookEvent::Stop,
+                            _ => unreachable!(),
+                        };
+                        match exo_node::handle_hook(node_event, &papers, &body).await {
+                            Ok(verdict) => println!("{verdict}"),
+                            Err(fallback_e) => {
+                                eprintln!(
+                                    "[exomonad] node hook: in-process fallback also failed ({fallback_e}); failing open"
+                                );
+                                print!("{}", fail_open_shape(&papers));
+                            }
+                        }
                     }
                 }
                 return Ok(());


### PR DESCRIPTION
This PR implements the hook-RPC client and rewires the `exomonad experimental hook` CLI arm.

Addressing final corrections:
- Reverted the in-process `handle_hook` fallback in `rust/exomonad/src/main.rs`. Correctness requirement: on socket failure, the behavior must be fail-open to avoid bypassing the safety nets (e.g., Gemini Stop deny loop prevention) and to maintain a single code path.
- Updated `fail_open_shape` for Gemini nodes to return `"{}"` (matching the sidecar server's allow shape).
- Cleaned up `body.clone()` as it's no longer needed.
- Maintained the 5s timeout and fail-open routing for all events except `SessionStart`.
- Verified with build, clippy, and fmt.