### PR TITLE
Subtree B: Stop → notify parent (per-role stop hooks + ChildIdle render)

### DIFF
--- a/rust/exo-node/CLAUDE.md
+++ b/rust/exo-node/CLAUDE.md
@@ -25,6 +25,7 @@ Assembles `exo-runtime` (all caps) + `exo-policy` (tools/hooks/roles) into a run
 
 - **`Chat` / `Event`** → `dispatch::dispatch` (last-hop deliver, rendered with a `[from: X, kind: Y]` header).
 - **`Control(Shutdown{grace_ms})`** → sleep the grace, then `Tmux::kill_pane` on the node's **own** pane — reaping pane + agent + sidecar in one shot.
+- **`System(SystemMessage)`** → `handle_system` (sidecar-consumed, never shown to the LLM unless it decides to act). A **review verdict** (`ReviewApproved`/`Denied`/`Changes`) from a one-shot reviewer is applied via `apply_verdict`, then that reviewer is torn down (`kill_pane` + `reclaim_worktree`) — teardown is **verdict-only**. A **`ChildIdle`** from a live child finishing a turn is rendered as a concise line (`render_child_idle`, preserving the child's `from`) and the child is **never** torn down. This render is the parent-side seam where idle-signal refinement (dedupe, richer state) will land.
 
 ## Native Teams delivery (the hard-won part)
 

--- a/rust/exo-node/src/inbound.rs
+++ b/rust/exo-node/src/inbound.rs
@@ -168,35 +168,67 @@ impl InboundHandler for RealHandler {
 }
 
 impl RealHandler {
-    /// Route a [`SystemMessage`] (sidecar-side; never injected into the LLM directly), then
-    /// reclaim the sender. A review verdict comes from a one-shot reviewer that is this node's
-    /// own `Worktree` child — it's done after the verdict, and its branch never merges, so
-    /// `teardown-on-merge` would miss it. Reclaim it here, best-effort, regardless of the verdict
-    /// outcome. (Assumes the reviewer is one-shot; revisit if the two-way reviewer back-channel
-    /// from #935's follow-ups lands.)
+    /// Route a [`SystemMessage`] (sidecar-side; never injected into the LLM directly).
+    ///
+    /// A **review verdict** comes from a one-shot reviewer that is this node's own `Worktree`
+    /// child — it's done after the verdict, and its branch never merges, so `teardown-on-merge`
+    /// would miss it. Apply the verdict, then reclaim that reviewer here, best-effort, regardless
+    /// of outcome. A **`ChildIdle`** comes from a LIVE child finishing a turn — render it and do
+    /// NOT tear the child down.
     async fn handle_system(
         &self,
         from: &Persona,
         system: &exo_caps::SystemMessage,
     ) -> NodeResult<()> {
-        let result = self.apply_verdict(system).await;
-
-        if let Persona::Agent(reviewer) = from {
-            if let Err(e) = exo_caps::Spawner::kill_pane(&*self.ctx.runtime, reviewer).await {
-                warn!(
-                    "reviewer teardown: kill_pane({}) failed: {e}",
-                    reviewer.as_str()
-                );
-            }
-            if let Err(e) = exo_caps::Spawner::reclaim_worktree(&*self.ctx.runtime, reviewer).await
-            {
-                warn!(
-                    "reviewer teardown: reclaim_worktree({}) failed: {e}",
-                    reviewer.as_str()
-                );
+        use exo_caps::SystemMessage;
+        match system {
+            // A live child yielded control. Render a concise line for this node's LLM; never tear
+            // the child down. (v1: no dedupe — volume is accepted; the refine-later seam is here.)
+            SystemMessage::ChildIdle { summary } => self.render_child_idle(from, summary).await,
+            // Review verdicts: apply, then reclaim the one-shot reviewer (verdict-only teardown).
+            SystemMessage::ReviewApproved { .. }
+            | SystemMessage::ReviewDenied { .. }
+            | SystemMessage::ReviewChanges { .. } => {
+                let result = self.apply_verdict(system).await;
+                if let Persona::Agent(reviewer) = from {
+                    if let Err(e) = exo_caps::Spawner::kill_pane(&*self.ctx.runtime, reviewer).await
+                    {
+                        warn!(
+                            "reviewer teardown: kill_pane({}) failed: {e}",
+                            reviewer.as_str()
+                        );
+                    }
+                    if let Err(e) =
+                        exo_caps::Spawner::reclaim_worktree(&*self.ctx.runtime, reviewer).await
+                    {
+                        warn!(
+                            "reviewer teardown: reclaim_worktree({}) failed: {e}",
+                            reviewer.as_str()
+                        );
+                    }
+                }
+                result
             }
         }
-        result
+    }
+
+    /// Render a concise \"child yielded control\" line into THIS node's LLM. The sender is a LIVE
+    /// child (not a one-shot reviewer), so it is NOT torn down. Preserves the child's identity as
+    /// `from` so the dispatch header attributes the line correctly.
+    async fn render_child_idle(&self, from: &Persona, summary: &str) -> NodeResult<()> {
+        let entry = IngestionEntry {
+            v: 1,
+            ts: Utc::now(),
+            from: from.clone(),
+            msg: Message {
+                text: MessageBody::new(format!("[child idle] {summary}"))
+                    .map_err(|e| std::io::Error::other(e.to_string()))?,
+                summary: Summary::new("[child idle]".into())
+                    .map_err(|e| std::io::Error::other(e.to_string()))?,
+                kind: MessageKind::Chat,
+            },
+        };
+        crate::dispatch::dispatch(&self.ctx, &entry).await
     }
 
     /// Act on a review verdict (escalate `[READY]` on a matching approval; wake the LLM on
@@ -266,11 +298,9 @@ impl RealHandler {
                     changes_branch.as_str(), message
                 )).await
             }
-            // Scaffold stub: leaf B3 restructures `handle_system` so ChildIdle is routed to its
-            // own render path (and the reviewer teardown becomes verdict-only). Until then no node
-            // emits ChildIdle, so this arm is unreached; render it as a fallback rather than panic.
-            SystemMessage::ChildIdle { summary } => {
-                self.deliver_to_llm(&format!("[child idle] {summary}")).await
+            // `ChildIdle` is intercepted in `handle_system` and never routed here.
+            SystemMessage::ChildIdle { .. } => {
+                unreachable!("ChildIdle is handled in handle_system, never reaches apply_verdict")
             }
         }
     }

--- a/rust/exo-policy/CLAUDE.md
+++ b/rust/exo-policy/CLAUDE.md
@@ -44,11 +44,11 @@ one entry.
 
 | Role | agent | tools | stop gate |
 |------|-------|-------|-----------|
-| **Root** | Claude | fork_wave, spawn_gemini, spawn_worker, merge, send_message | `stop_allow` (never gate the human's session) |
-| **Tl** | Claude | spawns, merge, notify_parent, send_message, submit_branch | `stop` (clean-gate) |
-| **Dev** | Gemini | notify_parent, submit_branch | `stop` (clean-gate) |
-| **Worker** | Gemini | notify_parent | `stop_allow` (inline child, no own branch to submit) |
-| **Reviewer** | Gemini | verdict, notify_parent | `stop_allow` (ephemeral; reviews a branch off its own worktree, then exits) |
+| **Root** | Claude | fork_wave, spawn_gemini, spawn_worker, merge, send_message | `stop_allow` (never gate the human's session; no parent to notify) |
+| **Tl** | Claude | spawns, merge, notify_parent, send_message, submit_branch | `stop` (clean-gate + notify parent on clean-allow) |
+| **Dev** | Gemini | notify_parent, submit_branch | `stop_notify` (notify parent, always allow — never block Gemini) |
+| **Worker** | Gemini | notify_parent | `stop_notify` (inline child, no branch to fold, but still signals on yield) |
+| **Reviewer** | Gemini | verdict, notify_parent | `stop_allow` (ephemeral; its `verdict` is already its done-signal) |
 
 ## The review gate (how `submit_branch` → `merge` is gated)
 
@@ -67,8 +67,12 @@ tool that skips review. (System messages are a general sidecar-consumed primitiv
 ## The hooks
 
 - **`pre_tool_use`** — default-**ALLOW** antipattern *nudge* (NOT a security gate). Currently one rule: deny `git add .` / `git add -A` (stage by path). Can `Deny` with guidance or `Modify` to rewrite.
-- **`stop`** — the **local convergence gate** (`R: Git + Log`). Blocks exit while the worktree is dirty: a parent folds a child by merging its *branch* off disk, so uncommitted work is invisible to that merge. **Fails OPEN** on any error — a hook must never wedge an agent's turn-loop (that bricks the session). Root/Worker use `stop_allow` (nothing to fold).
+- **`stop`** (tl) — the **local convergence gate** (`R: Git + Log + Bus`). Blocks exit while the worktree is dirty: a parent folds a child by merging its *branch* off disk, so uncommitted work is invisible to that merge. On a **clean** exit (Allow) it delivers a `System(ChildIdle)` to the parent — the turn-end "yielding control" signal so a TL no longer has to poke idle children. **Fails OPEN** on any git error — a hook must never wedge an agent's turn-loop (that bricks the session); the error-fallback Allow does not notify (state unknown).
+- **`stop_notify`** (dev, worker) — Gemini turn-end hook (`R: Bus + Log`): deliver `System(ChildIdle)` to the parent, then **always Allow**. **Never blocks** — Gemini's `AfterAgent` `deny` can infinite-loop (gemini-cli #20426). The committed-before-fold guarantee for a dev is enforced by `submit_branch`'s committed-check, not here.
+- **`stop_allow`** (root, reviewer) — unconditional Allow. Root has no parent; the reviewer's `verdict` is its done-signal.
 - **`session_start`** — identity bootstrap (the node-identity context is prepended by `exo-node`).
+
+The `ChildIdle` notification is deliberately minimal (v1: notify on every stop, no dedupe — volume accepted). Refinement (dedupe, richer state from the hook payload) lands parent-side in `exo-node`'s `handle_system`, not by growing the message.
 
 ## Gaps / not-yet
 

--- a/rust/exo-policy/src/hooks.rs
+++ b/rust/exo-policy/src/hooks.rs
@@ -148,9 +148,9 @@ pub fn stop<'a, R: Git + Log + Bus + Send + Sync>(ctx: &'a R) -> BoxFuture<'a, S
     })
 }
 
-/// Stop hook for nodes that never file a PR (root, worker): always allow exit — there is
-/// nothing to gate on, and querying GitHub would be pointless (and could wedge). The root
-/// especially must never be gated: blocking it bricks the human's session.
+/// Unconditional-allow stop hook (root, reviewer): nothing to fold and no parent to notify, so
+/// always allow exit. The root especially must never be gated — blocking it bricks the human's
+/// session; the reviewer's `verdict` is already its done-signal.
 pub fn stop_allow<R: Send + Sync>(_ctx: &R) -> BoxFuture<'_, StopDecision> {
     Box::pin(async move { StopDecision::Allow })
 }

--- a/rust/exo-policy/src/hooks.rs
+++ b/rust/exo-policy/src/hooks.rs
@@ -12,7 +12,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::tool::BoxFuture;
-use exo_caps::{Git, Log};
+use exo_caps::{
+    Addressee, Bus, CapResult, Git, Log, Message, MessageBody, MessageKind, Summary, SystemMessage,
+};
 
 /// A `PreToolUse` verdict. `Modify` rewrites the tool input in place (the PII-rewrite path).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -87,14 +89,49 @@ pub fn pre_tool_use<'a, R: Send + Sync>(
     })
 }
 
-/// The local convergence gate (v2 — no GitHub). A parent folds a child by merging its
-/// **branch** off disk, so uncommitted work is invisible to that merge. Block exit while the
-/// worktree is dirty — the agent must commit (or discard) before it stops. Fail OPEN on any
-/// error: a hook must never wedge an agent in its turn-loop (that bricks the session).
-pub fn stop<'a, R: Git + Log + Send + Sync>(ctx: &'a R) -> BoxFuture<'a, StopDecision> {
+/// Build the [`ChildIdle`](SystemMessage::ChildIdle) a non-root node delivers to its parent at
+/// turn-end. Minimal by design (v1): a fixed human-readable summary the parent's `handle_system`
+/// renders. Refinement (dedupe, richer state from the hook payload) lands parent-side later, not
+/// by growing this message.
+fn child_idle_message() -> CapResult<Message> {
+    let summary = "finished a turn and is yielding control";
+    Ok(Message {
+        text: MessageBody::new(format!("[idle] {summary}"))?,
+        summary: Summary::new(summary.into())?,
+        kind: MessageKind::System(SystemMessage::ChildIdle {
+            summary: summary.into(),
+        }),
+    })
+}
+
+/// Best-effort turn-end signal: deliver a `ChildIdle` to the parent. Logs and swallows any error
+/// — a stop hook must never fail an agent's exit over a missed notification. Root has no parent,
+/// so it never calls this (it uses `stop_allow`).
+async fn notify_parent_idle<R: Bus + Log>(ctx: &R) {
+    match child_idle_message() {
+        Ok(msg) => {
+            if let Err(e) = ctx.deliver(Addressee::Parent, msg).await {
+                ctx.error(&format!("stop hook: failed to notify parent of idle: {e}"));
+            }
+        }
+        Err(e) => ctx.error(&format!(
+            "stop hook: could not build ChildIdle message: {e}"
+        )),
+    }
+}
+
+/// The local convergence gate for a spawned TL (v2 — no GitHub). A parent folds a child by
+/// merging its **branch** off disk, so uncommitted work is invisible to that merge: block exit
+/// while the worktree is dirty (commit or discard first). On a clean exit the node is yielding
+/// control, so notify the parent it went idle. Fails OPEN on any git error — a hook must never
+/// wedge an agent in its turn-loop (that bricks the session).
+pub fn stop<'a, R: Git + Log + Bus + Send + Sync>(ctx: &'a R) -> BoxFuture<'a, StopDecision> {
     Box::pin(async move {
         match ctx.is_clean().await {
-            Ok(true) => StopDecision::Allow,
+            Ok(true) => {
+                notify_parent_idle(ctx).await;
+                StopDecision::Allow
+            }
             Ok(false) => StopDecision::Block {
                 reason: "Uncommitted changes in your worktree. Commit your work (a parent merges \
                          your branch off disk — uncommitted changes are invisible to that merge), \
@@ -118,6 +155,18 @@ pub fn stop_allow<R: Send + Sync>(_ctx: &R) -> BoxFuture<'_, StopDecision> {
     Box::pin(async move { StopDecision::Allow })
 }
 
+/// Stop hook for Gemini leaves (dev, worker): notify the parent this node yielded control, then
+/// ALWAYS allow exit. It NEVER blocks — Gemini's `AfterAgent` `deny` can infinite-loop
+/// (gemini-cli #20426), so a Gemini role must not block at stop. The committed-before-fold
+/// guarantee for a dev is enforced by `submit_branch`'s committed-check, not here; a worker is
+/// inline with no branch to fold.
+pub fn stop_notify<'a, R: Bus + Log + Send + Sync>(ctx: &'a R) -> BoxFuture<'a, StopDecision> {
+    Box::pin(async move {
+        notify_parent_idle(ctx).await;
+        StopDecision::Allow
+    })
+}
+
 pub fn session_start<'a, R: Send + Sync>(_ctx: &'a R) -> BoxFuture<'a, SessionStartOutput> {
     Box::pin(async move {
         // Root identity bootstrap context injection goes here (additional_context).
@@ -128,8 +177,55 @@ pub fn session_start<'a, R: Send + Sync>(_ctx: &'a R) -> BoxFuture<'a, SessionSt
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::testing::MockRuntime;
+    use crate::testing::{Call, MockRuntime};
     use serde_json::json;
+
+    fn delivered_child_idle_to_parent(calls: &[Call]) -> bool {
+        calls.iter().any(|c| {
+            matches!(
+                c,
+                Call::BusDeliver { to: Addressee::Parent, msg }
+                    if matches!(msg.kind, MessageKind::System(SystemMessage::ChildIdle { .. }))
+            )
+        })
+    }
+
+    #[tokio::test]
+    async fn test_stop_notifies_parent_on_clean_allow() {
+        let ctx = MockRuntime::default(); // is_clean = true
+        assert_eq!(stop(&ctx).await, StopDecision::Allow);
+        assert!(
+            delivered_child_idle_to_parent(&ctx.calls_made()),
+            "clean stop should notify parent of idle"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_stop_block_when_dirty_does_not_notify() {
+        let ctx = MockRuntime {
+            is_clean: false,
+            ..Default::default()
+        };
+        assert!(matches!(stop(&ctx).await, StopDecision::Block { .. }));
+        assert!(
+            !delivered_child_idle_to_parent(&ctx.calls_made()),
+            "a blocked (still-working) node must not notify idle"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_stop_notify_allows_and_notifies() {
+        let ctx = MockRuntime::default();
+        assert_eq!(stop_notify(&ctx).await, StopDecision::Allow);
+        assert!(delivered_child_idle_to_parent(&ctx.calls_made()));
+    }
+
+    #[tokio::test]
+    async fn test_stop_notify_never_blocks_even_if_deliver_fails() {
+        let ctx = MockRuntime::failing("deliver");
+        // Even when the bus delivery errors, a Gemini stop must allow exit (never block).
+        assert_eq!(stop_notify(&ctx).await, StopDecision::Allow);
+    }
 
     #[test]
     fn hook_decision_serde_is_tagged() {

--- a/rust/exo-policy/src/roles.rs
+++ b/rust/exo-policy/src/roles.rs
@@ -11,8 +11,8 @@
 
 use crate::caps::PolicyCaps;
 use crate::hooks::{
-    pre_tool_use, session_start, stop, stop_allow, HookDecision, HookInput, SessionStartOutput,
-    StopDecision,
+    pre_tool_use, session_start, stop, stop_allow, stop_notify, HookDecision, HookInput,
+    SessionStartOutput, StopDecision,
 };
 use crate::tool::{BoxFuture, Tool};
 use crate::tools::merge::Merge;
@@ -79,20 +79,20 @@ pub fn role_def<R: PolicyCaps>(kind: NodeKind) -> RoleDef<R> {
             stop,
             session_start,
         },
-        // A dev leaf works on its own branch and submits it for the parent to merge.
+        // A dev leaf works on its own branch and submits it for the parent to merge. It NEVER blocks at
+        // stop (Gemini #20426); the committed-before-fold guarantee is enforced by submit_branch.
         NodeKind::Dev => RoleDef {
             tools: vec![Box::new(NotifyParent), Box::new(SubmitBranch)],
             pre_tool_use,
-            stop,
+            stop: stop_notify,
             session_start,
         },
-        // A worker is an inline child sharing the parent's worktree — it has no own branch to
-        // submit, so it only reports back.
+        // A worker is an inline child sharing the parent's worktree — no own branch to submit, so it
+        // only reports back, but it still signals the parent when it yields control.
         NodeKind::Worker => RoleDef {
             tools: vec![Box::new(NotifyParent)],
             pre_tool_use,
-            // Workers are ephemeral and commit nothing to fold — nothing to gate on.
-            stop: stop_allow,
+            stop: stop_notify,
             session_start,
         },
         // A reviewer reads the under-review branch and emits a `verdict`, then exits. It does not
@@ -129,12 +129,16 @@ mod tests {
                 rd.pre_tool_use as usize,
                 pre_tool_use::<MockRuntime> as *const () as usize
             );
-            // Root/Worker never file a PR → no gate (stop_allow); Tl/Dev gate via `stop`.
+            // Root/Reviewer never yield work to fold → stop_allow. Dev/Worker (Gemini) notify the
+            // parent then allow (never block). Tl keeps the dirty-gate (stop).
             let expected_stop = match kind {
-                NodeKind::Root | NodeKind::Worker | NodeKind::Reviewer => {
+                NodeKind::Root | NodeKind::Reviewer => {
                     stop_allow::<MockRuntime> as *const () as usize
                 }
-                NodeKind::Tl | NodeKind::Dev => stop::<MockRuntime> as *const () as usize,
+                NodeKind::Dev | NodeKind::Worker => {
+                    stop_notify::<MockRuntime> as *const () as usize
+                }
+                NodeKind::Tl => stop::<MockRuntime> as *const () as usize,
             };
             assert_eq!(rd.stop as usize, expected_stop, "Role {:?} stop fn", kind);
             assert_eq!(
@@ -146,7 +150,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_role_stop_gate_blocks_when_dirty() {
-        let rd = role_def::<MockRuntime>(NodeKind::Dev);
+        let rd = role_def::<MockRuntime>(NodeKind::Tl);
         let ctx = MockRuntime {
             is_clean: false,
             ..Default::default()

--- a/rust/exo-policy/src/roles.rs
+++ b/rust/exo-policy/src/roles.rs
@@ -120,6 +120,7 @@ mod tests {
             NodeKind::Tl,
             NodeKind::Dev,
             NodeKind::Worker,
+            NodeKind::Reviewer,
         ] {
             let rd = role_def::<MockRuntime>(kind);
             assert!(!rd.tools.is_empty(), "Role {:?} should have tools", kind);


### PR DESCRIPTION
## Subtree B — "Stop → notify parent" (Wave-1, plan: foamy-dancing-parnas)

The turn-end signal: when a non-root node finishes a turn and yields control, its stop hook delivers a `System(ChildIdle)` to the parent over the bus — so a TL no longer has to poke idle children. Deliberately minimal (v1: notify on every stop, no dedupe); refinement lands parent-side later in `handle_system`.

### What changed

**B1 — `exo-policy/src/hooks.rs`** (folded via #937)
- `stop` (tl): keeps the dirty-gate `Block`; on a **clean** Allow now delivers `System(ChildIdle)` to the parent. Gains a `Bus` bound. Fails OPEN on git error (no notify on the error-fallback Allow).
- New `stop_notify` (dev, worker): notify parent + **always Allow, never Block** — Gemini's `AfterAgent` `deny` can infinite-loop (gemini-cli #20426).
- Helpers `child_idle_message()` + `notify_parent_idle()` (best-effort; logs and swallows delivery errors).
- 4 new unit tests vs `MockRuntime` (clean-notify, dirty-no-notify, stop_notify allow+notify, never-block-on-deliver-fail).

**B2 — `exo-policy/src/roles.rs`** (folded via #937)
- Role→stop wiring: Root→`stop_allow`, Tl→`stop`, Dev→`stop_notify`, Worker→`stop_notify`, Reviewer→`stop_allow`.
- Fixed role tests (pointer-equality mapping + dirty-gate test now targets Tl, since Dev no longer blocks).

**B3 — `exo-node/src/inbound.rs`** (folded via #940)
- `handle_system` restructured: reviewer teardown (`kill_pane` + `reclaim_worktree`) is now **verdict-only** — it no longer tears down the sender of *any* system message. Fixes the bug where a live `ChildIdle` sender would have been reclaimed.
- New `render_child_idle` renders a concise `[child idle] …` line via dispatch, preserving the child's `from`; the child is **never** torn down.
- Per Copilot review, the verdict path matches the three verdict variants explicitly (not a `_` catch-all), so a future `SystemMessage` variant can't accidentally hit teardown.

**Docs:** updated `exo-policy/CLAUDE.md` (Roles table + hooks section) and `exo-node/CLAUDE.md` (inbound `System` routing).

### Verification (integration gate, after both leaf PRs folded)
- `cargo build -p exo-policy -p exo-node` ✓
- `cargo clippy -p exo-policy -p exo-node --all-targets` ✓ (clean)
- `cargo test -p exo-policy -p exo-node` ✓ (36 exo-policy tests incl. the 4 new; exo-node green)

### Notes / scope boundary
- Disjoint from Subtree A (socket channel) — touched only `exo-policy/{hooks,roles}.rs`, `exo-node/inbound.rs`, and the two CLAUDE.md files. Did not touch hooksock/, main.rs, spawner, or run_node.
- No new exo-node unit test for the `handle_system` round-trip — that's the Wave-2 integration test (real Runtime + tempdir), per the plan. The bug fix is covered by compile-time exhaustiveness + the verdict-only teardown structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)