### PR TITLE
Subtree A: generic per-agent hook-RPC socket (N5)

### DIFF
--- a/rust/exo-caps/src/invocation.rs
+++ b/rust/exo-caps/src/invocation.rs
@@ -20,6 +20,15 @@ pub const PRE_TOOL_USE: &str = "pre-tool-use";
 pub const STOP: &str = "stop";
 pub const SESSION_START: &str = "session-start";
 
+/// Gemini CLI `settings.json` hook KEYS — the harness event names, distinct from the CLI event
+/// args above ([`PRE_TOOL_USE`]/[`STOP`]/[`SESSION_START`]). `AfterAgent` is Gemini's turn-end
+/// (the `Stop` equivalent); `BeforeTool` is its pre-tool event; `SessionStart` mirrors Claude.
+/// A Gemini hook entry maps one of these keys to the same `exomonad experimental hook <arg>`
+/// command — so `AfterAgent` runs `... hook stop`, `BeforeTool` runs `... hook pre-tool-use`.
+pub const GEMINI_AFTER_AGENT: &str = "AfterAgent";
+pub const GEMINI_BEFORE_TOOL: &str = "BeforeTool";
+pub const GEMINI_SESSION_START: &str = "SessionStart";
+
 /// MCP sidecar args for a child's `.mcp.json` (the `"command"` is [`BIN`]):
 /// `exomonad experimental node --papers <papers>`.
 pub fn node_args(papers: &str) -> [String; 4] {

--- a/rust/exo-node/CLAUDE.md
+++ b/rust/exo-node/CLAUDE.md
@@ -12,6 +12,7 @@ Assembles `exo-runtime` (all caps) + `exo-policy` (tools/hooks/roles) into a run
 |--------|------|------|
 | `outbound` (N1) | serve | Serve `role_def(kind).tools` as MCP over stdio (`tools/list` emits each tool's `name`/`description`/`inputSchema`, so the toolset is self-documenting). **Owns stdin/stdout → the node's lifetime anchor** (when it closes, the node ends). |
 | `inbound` (N2b) | watch | Watch the node's own ingestion inbox (byte-offset cursor + `notify` watch), route each new entry. |
+| `hooksock` (N5) | serve | Per-agent UDS hook-RPC channel — runs the role hook fn on the live runtime and shapes the verdict per agent_type (never a Gemini Stop deny). |
 | `dispatch` (N2a) | — | The **last hop**: deliver one entry into the agent's native interface (Teams inbox or tmux paste). |
 | `hook` (N4) | one-shot | `exomonad experimental hook <event>` → bootstrap from papers → run the role's `pre_tool_use`/`stop`/`session_start` → print the verdict. No server. |
 | `bootstrap` | — | Self-ID: read `--papers` → `NodePapers`, enrich with ambient env (`$TMUX_PANE`, `EXOMONAD_SWARM_RUN_ID`, `EXOMONAD_TMUX_SESSION`, `$HOME`), build `NodeContext { runtime, kind, own_inbox, parent_inbox, ... }`. |

--- a/rust/exo-node/src/hooksock/client.rs
+++ b/rust/exo-node/src/hooksock/client.rs
@@ -1,18 +1,67 @@
 //! Hook-RPC client — the short-lived `exomonad experimental hook` process.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
 
-use exo_caps::{HookRequest, HookVerdict};
+use exo_caps::{HookRequest, HookVerdict, NodePapers};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::UnixStream;
+use tokio::time::timeout;
 
-use crate::error::NodeResult;
+use crate::error::{NodeError, NodeResult};
 
 /// Connect to a node's hook socket, send one [`HookRequest`], return the [`HookVerdict`]. The
-/// caller (`exomonad experimental hook`) prints `verdict.stdout` verbatim and exits 0. On a
-/// connect failure the caller must **fail open** (print the allow-shape for its agent type and
-/// exit 0) — the sidecar being down means there are no tools to gate anyway.
+/// caller prints `verdict.stdout` verbatim and exits 0. On any failure the caller must **fail
+/// open** — the sidecar being down means there are no tools to gate anyway.
 ///
-/// **Status: Wave-0 stub.** Body lands in leaf A2 (reuse the `uds_client.rs` hyper-over-UnixStream
-/// pattern; this is a tiny JSON request/response).
-pub async fn client_request(_sock: &Path, _req: &HookRequest) -> NodeResult<HookVerdict> {
-    todo!("A2: connect UDS, send HookRequest JSON, read HookVerdict JSON")
+/// Framing: write the request JSON, half-close the write side (EOF signals end-of-request to the
+/// server), then read the response JSON to EOF.
+pub async fn client_request(sock: &Path, req: &HookRequest) -> NodeResult<HookVerdict> {
+    let verdict = timeout(Duration::from_secs(5), async {
+        let mut stream = UnixStream::connect(sock).await?;
+        let bytes = serde_json::to_vec(req)
+            .map_err(|e| std::io::Error::other(format!("encode HookRequest: {e}")))?;
+        stream.write_all(&bytes).await?;
+        stream.shutdown().await?;
+
+        let mut resp = Vec::new();
+        stream.read_to_end(&mut resp).await?;
+        let verdict: HookVerdict = serde_json::from_slice(&resp).map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("decode HookVerdict: {e}"),
+            )
+        })?;
+        Ok::<HookVerdict, NodeError>(verdict)
+    })
+    .await
+    .map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            format!("hook socket RPC timed out for {}", sock.display()),
+        )
+    })??;
+
+    Ok(verdict)
+}
+
+/// Resolve this node's hook socket path from its papers + ambient run env, identically to how the
+/// sidecar's server binds it (both go through [`exo_caps::paths::hook_sock`], so they always
+/// agree). The pane comes from papers; the run-id and home from the env the parent set at spawn.
+pub fn resolve_hook_sock(papers_path: &Path) -> NodeResult<PathBuf> {
+    let bytes = std::fs::read(papers_path)?;
+    let papers: NodePapers = serde_json::from_slice(&bytes).map_err(|e| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("parse papers {}: {e}", papers_path.display()),
+        )
+    })?;
+    let run_id = std::env::var("EXOMONAD_SWARM_RUN_ID")
+        .map_err(|_| NodeError::MissingContext("EXOMONAD_SWARM_RUN_ID"))?;
+    let home = std::env::var("HOME").map_err(|_| NodeError::MissingContext("HOME"))?;
+    Ok(exo_caps::paths::hook_sock(
+        Path::new(&home),
+        &run_id,
+        &papers.pane,
+    ))
 }

--- a/rust/exo-node/src/hooksock/server.rs
+++ b/rust/exo-node/src/hooksock/server.rs
@@ -1,22 +1,191 @@
 //! Hook-RPC server (N5) — runs in the sidecar, sharing `ctx.runtime` with the other loops.
 
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
 use std::sync::Arc;
 
+use exo_caps::{AgentType, HookEvent, HookRequest, HookVerdict};
+use exo_policy::{role_def, HookDecision, HookInput, RoleDef, StopDecision};
+use serde_json::json;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{UnixListener, UnixStream};
+use tracing::{info, warn};
+
 use crate::bootstrap::NodeContext;
-use crate::error::NodeResult;
+use crate::error::{NodeError, NodeResult};
 
 /// Serve the per-agent hook-RPC socket. Binds `paths::hook_sock(home, run_id, own_pane)`
 /// (remove-before-bind to clear a stale socket, then `0o600`), accepts connections, and for each
 /// [`HookRequest`](exo_caps::HookRequest) runs the role's hook fn against the **live**
-/// `ctx.runtime` (NOT a fresh `bootstrap()` Runtime — sharing the live one is the whole point),
-/// then replies with a [`HookVerdict`](exo_caps::HookVerdict) whose `stdout` is already shaped
-/// for the node's `agent_type` (Claude vs Gemini; **never a Gemini Stop `deny`** — Gemini
-/// `AfterAgent` deny can infinite-loop, gemini-cli #20426).
+/// `ctx.runtime` (NOT a fresh `bootstrap()` Runtime), then replies with a
+/// [`HookVerdict`](exo_caps::HookVerdict) shaped for the node's `agent_type` — **never a Gemini
+/// Stop `deny`** (gemini-cli #20426 can infinite-loop on `AfterAgent` deny).
 ///
 /// Spawned as a background task by [`run_node`](crate::run_node) and aborted when the outbound
-/// serve loop (the lifetime anchor) returns; an error here is logged, never fatal.
-///
-/// **Status: Wave-0 stub.** Body lands in leaf A1 (reuse the `serve.rs` `UnixListener` pattern).
-pub async fn serve(_ctx: Arc<NodeContext>) -> NodeResult<()> {
-    todo!("A1: remove-before-bind hook_sock + 0o600; accept loop; per-conn read HookRequest, run role_def(ctx.kind).<event> on ctx.runtime, shape verdict per agent_type, write HookVerdict")
+/// serve loop returns; an error here is logged, never fatal.
+pub async fn serve(ctx: Arc<NodeContext>) -> NodeResult<()> {
+    let home = std::env::var("HOME").map_err(|_| NodeError::MissingContext("HOME"))?;
+    let sock = exo_caps::paths::hook_sock(Path::new(&home), &ctx.run_id, &ctx.own_pane);
+
+    if let Some(parent) = sock.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    // Remove a stale socket so bind() can't fail with EADDRINUSE. NotFound is fine.
+    match std::fs::remove_file(&sock) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => return Err(e.into()),
+    }
+
+    let listener = UnixListener::bind(&sock)?;
+    std::fs::set_permissions(&sock, std::fs::Permissions::from_mode(0o600))?;
+    info!(socket = %sock.display(), "hooksock: listening");
+
+    loop {
+        let (stream, _addr) = listener.accept().await?;
+        let ctx = ctx.clone();
+        tokio::spawn(async move {
+            if let Err(e) = handle_conn(ctx, stream).await {
+                warn!("hooksock: connection handler error: {e}");
+            }
+        });
+    }
+}
+
+/// One request/response cycle. The client writes a `HookRequest` then half-closes its write side;
+/// we read to EOF, run the hook, write the `HookVerdict`, and close.
+async fn handle_conn(ctx: Arc<NodeContext>, stream: UnixStream) -> NodeResult<()> {
+    let mut buf = Vec::new();
+    // Read up to 64KB with a 2-second timeout to prevent memory exhaustion and deadlocks.
+    // The client MUST half-close its write side for us to see EOF.
+    let mut limited = stream.take(64 * 1024);
+    let read_fut = limited.read_to_end(&mut buf);
+    match tokio::time::timeout(std::time::Duration::from_secs(2), read_fut).await {
+        Ok(Ok(_)) => {}
+        Ok(Err(e)) => return Err(e.into()),
+        Err(_) => {
+            return Err(std::io::Error::new(std::io::ErrorKind::TimedOut, "hooksock: request timeout").into())
+        }
+    }
+    let mut stream = limited.into_inner();
+
+    let req: HookRequest = serde_json::from_slice(&buf).map_err(|e| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("hooksock: bad HookRequest: {e}"),
+        )
+    })?;
+
+    let verdict = run(&ctx, &req).await;
+    let out = serde_json::to_vec(&verdict)
+        .map_err(|e| std::io::Error::other(format!("hooksock: encode HookVerdict: {e}")))?;
+    stream.write_all(&out).await?;
+    stream.shutdown().await?;
+    Ok(())
+}
+
+/// Run the role's hook fn on the LIVE runtime, then shape stdout for the node's agent_type.
+async fn run(ctx: &NodeContext, req: &HookRequest) -> HookVerdict {
+    let rd = role_def::<exo_runtime::Runtime>(ctx.kind);
+    let agent_type = ctx.kind.agent_type();
+    let stdout = match req.event {
+        HookEvent::PreToolUse => {
+            shape_pre_tool_use(&rd, &ctx.runtime, &req.stdin_json, agent_type).await
+        }
+        HookEvent::Stop => shape_stop(&rd, &ctx.runtime, agent_type).await,
+        HookEvent::SessionStart => {
+            // SessionStart is handled one-shot by the client, never over the socket. A hook must
+            // never wedge an agent, so be defensive and fail-safe allow if one ever arrives.
+            warn!("hooksock: unexpected SessionStart over socket; returning allow");
+            allow_json(agent_type)
+        }
+    };
+    HookVerdict { stdout }
+}
+
+async fn shape_pre_tool_use(
+    rd: &RoleDef<exo_runtime::Runtime>,
+    rt: &exo_runtime::Runtime,
+    stdin_json: &str,
+    agent_type: AgentType,
+) -> String {
+    let input: HookInput = match serde_json::from_str(stdin_json) {
+        Ok(i) => i,
+        Err(e) => {
+            warn!("hooksock: bad PreToolUse stdin ({e}); allowing");
+            return allow_json(agent_type);
+        }
+    };
+    let decision = (rd.pre_tool_use)(rt, &input).await;
+    match agent_type {
+        AgentType::Claude | AgentType::Shoal => match decision {
+            HookDecision::Allow => json!({"continue": true}).to_string(),
+            HookDecision::Deny { reason } => {
+                json!({"continue": true, "systemMessage": reason}).to_string()
+            }
+            HookDecision::Modify { input } => json!({
+                "continue": true,
+                "hookSpecificOutput": {"hookEventName": "PreToolUse", "toolInput": input}
+            })
+            .to_string(),
+        },
+        AgentType::Gemini => match decision {
+            HookDecision::Allow => json!({}).to_string(),
+            // BeforeTool deny is safe (delivered as a tool error, no retry loop).
+            HookDecision::Deny { reason } => {
+                json!({"decision": "deny", "reason": reason}).to_string()
+            }
+            // Gemini BeforeTool has no tool-input rewrite shape; surface nothing and allow.
+            HookDecision::Modify { .. } => {
+                warn!("hooksock: dropping Gemini PreToolUse Modify (no BeforeTool rewrite shape)");
+                json!({}).to_string()
+            }
+        },
+    }
+}
+
+async fn shape_stop(
+    rd: &RoleDef<exo_runtime::Runtime>,
+    rt: &exo_runtime::Runtime,
+    agent_type: AgentType,
+) -> String {
+    let decision = (rd.stop)(rt).await;
+    match agent_type {
+        AgentType::Claude | AgentType::Shoal => match decision {
+            StopDecision::Allow => json!({"continue": true}).to_string(),
+            StopDecision::Block { reason } => {
+                json!({"decision": "block", "reason": reason}).to_string()
+            }
+        },
+        // SAFETY NET: never emit a Gemini Stop deny. `AfterAgent` deny can infinite-loop
+        // (gemini-cli #20426). Policy already must not block Gemini at stop; this downgrade is
+        // defence in depth.
+        AgentType::Gemini => match decision {
+            StopDecision::Allow => json!({}).to_string(),
+            StopDecision::Block { reason } => {
+                warn!("hooksock: downgrading Gemini Stop block to allow (gemini-cli #20426): {reason}");
+                json!({}).to_string()
+            }
+        },
+    }
+}
+
+fn allow_json(agent_type: AgentType) -> String {
+    match agent_type {
+        AgentType::Claude | AgentType::Shoal => json!({"continue": true}).to_string(),
+        AgentType::Gemini => json!({}).to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::allow_json;
+    use exo_caps::AgentType;
+
+    #[test]
+    fn allow_shape_per_agent_type() {
+        assert_eq!(allow_json(AgentType::Claude), r#"{"continue":true}"#);
+        assert_eq!(allow_json(AgentType::Shoal), r#"{"continue":true}"#);
+        assert_eq!(allow_json(AgentType::Gemini), "{}");
+    }
 }

--- a/rust/exo-node/src/lib.rs
+++ b/rust/exo-node/src/lib.rs
@@ -31,15 +31,16 @@ pub use hook::{handle as handle_hook, HookEvent};
 
 use std::sync::Arc;
 
-/// Run the node's two concurrent stimuli in one process (outbound serve + inbound watch):
+/// Run the node's three concurrent stimuli in one process (outbound serve + inbound watch + hooksock):
 /// - **outbound** ([`outbound::serve`]) — serve the role's MCP tools over stdio. This owns
 ///   stdin/stdout and returns when the stream closes (agent gone), so it is the node's
 ///   **lifetime anchor**: when it ends, the node ends.
 /// - **inbound** ([`inbound::watch`]) — watch the ingestion inbox (cursor + notify) and route
 ///   each entry; ends on a `Control(Shutdown)`.
+/// - **hooksock** ([`hooksock::serve`]) — background hook-RPC socket (N5); also aborted when serve returns.
 ///
-/// The inbound loop is aborted when `serve` returns. `Arc<NodeContext>` satisfies the
-/// `R: Send + Sync + 'static` dispatch boundary. The background loop erroring is logged but does
+/// The background loops are aborted when `serve` returns. `Arc<NodeContext>` satisfies the
+/// `R: Send + Sync + 'static` dispatch boundary. A background loop erroring is logged but does
 /// not tear down the node — only the outbound anchor closing (or a shutdown) ends it.
 pub async fn run_node(ctx: Arc<NodeContext>) -> NodeResult<()> {
     let inbound = tokio::spawn({
@@ -51,11 +52,22 @@ pub async fn run_node(ctx: Arc<NodeContext>) -> NodeResult<()> {
         }
     });
 
+    // N5 — per-agent hook-RPC socket. Background like inbound; an error is logged, not fatal.
+    let hooksock = tokio::spawn({
+        let ctx = ctx.clone();
+        async move {
+            if let Err(e) = hooksock::serve(ctx).await {
+                tracing::error!("hooksock loop exited with error: {e}");
+            }
+        }
+    });
+
     // The outbound serve owns stdio and runs for the node's lifetime.
     let result = outbound::serve(ctx).await;
 
-    // Agent stream closed (or serve errored) → reap the background loop.
+    // Agent stream closed (or serve errored) → reap the background loops.
     inbound.abort();
+    hooksock.abort();
 
     result
 }

--- a/rust/exo-node/tests/converge.rs
+++ b/rust/exo-node/tests/converge.rs
@@ -9,7 +9,7 @@
 use std::sync::Arc;
 
 use exo_caps::{
-    Addressee, AgentName, Branch, Bus, IngestionEntry, InboxPath, Message, MessageBody,
+    Addressee, AgentName, Branch, Bus, InboxPath, IngestionEntry, Message, MessageBody,
     MessageKind, NodePath, PaneId, Persona, Summary,
 };
 use exo_runtime::Runtime;

--- a/rust/exo-runtime/CLAUDE.md
+++ b/rust/exo-runtime/CLAUDE.md
@@ -16,8 +16,9 @@ The single concrete `Runtime` struct that implements **every** `exo-caps` trait.
 | `spawner` | `impl Spawner` — the recursion (birth + teardown). See below. |
 | `tmux` | `impl Tmux` — delegates to exomonad-core `TmuxIpc::inject_input` (hardened buffer-paste). |
 | `fs` `kv` `log` `process` | The remaining cap impls. |
-| `node_config` | `write_node_agent_config` — writes a Claude child's `.mcp.json` + `.claude/settings.local.json` (PreToolUse/Stop/SessionStart hooks via `exo_caps::invocation`). |
+| `node_config` | `write_node_agent_config` / `write_gemini_node_config` — writes child agent config (MCP + hooks). |
 | `session_boot` | `boot_root_session` — creates the detached `{session}` tmux window for the root, returns its pane. |
+
 
 ## Spawn: `birth` and record-first ordering (read before editing `spawner.rs`)
 

--- a/rust/exo-runtime/src/node_config.rs
+++ b/rust/exo-runtime/src/node_config.rs
@@ -33,6 +33,9 @@ pub async fn write_node_agent_config(agent_dir: &Path, papers_path: &Path) -> st
     let p_str = esc(&papers_path.to_string_lossy());
     use exo_caps::invocation::{hook_command, PRE_TOOL_USE, SESSION_START, STOP};
     // The Stop hook is a local convergence gate (reads `git status`); no GitHub token needed.
+    // PreToolUse + Stop route to the sidecar's hook socket via the thin client; SessionStart
+    // stays one-shot in-process. (Gemini gets the equivalent BeforeTool/AfterAgent wiring in
+    // `write_gemini_node_config` below.)
     let settings = serde_json::json!({
         "hooks": {
             "PreToolUse": [{
@@ -58,4 +61,95 @@ pub async fn write_node_agent_config(agent_dir: &Path, papers_path: &Path) -> st
     f.sync_all().await?;
 
     Ok(())
+}
+
+/// Write the Gemini-specific `settings.json` (MCP + hooks) to the given agent directory.
+pub async fn write_gemini_node_config(agent_dir: &Path, papers_path: &Path) -> std::io::Result<()> {
+    let p_raw = papers_path.to_string_lossy();
+    let p_esc = shell_escape::escape(p_raw.clone().into_owned().into()).into_owned();
+
+    let settings = gemini_settings_json(&p_raw, &p_esc);
+    let settings_json = serde_json::to_vec_pretty(&settings).map_err(|e| {
+        std::io::Error::other(format!("gemini settings encode: {e}"))
+    })?;
+
+    // Gemini settings live in the agent root (unlike Claude's .claude/ subfolder),
+    // pointed to by GEMINI_CLI_SYSTEM_SETTINGS_PATH.
+    let settings_path = agent_dir.join("settings.json");
+    let mut f = tokio::fs::File::create(&settings_path).await?;
+    f.write_all(&settings_json).await?;
+    f.sync_all().await?;
+
+    Ok(())
+}
+
+pub(crate) fn gemini_settings_json(papers_path: &str, p_str_escaped: &str) -> serde_json::Value {
+    use exo_caps::invocation::{
+        hook_command, GEMINI_AFTER_AGENT, GEMINI_BEFORE_TOOL, GEMINI_SESSION_START,
+        PRE_TOOL_USE, SESSION_START, STOP,
+    };
+
+    let mut hooks = serde_json::Map::new();
+    hooks.insert(
+        GEMINI_BEFORE_TOOL.to_string(),
+        serde_json::json!([{
+            "matcher": ".*",
+            "hooks": [{"type": "command", "command": hook_command(PRE_TOOL_USE, p_str_escaped)}]
+        }]),
+    );
+    hooks.insert(
+        GEMINI_AFTER_AGENT.to_string(),
+        serde_json::json!([{
+            "matcher": "",
+            "hooks": [{"type": "command", "command": hook_command(STOP, p_str_escaped)}]
+        }]),
+    );
+    hooks.insert(
+        GEMINI_SESSION_START.to_string(),
+        serde_json::json!([{
+            "matcher": "",
+            "hooks": [{"type": "command", "command": hook_command(SESSION_START, p_str_escaped)}]
+        }]),
+    );
+
+    serde_json::json!({
+        "mcpServers": {
+            "exomonad": {
+                "type": "stdio",
+                "command": "exomonad",
+                "args": exo_caps::invocation::node_args(papers_path)
+            }
+        },
+        "hooks": hooks
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use exo_caps::invocation::{GEMINI_AFTER_AGENT, GEMINI_BEFORE_TOOL, GEMINI_SESSION_START};
+
+    #[test]
+    fn test_gemini_settings_shape() {
+        let papers = "/tmp/node.json";
+        let escaped = "'/tmp/node.json'";
+        let json = gemini_settings_json(papers, escaped);
+
+        // 1. MCP server args
+        let args = &json["mcpServers"]["exomonad"]["args"];
+        assert_eq!(args[3], papers);
+
+        // 2. Hook keys and matchers (BeforeTool = regex (.*), lifecycle events = exact-string (""))
+        let hooks = &json["hooks"];
+        assert_eq!(hooks[GEMINI_BEFORE_TOOL][0]["matcher"], ".*");
+        assert_eq!(hooks[GEMINI_AFTER_AGENT][0]["matcher"], "");
+        assert_eq!(hooks[GEMINI_SESSION_START][0]["matcher"], "");
+
+        // 3. Command wiring
+        let cmd = hooks[GEMINI_BEFORE_TOOL][0]["hooks"][0]["command"]
+            .as_str()
+            .unwrap();
+        assert!(cmd.contains("pre-tool-use"));
+        assert!(cmd.contains(escaped));
+    }
 }

--- a/rust/exo-runtime/src/spawner.rs
+++ b/rust/exo-runtime/src/spawner.rs
@@ -394,32 +394,23 @@ impl Runtime {
                 exomonad_core::services::agent_control::AgentType::Claude
             }
             AgentType::Gemini => {
-                // Gemini discovers the node MCP server via GEMINI_CLI_SYSTEM_SETTINGS_PATH.
-                let mcp_config = serde_json::json!({
-                    "mcpServers": {
-                        "exomonad": {
-                            "type": "stdio",
-                            "command": "exomonad",
-                            "args": exo_caps::invocation::node_args(&papers_path.to_string_lossy())
-                        }
-                    }
-                });
-                let settings_path = papers_path.with_file_name("settings.json");
-                tokio::fs::write(
-                    &settings_path,
-                    serde_json::to_vec_pretty(&mcp_config).map_err(|e| SpawnError::Failed {
-                        op: "write_gemini_settings",
+                // Gemini discovers the node MCP server via GEMINI_CLI_SYSTEM_SETTINGS_PATH, and
+                // fires hooks through the same `exomonad experimental hook` thin client as Claude.
+                crate::node_config::write_gemini_node_config(child_dir, &papers_path)
+                    .await
+                    .map_err(|e| SpawnError::Failed {
+                        op: "write_gemini_node_config",
                         child: Some(core.name.clone()),
                         detail: e.to_string(),
-                    })?,
-                )
-                .await?;
+                    })?;
+                let settings_path = child_dir.join("settings.json");
                 env_vars.insert(
                     "GEMINI_CLI_SYSTEM_SETTINGS_PATH".into(),
                     settings_path.to_string_lossy().into_owned(),
                 );
                 exomonad_core::services::agent_control::AgentType::Gemini
             }
+
             AgentType::Shoal => {
                 return Err(SpawnError::Failed {
                     op: "launch",

--- a/rust/exomonad/src/main.rs
+++ b/rust/exomonad/src/main.rs
@@ -28,6 +28,20 @@ use tokio::io::AsyncWriteExt;
 use tokio::net::UnixStream;
 use tracing::warn;
 
+/// The allow-shaped hook stdout for a node, by its agent type. Used to fail open when the sidecar
+/// socket is unreachable. Defaults to the Claude allow if papers can't be read (exit 0 is allow
+/// for both harnesses anyway, so this only affects the printed JSON).
+fn fail_open_shape(papers_path: &std::path::Path) -> &'static str {
+    let agent_type = std::fs::read(papers_path)
+        .ok()
+        .and_then(|b| serde_json::from_slice::<exo_caps::NodePapers>(&b).ok())
+        .map(|p| p.role.agent_type());
+    match agent_type {
+        Some(exo_caps::AgentType::Gemini) => "{}",
+        _ => r#"{"continue":true}"#,
+    }
+}
+
 // ============================================================================
 // CLI Types
 // ============================================================================
@@ -198,25 +212,59 @@ async fn main() -> Result<()> {
                 runtime: _,
                 papers,
             } => {
-                let node_event = match event {
-                    HookEventType::PreToolUse => exo_node::HookEvent::PreToolUse,
-                    HookEventType::Stop => exo_node::HookEvent::Stop,
-                    HookEventType::SessionStart => exo_node::HookEvent::SessionStart,
+                use std::io::Read;
+                let mut body = String::new();
+                std::io::stdin().read_to_string(&mut body)?;
+
+                // SessionStart stays one-shot in-process: it needs no live state and must survive
+                // a cold-start race before the sidecar socket is listening.
+                if event == HookEventType::SessionStart {
+                    let verdict =
+                        exo_node::handle_hook(exo_node::HookEvent::SessionStart, &papers, &body)
+                            .await
+                            .context("node session-start hook")?;
+                    println!("{verdict}");
+                    return Ok(());
+                }
+
+                // All other hooks route to the sidecar over its per-agent socket.
+                let hook_event = match event {
+                    HookEventType::PreToolUse => exo_caps::HookEvent::PreToolUse,
+                    HookEventType::Stop => exo_caps::HookEvent::Stop,
                     other => {
                         eprintln!(
                             "[exomonad] node hook: unhandled event {other:?}, passing through"
                         );
-                        println!("{{\"continue\": true}}");
+                        print!("{}", fail_open_shape(&papers));
                         return Ok(());
                     }
                 };
-                let mut body = String::new();
-                use std::io::Read;
-                std::io::stdin().read_to_string(&mut body)?;
-                let verdict = exo_node::handle_hook(node_event, &papers, &body)
-                    .await
-                    .context("node hook")?;
-                println!("{verdict}");
+
+                let req = exo_caps::HookRequest {
+                    event: hook_event,
+                    stdin_json: body,
+                };
+
+                // Fail-open on ANY error: if the sidecar is unreachable there are no tools to
+                // gate, so never wedge the agent. Shape the allow per agent_type.
+                match exo_node::hooksock::client::resolve_hook_sock(&papers) {
+                    Ok(sock) => match exo_node::hooksock::client::client_request(&sock, &req).await
+                    {
+                        Ok(verdict) => print!("{}", verdict.stdout),
+                        Err(e) => {
+                            eprintln!(
+                                "[exomonad] node hook: socket RPC failed ({e}); failing open"
+                            );
+                            print!("{}", fail_open_shape(&papers));
+                        }
+                    },
+                    Err(e) => {
+                        eprintln!(
+                            "[exomonad] node hook: cannot resolve hook socket ({e}); failing open"
+                        );
+                        print!("{}", fail_open_shape(&papers));
+                    }
+                }
                 return Ok(());
             }
         },


### PR DESCRIPTION
## Subtree A — "Socket Channel"

Implements the generic per-agent hook-RPC UNIX socket for v2 node-mode: the third sidecar loop (N5) plus the thin-client rewiring and Gemini hook config. This is the transport half of the plan; Subtree B ("Stop → notify parent") supplies the policy that rides on it.

### What's here (A1–A4)

- **A1 — socket server** (`exo-node/src/hooksock/server.rs`): binds `paths::hook_sock` (remove-before-bind to clear a stale socket, then `0o600`), accept loop, and per-connection runs the role's hook fn against the **live `ctx.runtime`** (not a fresh `bootstrap()`), shaping the verdict per `agent_type`. Hardened with a 64 KiB read cap + 2 s timeout. Half-close framing (read-to-EOF → run → write → shutdown).
- **A4 — third-loop wiring** (`exo-node/src/lib.rs`): `run_node` spawns `hooksock::serve` as a background task alongside `inbound`, aborted when the outbound anchor returns. A loop error is logged, never fatal.
- **A2 — thin client + CLI arm** (`exo-node/src/hooksock/client.rs`, `exomonad/src/main.rs`): `client_request` (5 s timeout) + `resolve_hook_sock` (derives the socket path from papers + env, identically to the server). The `experimental hook` arm routes **SessionStart in-process** (one-shot — survives cold-start before the socket is listening) and **PreToolUse/Stop over the socket**, **failing open** on any socket error (Claude `{"continue":true}`, Gemini `{}`).
- **A3 — config writers** (`exo-runtime/src/spawner.rs`, `node_config.rs`, `exo-caps/src/invocation.rs`): Gemini node-children now get `BeforeTool`/`AfterAgent`/`SessionStart` hooks in their settings.json, wired to the same `exomonad experimental hook` thin client; new `GEMINI_*` harness-key consts in `invocation.rs`.

### The load-bearing invariant

The socket server **never emits a Gemini `Stop` deny** — a Gemini `AfterAgent` deny can infinite-loop (gemini-cli #20426). Any Gemini Stop block is downgraded to allow (`{}`). This safety net lives **only** in the sidecar server, which is why the client fails *open* on socket failure rather than running policy in-process (in-process shaping is Claude-only and would bypass the net).

### Gemini hook matchers (empirically verified, `hook-events-cc-gemini`)

- `BeforeTool` matcher = regex on tool_name → `.*` (not `*`, an invalid regex).
- `AfterAgent` / `SessionStart` matcher = exact-string lifecycle → `""` (not `*`, which would match a literal event named `*` and never fire).

### Verification

- `cargo build --workspace` ✓
- `cargo clippy -p exo-caps -p exo-policy -p exo-node -p exo-runtime -p exomonad -- -D warnings` ✓
- `cargo test -p exo-caps -p exo-policy -p exo-node -p exo-runtime` → 88 tests pass, 0 failures ✓

Merged from three Copilot-reviewed leaf PRs: #938 (server+wiring), #939 (Gemini config), #941 (client+CLI). Cross-subtree integration tests (UDS round-trip, stop→ChildIdle bus round-trip) are Wave-2 root-TL scope after Subtree B folds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)